### PR TITLE
chore: bump Rust package version numbers for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["packages/*"]
 
 [workspace.package]
-version = "0.1.0"
+version = "2.0.0"
 edition = "2021"
 
 [profile.dev]

--- a/packages/cipherstash-proxy/Cargo.toml
+++ b/packages/cipherstash-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cipherstash-proxy"
-version = "0.1.0"
+version = "2.0.0"
 edition = "2021"
 
 [dependencies]

--- a/packages/eql-mapper/Cargo.toml
+++ b/packages/eql-mapper/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "eql-mapper"
 description = "The SQL transformation layer of CipherStash Proxy. Safely transforms SQL to SQL+EQL using a reference schema and type inference approach"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 authors = [
   "James Sadler <james@cipherstash.com>",
   "Yuji Yokoo <yuji@cipherstash.com>",
-  "Ragib Badaruddin <ragib@cipherstash.com>",
+  "Drew Thomas <drew@cipherstash.com>",
+  "Toby Hede <drew@cipherstash.com>"
 ]
 
 [dependencies]


### PR DESCRIPTION
Not for merge yet, but what it says on the tin.