### PR TITLE
fix(mapper): handle multiple statements in simple query messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,6 +714,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "cipherstash-proxy",
+ "fake 4.0.0",
  "rand 0.9.0",
  "recipher",
  "rustls",
@@ -1123,6 +1124,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dummy"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abcba80bdf851db5616e27ff869399468e2d339d7c6480f5887681e6bdfc2186"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,9 +1196,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d391ba4af7f1d93f01fcf7b2f29e2bc9348e109dfdbf4dcbdc51dfa38dab0b6"
 dependencies = [
  "deunicode",
- "dummy",
+ "dummy 0.8.0",
  "rand 0.8.5",
  "uuid",
+]
+
+[[package]]
+name = "fake"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206294f947d314ea224901e0b409c25465d1014ea0c3af27baaec861061a0426"
+dependencies = [
+ "deunicode",
+ "dummy 0.9.2",
+ "rand 0.9.0",
 ]
 
 [[package]]
@@ -4636,7 +4660,7 @@ dependencies = [
  "async-trait",
  "base64",
  "cipherstash-config",
- "fake",
+ "fake 2.10.0",
  "opaque-debug",
  "rand 0.8.5",
  "serde",

--- a/packages/cipherstash-proxy-integration/Cargo.toml
+++ b/packages/cipherstash-proxy-integration/Cargo.toml
@@ -22,3 +22,6 @@ tokio-rustls = "0.26.0"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 webpki-roots = "0.26.7"
+
+[dev-dependencies]
+fake = { version = "4", features = ["derive"] }

--- a/packages/cipherstash-proxy-integration/src/simple_protocol/error_handling.rs
+++ b/packages/cipherstash-proxy-integration/src/simple_protocol/error_handling.rs
@@ -1,0 +1,32 @@
+#[cfg(test)]
+mod tests {
+    use crate::common::{connect_with_tls, id, PROXY};
+
+    #[tokio::test]
+    async fn frontend_error_does_not_crash_connection() {
+        let client = connect_with_tls(PROXY).await;
+
+        // Statement has the wrong column name
+        let sql = format!(
+            "INSERT INTO encrypted (id, encrypted) VALUES ({}, 'foo@example.net')",
+            id()
+        );
+
+        let result = client.simple_query(&sql).await;
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+
+        // The connection should not be closed
+        assert!(!error.is_closed());
+
+        // And we can still use the connection
+        let sql = format!(
+            "INSERT INTO encrypted (id, encrypted_text) VALUES ({}, 'foo@example.net')",
+            id()
+        );
+        let result = client.simple_query(&sql).await;
+
+        assert!(result.is_ok());
+    }
+}

--- a/packages/cipherstash-proxy-integration/src/simple_protocol/mod.rs
+++ b/packages/cipherstash-proxy-integration/src/simple_protocol/mod.rs
@@ -1,2 +1,4 @@
+mod error_handling;
 mod map_literals;
 mod map_nulls;
+mod multiple_statements;

--- a/packages/cipherstash-proxy-integration/src/simple_protocol/multiple_statements.rs
+++ b/packages/cipherstash-proxy-integration/src/simple_protocol/multiple_statements.rs
@@ -1,0 +1,111 @@
+#[cfg(test)]
+mod tests {
+    use crate::common::{clear, connect_with_tls, id, trace, PROXY};
+    use fake::{Fake, Faker};
+    use tokio_postgres::SimpleQueryMessage::CommandComplete;
+
+    #[tokio::test]
+    async fn multiple_inserts_with_text() {
+        trace();
+        clear().await;
+
+        let client = connect_with_tls(PROXY).await;
+
+        let data = (0..5)
+            .map(|_| (id(), Faker.fake::<String>()))
+            .collect::<Vec<_>>();
+
+        // Build SQL string containing multiple statements;
+        let sql: String = data
+            .iter()
+            .map(|(id, encrypted_text)| {
+                format!(
+                    "INSERT INTO encrypted (id, encrypted_text) VALUES ({id}, '{encrypted_text}')"
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(";");
+
+        let insert_result = client.simple_query(&sql).await.unwrap();
+
+        // CmmandComplete does not implement PartialEq, so no equality check with ==
+        match &insert_result[0] {
+            CommandComplete(n) => assert_eq!(1, *n),
+            _unexpected => panic!("unexpected insert result: {:?}", insert_result),
+        }
+
+        // Check each Row by ID
+        for (id, encrypted_text) in data {
+            let sql = "SELECT id, encrypted_text FROM encrypted WHERE id = $1";
+            let rows = client.query(sql, &[&id]).await.unwrap();
+
+            assert_eq!(rows.len(), 1);
+
+            for row in rows {
+                let result: String = row.get("encrypted_text");
+                assert_eq!(encrypted_text, result);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn multiple_inserts_and_updates_with_text() {
+        trace();
+        clear().await;
+
+        let client = connect_with_tls(PROXY).await;
+
+        let data = (0..5)
+            .map(|_| (id(), Faker.fake::<String>(), Faker.fake::<String>()))
+            .collect::<Vec<_>>();
+
+        // Build SQL string containing multiple statements;
+        let sql: String = data
+            .iter()
+            .map(|(id, encrypted_text, _)| {
+                format!(
+                    "INSERT INTO encrypted (id, encrypted_text) VALUES ({id}, '{encrypted_text}')"
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(";");
+
+        let insert_result = client.simple_query(&sql).await.unwrap();
+
+        // CmmandComplete does not implement PartialEq, so no equality check with ==
+        match &insert_result[0] {
+            CommandComplete(n) => assert_eq!(1, *n),
+            _unexpected => panic!("unexpected insert result: {:?}", insert_result),
+        }
+
+        // Build SQL string containing multiple statements;
+        let sql: String = data
+            .iter()
+            .map(|(id, _, encrypted_text)| {
+                format!("UPDATE encrypted SET encrypted_text = '{encrypted_text}' WHERE id = {id}")
+            })
+            .collect::<Vec<_>>()
+            .join(";");
+
+        let insert_result = client.simple_query(&sql).await.unwrap();
+
+        // CmmandComplete does not implement PartialEq, so no equality check with ==
+        match &insert_result[0] {
+            CommandComplete(n) => assert_eq!(1, *n),
+            _unexpected => panic!("unexpected insert result: {:?}", insert_result),
+        }
+
+        // Check each Row by ID
+        for (id, _, encrypted_text) in data {
+            let sql = "SELECT id, encrypted_text FROM encrypted WHERE id = $1";
+            let rows = client.query(sql, &[&id]).await.unwrap();
+
+            assert_eq!(rows.len(), 1);
+
+            for row in rows {
+                let result: String = row.get("encrypted_text");
+                assert_eq!(encrypted_text, result);
+            }
+        }
+    }
+}

--- a/packages/cipherstash-proxy/src/error.rs
+++ b/packages/cipherstash-proxy/src/error.rs
@@ -111,7 +111,7 @@ pub enum ConfigError {
     #[error("Invalid {name}: {value}")]
     InvalidParameter { name: String, value: String },
 
-    #[error("Expected an active Encrypt configuration")]
+    #[error("Missing an active Encrypt configuration")]
     MissingActiveEncryptConfig,
 
     #[error("Missing field {name} from configuration file or environment")]


### PR DESCRIPTION
Parse simple query messages into Vec of Statement AST/s and encrypt each statement if required.
Adds new EncryptedText variant of Portal to distinguish Simple Protocol in the backend

