### PR TITLE
Functions with literals and params should type resolve

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -33,7 +33,7 @@ DOCKER_CLI_HINTS = "false" # Please don't show us What's Next.
 [tasks.proxy]
 alias = 'p'
 description = "Run the proxy (with `cargo run`)"
-run = 'pwd && env | grep CS_ && cargo run {{option(name="extra-args",default="")}}'
+run = 'pwd && env | grep CS_ && echo cargo run {{option(name="extra-args",default="")}} | bash'
 
 [tasks."proxy:kill"]
 alias = 'k'
@@ -71,20 +71,6 @@ cp {{config_root}}/target/{{ target }}/release/cipherstash-proxy {{config_root}}
 # build a new container
 mise run build:docker --platform {{docker_platform}}
 
-# if [[ "{{arg(name="service",default="proxy")}}" =~ "proxy-tls" ]]; then
-#   if [ -z "${CS_TLS__CERTIFICATE}" ]; then
-#     echo "error: CS_TLS__CERTIFICATE is not set, and you are trying to bring up the proxy-tls container"
-#   fi
-#   if [ -z "${CS_TLS__PRIVATE_KEY}" ]; then
-#     echo "error: CS_TLS__PRIVATE_KEY is not set, and you are trying to bring up the proxy-tls container"
-#   fi
-#   if [ -z "${CS_TLS__TYPE}" ]; then
-#     echo "error: CS_TLS__TYPE is not set (either 'Pem' or 'Path' required), and you are trying to bring up the proxy-tls container"
-#   fi
-#   if [ -z "${CS_TLS__CERTIFICATE}" ] || [ -z "${CS_TLS__CERTIFICATE}" ] || [ -z "${CS_TLS__TYPE}" ];; then
-#     exit 67
-#   fi
-# fi
 
 # Make the default invocation with `mise run proxy:up` work.
 # The default mise environment configuration works for Proxy running as a process, connecting via a port forward.
@@ -148,6 +134,13 @@ alias = 'li'
 description = "Runs test/s"
 run = """
 cargo nextest run --no-fail-fast --nocapture -p cipherstash-proxy-integration
+"""
+
+[tasks."test:local:mapper"]
+alias = 'lm'
+description = "Runs test/s"
+run = """
+cargo nextest run --no-fail-fast --nocapture -p eql-mapper
 """
 
 [tasks."test:unit"]

--- a/packages/eql-mapper/src/inference/registry.rs
+++ b/packages/eql-mapper/src/inference/registry.rs
@@ -85,6 +85,7 @@ pub(crate) mod test_util {
     };
     use sqltk::{Break, Visitable, Visitor};
     use std::{convert::Infallible, fmt::Debug, ops::ControlFlow};
+    use tracing::error;
 
     use super::{NodeKey, TypeRegistry};
 
