### PR TITLE
test(eql): Add null record to ORE operator tests

### DIFF
--- a/packages/cipherstash-proxy-integration/src/map_ore_index_where.rs
+++ b/packages/cipherstash-proxy-integration/src/map_ore_index_where.rs
@@ -64,14 +64,9 @@ mod tests {
                 .expect("insert failed");
         }
 
-        /* Currently, the `<` operator returns null rows when they shouldn't
-         * TODO: uncomment this when the operator issue is addressed
+        // NULL record
         let sql = format!("INSERT INTO encrypted (id, {col_name}) VALUES ($1, null)");
-        client
-            .query(&sql, &[&id()])
-            .await
-            .expect("insert failed");
-         */
+        client.query(&sql, &[&id()]).await.expect("insert failed");
 
         // GT: given [1, 3], `> 1` returns [3]
         let sql = format!("SELECT {col_name} FROM encrypted WHERE {col_name} > $1");


### PR DESCRIPTION
Adds `null` record to ORE operator tests. Test behaviour is unchanged, null records should now be excluded from comparison, following existing PostgreSQL behaviour.

Fix is in EQL ore here https://github.com/cipherstash/encrypt-query-language/pull/94




