### PR TITLE
feat: optionally trigger EQL install on container start

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,27 @@ TODO: Add instructions for running Proxy locally
 
 ### Setting up the database schema
 
-TODO: Add instructions for setting up the database schema
+Under the hood, Proxy uses [CipherStash Encrypt Query Language](https://github.com/cipherstash/encrypt-query-language/) to index and search encrypted data.
+
+When you start the Proxy container, you can install EQL by setting the `CS_DATABASE__INSTALL_EQL` environment variable:
+
+```bash
+CS_DATABASE__INSTALL_EQL=true
+```
+
+This will install the version of EQL bundled with the Proxy container.
+The version of EQL bundled with the Proxy container is tested to work with that version of Proxy.
+
+If you are following the [getting started](#getting-started) guide above, EQL is automatically installed for you.
+You can also install EQL by running [the installation script](https://github.com/cipherstash/encrypt-query-language/releases) as a database migration in your application.
+
+Once you have installed EQL, you can see what version is installed by querying the database:
+
+```sql
+SELECT cs_eql_version();
+```
+
+This will output the version of EQL installed.
 
 #### Creating columns with the right types
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - CS_DATABASE__HOST=postgres
       - CS_DATABASE__PORT=5432
       - CS_PROMETHEUS__ENABLED=${CS_PROMETHEUS__ENABLED:-true}
+      - CS_DATABASE__INSTALL_EQL=true # install EQL into the PostgreSQL database we start above
     networks:
       - cipherstash
 

--- a/mise.toml
+++ b/mise.toml
@@ -52,21 +52,8 @@ run = """
 {% set target = arch() ~ "-unknown-linux-gnu" | replace(from="arm64", to="aarch64") | replace(from="x64", to="x86_64") %}
 {% set docker_platform = "linux/" ~ arch() | replace(from="x64", to="amd64") %}
 
-{# If we are on macos, cross-compile for Linux, so we can run the binary in a Docker container. #}
-{# Only supports Apple Silicon. #}
-{% if os() == "macos" %}
-if ! which {{ target }}-gcc ; then
-  brew install MaterializeInc/crosstools/aarch64-unknown-linux-gnu
-fi
-export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER={{ target }}-gcc
-{% endif %}
-
-# cross-compile
-rustup target add --toolchain stable {{ target }}
-
-cargo build --locked --target {{ target }} --release --package cipherstash-proxy
-
-cp {{config_root}}/target/{{ target }}/release/cipherstash-proxy {{config_root}}/
+# build a binary
+mise run build:binary --target {{target}}
 
 # build a new container
 mise run build:docker --platform {{docker_platform}}
@@ -514,8 +501,29 @@ mise run build:docker --platform {{option(name="platform",default=default_platfo
 [tasks."build:binary"]
 description = "Build a releasable binary for cipherstash-proxy"
 run = """
-cargo build --locked --release --package cipherstash-proxy
-cp -v target/release/cipherstash-proxy .
+#!/bin/bash
+{% set default_target_arch = arch() | replace(from="arm64", to="aarch64") | replace(from="x64", to="x86_64") %}
+{% set default_target_os = os() | replace(from="linux", to="unknown-linux-gnu") | replace(from="macos", to="apple-darwin") %}
+{% set default_target = default_target_arch ~ "-" ~ default_target_os %}
+{% set target = option(name="target", default=default_target) %}
+
+{# If we are on macos and are cross-compiling for Linux, set up a linker and toolchain. #}
+{# Only supports cross-compiling to Linux/ARM64. #}
+{% if os() == "macos" %}
+{% if target is containing("linux") %}
+if ! which {{ target }}-gcc ; then
+  brew install MaterializeInc/crosstools/aarch64-unknown-linux-gnu
+fi
+export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER={{ target }}-gcc
+{% endif %}
+{% endif %}
+
+# cross-compile
+rustup target add --toolchain stable {{ target }}
+
+cargo build --locked --target {{ target }} --release --package cipherstash-proxy
+
+cp {{config_root}}/target/{{ target }}/release/cipherstash-proxy {{config_root}}/
 """
 
 [tasks."build:docker"]

--- a/mise.toml
+++ b/mise.toml
@@ -523,7 +523,7 @@ rustup target add --toolchain stable {{ target }}
 
 cargo build --locked --target {{ target }} --release --package cipherstash-proxy
 
-cp {{config_root}}/target/{{ target }}/release/cipherstash-proxy {{config_root}}/
+cp -v {{config_root}}/target/{{ target }}/release/cipherstash-proxy {{config_root}}/
 """
 
 [tasks."build:docker"]

--- a/mise.toml
+++ b/mise.toml
@@ -510,12 +510,12 @@ run = """
 {# If we are on macos and are cross-compiling for Linux, set up a linker and toolchain. #}
 {# Only supports cross-compiling to Linux/ARM64. #}
 {% if os() == "macos" %}
-{% if target is containing("linux") %}
-if ! which {{ target }}-gcc ; then
-  brew install MaterializeInc/crosstools/aarch64-unknown-linux-gnu
+if [[ "{{option(name="target", default=default_target)}}" =~ "linux" ]]; then
+  if ! which {{ target }}-gcc ; then
+    brew install MaterializeInc/crosstools/aarch64-unknown-linux-gnu
+  fi
+  export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER={{ target }}-gcc
 fi
-export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER={{ target }}-gcc
-{% endif %}
 {% endif %}
 
 # cross-compile

--- a/proxy.Dockerfile
+++ b/proxy.Dockerfile
@@ -6,6 +6,7 @@ RUN apt update && apt install -y ca-certificates postgresql-client curl
 
 # Copy binary
 COPY cipherstash-proxy /usr/local/bin/cipherstash-proxy
+# Copy entrypoint, for handling Proxy startup
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 # Copy EQL install scripts

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -57,10 +57,7 @@ services:
       - CS_DEFAULT_KEYSET_ID=${CS_DEFAULT_KEYSET_ID}
       - CS_CLIENT_KEY=${CS_CLIENT_KEY}
       - CS_CLIENT_ID=${CS_CLIENT_ID}
-
       - CS_PROMETHEUS__ENABLED=${CS_PROMETHEUS__ENABLED:-true}
-
-
     networks:
       - postgres
 


### PR DESCRIPTION
Running the Proxy container and setting `CS_DATABASE__INSTALL_EQL=true` will install EQL into the target database. 

This PR also:

- [Documents](https://github.com/cipherstash/proxy/pull/157/commits/42ff8e44e13ecceeac11d78248287ccdc18b5254) how to install EQL using the environment variable
- [Refactors](https://github.com/cipherstash/proxy/pull/157/commits/8bd8be7dea0c20bd3a0fd8471bf7ff8c180a97e0) building of a `cipherstash-proxy` binary into a reusable task
- [Cleans up](https://github.com/cipherstash/proxy/pull/157/commits/25adddc79ae851f3314e0b06ee63bdc9640fdbc5) whitespace in `docker-compose.yml`