### PR TITLE
test: check that `Cargo.lock` is up to date

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -351,8 +351,14 @@ description = "Runs cargo fmt"
 run = 'cargo fmt --all -- --check'
 
 [tasks."test:check"]
-description = "Runs cargo check"
-run = 'cargo check'
+description = "Runs cargo check to check types and dependencies"
+run = """
+# Assert that `Cargo.lock` will remain unchanged
+cargo check --locked
+
+# Check types of packages and dependencies"
+cargo check
+"""
 
 [tasks."test:clippy"]
 description = "Runs clippy"


### PR DESCRIPTION
Background: 

- Last merge commit (61fad6199b904e746bb0ee3c08c54ee6be79a353) on `main` has a failing check
- The `release.yml` workflow is trying to build a binary, but [it is failing](https://github.com/cipherstash/proxy/actions/runs/13780037617/job/38536506825) because `Cargo.lock` will change:
   ```
    $ cargo build --locked --release --package cipherstash-proxy
        Updating crates.io index
    error: the lock file /home/runner/work/proxy/proxy/Cargo.lock needs to be updated but --locked was passed to prevent this
    If you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.
   ```

This brings the `Cargo.lock` check into the normal PR review, so issues can be identified earlier. 