@@ -97,7 +98,7 @@ pub(crate) mod test_util {
         pub(crate) fn dump_node<N: Display + Visitable + Debug>(&self, node: &N) {
             let key = NodeKey::new_from_visitable(node);
             if let Some(ty) = self.node_types.get(&key) {
-                eprintln!(
+                error!(
                     "TYPE<\nast: {}\nsyn: {}\nty: {}\n>",
                     std::any::type_name::<N>(),
                     node,

--- a/packages/eql-mapper/src/lib.rs
+++ b/packages/eql-mapper/src/lib.rs
@@ -35,6 +35,7 @@ mod test {
     use sqlparser::ast::{self as ast};
     use std::collections::HashMap;
     use std::sync::Arc;
+    use tracing::error;
 
     fn resolver(schema: Schema) -> Arc<TableResolver> {
         Arc::new(TableResolver::new_fixed(schema.into()))
@@ -119,7 +120,6 @@ mod test {
 
         match type_check(schema, &statement) {
             Ok(typed) => {
-                eprintln!("{:#?}", &typed.literals);
                 assert!(typed.literals.contains(&(
                     EqlValue(TableColumn {
                         table: id("users"),
@@ -151,7 +151,6 @@ mod test {
 
         match type_check(schema, &statement) {
             Ok(typed) => {
-                eprintln!("{:#?}", &typed.literals);
                 assert!(typed.literals.contains(&(
                     EqlValue(TableColumn {
                         table: id("users"),
@@ -184,7 +183,6 @@ mod test {
 
         match type_check(schema, &statement) {
             Ok(typed) => {
-                eprintln!("{:#?}", &typed.literals);
                 assert!(typed.literals.contains(&(
                     EqlValue(TableColumn {
                         table: id("users"),
@@ -718,7 +716,6 @@ mod test {
         let typed = match type_check(schema, &statement) {
             Ok(typed) => typed,
             Err(err) => {
-                // eprintln!("Error: {}", err, err.source());
                 panic!("type check failed: {:#?}", err)
             }
         };
@@ -1143,6 +1140,7 @@ mod test {
     #[test]
     fn update_with_concat_regression() {
         let _ = tracing_subscriber::fmt::try_init();
+
         let schema = resolver(schema! {
             tables: {
                 example: {
@@ -1163,5 +1161,158 @@ mod test {
         // Can use concat in an update on a plaintext column
         let statement = parse("update example set other_str = other_str || 'a'");
         type_check(schema, &statement).expect("expected type check to succeed, but it failed");
+    }
+
+    #[test]
+    fn function_with_literal() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        let schema = resolver(schema! {
+            tables: {
+                employees: {
+                    id,
+                    name,
+                    salary (EQL),
+                }
+            }
+        });
+
+        let statement = parse(
+            r#"
+                select upper('x'), salary from employees;
+            "#,
+        );
+        let typed = type_check(schema, &statement).unwrap();
+
+        error!("{:?}", typed.projection);
+        assert_eq!(
+            typed.projection,
+            Some(projection![
+                (NATIVE as upper),
+                (EQL(employees.salary) as salary)
+            ])
+        );
+    }
+
+    #[test]
+    fn function_with_wildcard() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        let schema = resolver(schema! {
+            tables: {
+                employees: {
+                    id,
+                    name,
+                    salary (EQL),
+                }
+            }
+        });
+
+        let statement = parse(
+            r#"
+                select count(*), salary from employees group by salary;
+            "#,
+        );
+        let typed = type_check(schema, &statement).unwrap();
+
+        assert_eq!(
+            typed.projection,
+            Some(projection![
+                (NATIVE as count),
+                (EQL(employees.salary) as salary)
+            ])
+        );
+    }
+
+    #[test]
+    fn function_with_column_and_literal() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        let schema = resolver(schema! {
+            tables: {
+                employees: {
+                    id,
+                    name,
+                    salary (EQL),
+                }
+            }
+        });
+
+        let statement = parse(
+            r#"
+                select concat(name, 'x'), salary from employees;
+            "#,
+        );
+        let typed = type_check(schema, &statement).unwrap();
+
+        assert_eq!(
+            typed.projection,
+            Some(projection![
+                (NATIVE(employees.name) as concat),
+                (EQL(employees.salary) as salary)
+            ])
+        );
+    }
+
+    #[test]
+    fn function_with_param() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        let schema = resolver(schema! {
+            tables: {
+                employees: {
+                    id,
+                    name,
+                    salary (EQL),
+                }
+            }
+        });
+
+        let statement = parse(
+            r#"
+                select concat(name, $1), salary from employees;
+            "#,
+        );
+
+        let typed = type_check(schema, &statement).unwrap();
+
+        let a = Value::Native(NativeValue(Some(TableColumn {
+            table: id("employees"),
+            column: id("name"),
+        })));
+
+        assert_eq!(typed.params, vec![a]);
+
+        assert_eq!(
+            typed.projection,
+            Some(projection![
+                (NATIVE(employees.name) as concat),
+                (EQL(employees.salary) as salary)
+            ])
+        );
+    }
+
+    #[test]
+    fn function_with_eql_column_and_literal() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        let schema = resolver(schema! {
+            tables: {
+                employees: {
+                    id,
+                    name (EQL),
+                    salary (EQL),
+                }
+            }
+        });
+
+        let statement = parse(
+            r#"
+                select concat(name, 'x'), salary from employees;
+            "#,
+        );
+
+        type_check(schema, &statement)
+            .expect_err("eql columns in functions should be a type error");
     }
 }


### PR DESCRIPTION
SQL statements containing literals or param placeholders currently trigger type check error. 
```
-- The arg `'x'` causes mapping to fail.
-- This causes `encrypted_text` to fail to decrypt in the results.
select concat(plaintext, 'x'), encrypted_text from encrypted;
```

This change unifies function types with `Type::any_native()`. 
EQL values will be rejected in function calls, which is the correct behaviour in most situations as EQL columns need to be decrypted. 

eg, `concat(encrypted_column, 'str')` will attempt to concat the encrypted json data. 

Future work will add support for the EQL functions. 
