### PR TITLE
feat(migrate): Import migrator code and add as proxy subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-client"
-version = "0.18.0-pre.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a318a2cf39148ea11fc8598f16d0ee8bae640a09eb5780054cf5ef62f996f6"
+checksum = "f099b1db6cf37b0ca36e9c8e0c2dade20f2035804e225f52475d44e750dd5dd5"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -606,7 +606,6 @@ dependencies = [
  "chrono",
  "cipherstash-config",
  "cipherstash-core",
- "cipherstash-stats",
  "cllw-ore",
  "derive_more",
  "dirs",
@@ -729,6 +728,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "cipherstash-proxy",
+ "clap",
  "fake 4.0.0",
  "rand 0.9.0",
  "recipher",
@@ -746,16 +746,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cipherstash-stats"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10da9699454e308aeb16b30800282bbb175c28c073d4f7114d1c731c20a5c00"
-dependencies = [
- "lazy_static",
- "prometheus",
-]
-
-[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -778,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -790,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2644,27 +2634,6 @@ checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "prometheus"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
-dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "memchr",
- "parking_lot 0.12.3",
- "protobuf",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "ptr_meta"

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@
 
 <!-- start -->
 
-# What's CipherStash Proxy?
-
 CipherStash Proxy provides a transparent proxy to your existing postgres database, handling the complexity of encrypting and decrypting your data.
 CipherStash Proxy keeps your sensitive data in PostgreSQL encrypted and searchable, without changing your SQL queries.
 
@@ -43,10 +41,16 @@ Behind the scenes, it uses the [Encrypt Query Language](https://github.com/ciphe
   - [Running Proxy locally](#running-proxy-locally)
   - [Setting up the database schema](#setting-up-the-database-schema)
     - [Creating columns with the right types](#creating-columns-with-the-right-types)
+  - [Encrypting data in an existing database](#encrypting-data-in-an-existing-database)
+    - [Usage](#usage)
+    - [How it works](#how-it-works)
+    - [Configuration](#configuration)
+    - [Example usage](#example-usage)
 - [Reference](#reference)
   - [Proxy config options](#proxy-config-options)
   - [Prometheus metrics](#prometheus-metrics)
     - [Available metrics](#available-metrics)
+  - [`encrypt` tool config options](#encrypt-tool-config-options)
 - [More info](#more-info)
   - [Developing for Proxy](#developing-for-proxy)
 
@@ -208,6 +212,72 @@ TODO: Add instructions for setting up the database schema
 #### Creating columns with the right types
 
 TODO: Add instructions for creating columns with the right types
+
+## Encrypting data in an existing database
+
+CipherStash Proxy includes an `encrypt` tool – a CLI application to encrypt existing data, or to apply index changes after changes to the encryption configuration of a protected database.
+
+### Usage
+
+Encrypt the `source` column data in `table` into the specified encrypted `target` column.
+The `encrypt` tool connects to CipherStash Proxy using the `cipherstash.toml` configuration or `ENV` variables.
+
+```
+cipherstash-proxy encrypt [OPTIONS] --table <TABLE>  --columns <SOURCE_COLUMN=TARGET_COLUMN>...
+```
+
+### How it works
+
+At a high-level, the process for encrypting a column in the database is:
+
+1. Add a new encrypted destination column with the appropriate encrypted configuration.
+2. Using CipherStash Proxy to process:
+  1. Select from the original plaintext column.
+  2. Update the encrpted column to set the plaintext value.
+3. Drop the original plaintext column.
+4. Rename the encrypted column to the original plaintext column name.
+
+The CipherStash Proxy `encrypt` tool automates the data process to encrypt one or more columns in a table.
+Updates are executed in batches of 100 records (and the `batch_size` is configurable).
+The process is idempotent and can be run repeatedly.
+
+### Configuration
+
+The CipherStash Proxy `encrypt` tool reuses the CipherStash Proxy configuration for the Proxy connection details. See [`encrypt` tool config options](#encrypt-tool-config-options) for the available options.
+
+{% callout title="Connection" %}
+Connection to CipherStash Proxy reuses Proxy configuration:
+ - server host
+ - server port
+ - database username
+ - database password
+ - database name
+{% /callout %}
+
+### Example usage
+
+Given a running instance of CipherStash Proxy and a `users` table with:
+ - `id` – a primary key column
+ - `email` – a source plaintext column
+ - `encrypted_email` – a destination column configured to be encrypted text.
+
+Encrypt `email` into `encrypted_email`:
+
+```bash
+cipherstash-proxy encrypt --table users --columns email=encrypted_email
+```
+
+Specify the primary key column:
+
+```bash
+cipherstash-proxy encrypt --table users --columns email=encrypted_email --primary-key user_id
+```
+
+Specify multiple primary key columns (compound primary key):
+
+```bash
+cipherstash-proxy encrypt --table users --columns email=encrypted_email --primary-key user_id tenant_id
+```
 
 ## Reference
 
@@ -443,42 +513,7 @@ If the proxy is running on a host other than localhost, access on that host.
 | `cipherstash_proxy_statements_total`                  | Counter   | Total number of SQL statements processed by CipherStash Proxy               |
 | `cipherstash_proxy_statements_unmappable_total`       | Counter   | Total number of unmappable SQL statements processed by CipherStash Proxy    |
 
-
-
-## Encrypting data in an existing database
-
-CipherStash Proxy includes a CLI application to encrypt existing data or to apply index changes after encryption configuration changes of a protected database.
-
-### Usage
-
-Encrypt the `source` column data in `table` into the specified encrypted `target` column.
-Connects to CipherStash Proxy using the `cipherstash.toml` configuration or `ENV` variables.
-
-```
-cipherstash-proxy encrypt [OPTIONS] --table <TABLE>  --columns <SOURCE_COLUMN=TARGET_COLUMN>...
-```
-
-### How it works
-
-At a high-level, the process for encrypting a column in the database is:
-
-- add a new encrypted destination column with the appropriate encrypted configuration
-- using CipherStash proxy to process
-  - select from the original plaintext column
-  - update the encrpted column to set the plaintext value
-- drop the original plaintext column
-- rename the encrypted column to the original plaintext column name
-
-The CipherStash Proxy `encrypt` tool automates the data process to encrypt one or more columns in a table.
-Updates are executed in batches of 100 records (and the `batch_size` is configurable).
-The process is idempotent and can be run repeatedly.
-
-
-### Configuration
-
-The CipherStash Proxy `encrypt` tool reuses the CipherStash Proxy configuration for the Proxy connection details.
-
-## Options
+### `encrypt` tool config options
 
 | Option                  | Description                                                    | Default         |
 | ----------------------- | -------------------------------------------------------------- | --------------- |
@@ -490,41 +525,6 @@ The CipherStash Proxy `encrypt` tool reuses the CipherStash Proxy configuration 
 | `-v`, `--verbose`       | Turn on additional logging output                              | None (Optional) |
 | `-h`, `--help`          | Displays this help message                                     | -               |
 
-
-{% callout title="Connection" %}
-Connection to CipherStash Proxy reuses Proxy configuration:
- - server host
- - server port
- - database username
- - database password
- - database name
-{% /callout %}
-
-
-### Example usage
-
-Given a running instance of CipherStash Proxy and a `users` table with:
- - a primary key `id` column
- - a source plaintext `email` column
- - a destination `encrypted_email` column configured to be encrypted text.
-
-Encrypt `email` into `encrypted_email`
-
-```bash
-cipherstash-proxy encrypt --table users --columns email=encrypted_email
-```
-
-Specify the primary key column
-
-```bash
-cipherstash-proxy encrypt --table users --columns email=encrypted_email --primary-key user_id
-```
-
-Specify multiple primary key columns (compound primary key)
-
-```bash
-cipherstash-proxy encrypt --table users --columns email=encrypted_email --primary-key user_id tenant_id
-```
 
 
 ## More info

--- a/mise.toml
+++ b/mise.toml
@@ -307,7 +307,6 @@ mise --env tls run test:wait_for_postgres_to_quack --port 6432 --max-retries 20 
 mise --env tls run test:integration:psql-tls
 mise --env tls run proxy:down
 
-
 echo
 echo '###############################################'
 echo '# Test: Integration'
@@ -318,6 +317,17 @@ mise --env tls run proxy:up proxy-tls --extra-args "--detach --wait"
 mise --env tls run test:wait_for_postgres_to_quack --port 6432 --max-retries 20 --tls
 cargo nextest run --no-fail-fast --nocapture -E 'package(cipherstash-proxy-integration)'
 mise --env tls run proxy:down
+
+echo
+echo '###############################################'
+echo '# Test: Migrate'
+echo '###############################################'
+echo
+
+mise --env tcp run proxy:up proxy --extra-args "--detach --wait"
+mise --env tcp run test:wait_for_postgres_to_quack --port 6432 --max-retries 20
+mise --env tcp run test:integration:migrate
+mise --env tcp run proxy:down
 
 echo
 echo '###############################################'

--- a/packages/cipherstash-proxy-integration/Cargo.toml
+++ b/packages/cipherstash-proxy-integration/Cargo.toml
@@ -24,4 +24,5 @@ tracing-subscriber = { workspace = true }
 webpki-roots = "0.26.7"
 
 [dev-dependencies]
+clap = "4.5.32"
 fake = { version = "4", features = ["derive"] }

--- a/packages/cipherstash-proxy-integration/src/lib.rs
+++ b/packages/cipherstash-proxy-integration/src/lib.rs
@@ -9,6 +9,7 @@ mod map_ore_index_order;
 mod map_ore_index_where;
 mod map_params;
 mod map_unique_index;
+mod migrate;
 mod passthrough;
 mod pipeline;
 mod schema_change;

--- a/packages/cipherstash-proxy-integration/src/migrate/mod.rs
+++ b/packages/cipherstash-proxy-integration/src/migrate/mod.rs
@@ -13,8 +13,8 @@ mod tests {
         clear().await;
 
         let args = Args {
-            config_file: "".to_string(),
-            log_level: LogLevel::Info,
+            config_file_path: "".to_string(),
+            log_level: LogLevel::Debug,
             log_format: LogFormat::Pretty,
             command: None,
         };

--- a/packages/cipherstash-proxy-integration/src/migrate/mod.rs
+++ b/packages/cipherstash-proxy-integration/src/migrate/mod.rs
@@ -1,0 +1,56 @@
+#[cfg(test)]
+mod tests {
+    use crate::common::{clear, connect_with_tls, id, trace, PROXY};
+    use cipherstash_proxy::{
+        config::{LogFormat, LogLevel},
+        Args, Migrate, TandemConfig,
+    };
+    use fake::{Fake, Faker};
+
+    #[tokio::test]
+    async fn migrate_text() {
+        trace();
+        clear().await;
+
+        let args = Args {
+            config_file: "".to_string(),
+            log_level: LogLevel::Info,
+            log_format: LogFormat::Pretty,
+            command: None,
+        };
+
+        let config = match TandemConfig::load(&args) {
+            Ok(config) => config,
+            Err(err) => {
+                eprintln!("Configuration Error: {}", err);
+                panic!();
+            }
+        };
+
+        let client = connect_with_tls(PROXY).await;
+
+        for _ in 1..10 {
+            let id = id();
+            let plaintext = Faker.fake::<String>();
+
+            let sql = "INSERT INTO encrypted (id, plaintext) VALUES ($1, $2)";
+            client.query(sql, &[&id, &plaintext]).await.unwrap();
+        }
+
+        let table = "encrypted".to_string();
+        let columns = vec![("plaintext".to_string(), "encrypted_text".to_string())];
+        let migrate = Migrate::new(table, columns);
+
+        migrate.run(config).await.unwrap();
+
+        let sql = "SELECT id, plaintext, encrypted_text FROM encrypted";
+        let rows = client.query(sql, &[]).await.unwrap();
+
+        for row in rows {
+            let pt: String = row.get("plaintext");
+            let encrypted: String = row.get("encrypted_text");
+
+            assert_eq!(pt, encrypted);
+        }
+    }
+}

--- a/packages/cipherstash-proxy/src/cli/migrate/mod.rs
+++ b/packages/cipherstash-proxy/src/cli/migrate/mod.rs
@@ -17,27 +17,34 @@ const LOCALHOST: &str = "127.0.0.1";
 #[derive(clap::Args, Clone, Debug)]
 #[command(version, about, long_about)]
 ///
-/// Encrypt data in table
+/// Encrypt one or more columns in table
+/// Requires a running and configured CipherStash Proxy instance.
 ///
 pub struct Migrate {
+    ///
+    /// Name of database table
+    ///
     #[arg(short, long)]
     table: String,
 
     ///
+    /// Source and destination columns as space-delimited key pairs `--columns source=destination`
+    ///
+    #[arg(short, required = true, long, num_args(1..), value_parser = parse_key_val::<String, String>)]
+    columns: Vec<(String, String)>,
+
+    ///
     /// Primary key column/s
-    /// Compound primary keys can be provided as a space delimted list: `--primary-key id user_id``
+    /// Compound primary keys can be provided as a space delimted list: `--primary-key id user_id`
     ///
     #[arg(short = 'k', long, num_args(1..), value_delimiter = ' ', default_values_t = vec![ID.to_string()])]
     primary_key: Vec<String>,
-
-    #[arg(short, long, num_args(1..), value_parser = parse_key_val::<String, String>)]
-    columns: Vec<(String, String)>,
 
     // Updates `batch_size` records at a time
     #[arg(short, long, default_value_t = 100)]
     batch_size: usize,
 
-    /// Run without update. Data is loaded, but updates are not performed.
+    /// Run without update. Data is fetched, but updates are not performed.
     #[arg(short, long, default_value_t = false)]
     dry_run: bool,
 

--- a/packages/cipherstash-proxy/src/cli/migrate/mod.rs
+++ b/packages/cipherstash-proxy/src/cli/migrate/mod.rs
@@ -20,6 +20,10 @@ pub struct Migrate {
     #[arg(short, long)]
     table: String,
 
+    ///
+    /// Primary key column/s
+    /// Compound primary keys can be provided as a space delimted list: `--primary-key id user_id``
+    ///
     #[arg(short = 'k', long, num_args(1..), value_delimiter = ' ', default_values_t = vec![ID.to_string()])]
     primary_key: Vec<String>,
 
@@ -238,5 +242,22 @@ impl Migrate {
         }
 
         Ok(())
+    }
+}
+
+mod tests {
+    use super::Migrate;
+
+    impl Migrate {
+        pub fn new(table: String, columns: Vec<(String, String)>) -> Self {
+            Migrate {
+                table,
+                columns,
+                primary_key: vec!["id".to_string()],
+                batch_size: 10,
+                dry_run: false,
+                verbose: false,
+            }
+        }
     }
 }

--- a/packages/cipherstash-proxy/src/cli/migrate/mod.rs
+++ b/packages/cipherstash-proxy/src/cli/migrate/mod.rs
@@ -1,0 +1,242 @@
+use postgres_protocol::escape::{escape_identifier, escape_literal};
+use std::error::Error as ClapError;
+use std::{self};
+use tokio_postgres::NoTls;
+use tracing::{debug, error, info, warn};
+
+use crate::error::Error;
+use crate::log::MIGRATE;
+use crate::TandemConfig;
+
+const ID: &str = "id";
+const LOCALHOST: &str = "127.0.0.1";
+
+#[derive(clap::Args, Clone, Debug)]
+#[command(version, about, long_about)]
+///
+/// Encrypt data in table
+///
+pub struct Migrate {
+    #[arg(short, long)]
+    table: String,
+
+    #[arg(short = 'k', long, num_args(1..), value_delimiter = ' ', default_values_t = vec![ID.to_string()])]
+    primary_key: Vec<String>,
+
+    #[arg(short, long, num_args(1..), value_parser = parse_key_val::<String, String>)]
+    columns: Vec<(String, String)>,
+
+    // Updates `batch_size` records at a time
+    #[arg(short, long, default_value_t = 100)]
+    batch_size: usize,
+
+    /// Run without update. Data is loaded, but updates are not performed.
+    #[arg(short, long, default_value_t = false)]
+    dry_run: bool,
+
+    /// Turn on additional logging output
+    #[arg(short, long, default_value_t = false)]
+    verbose: bool,
+}
+
+/// Parse a single key-value pair - copied from clap example https://github.com/clap-rs/clap/blob/master/examples/typed-derive.rs#L25
+fn parse_key_val<T, U>(s: &str) -> Result<(T, U), Box<dyn ClapError + Send + Sync + 'static>>
+where
+    T: std::str::FromStr,
+    T::Err: ClapError + Send + Sync + 'static,
+    U: std::str::FromStr,
+    U::Err: ClapError + Send + Sync + 'static,
+{
+    let pos = s
+        .find('=')
+        .ok_or_else(|| format!("invalid KEY=value: no `=` found in `{s}`"))?;
+    Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
+}
+
+impl Migrate {
+    ///
+    /// Returns true if this is not a `dry_run`
+    ///
+    fn commit(&self) -> bool {
+        !self.dry_run
+    }
+
+    ///
+    /// Run the encryption migration process
+    ///
+    pub async fn run(&self, config: TandemConfig) -> Result<(), Error> {
+        let connection_string = format!(
+            "postgresql://{}:{}@{}:{}/{}",
+            config.database.username,
+            config.database.password,
+            config.server.host,
+            config.server.port,
+            config.database.name
+        );
+
+        let (client, connection) = tokio_postgres::connect(&connection_string, NoTls)
+            .await
+            .inspect_err(|_| {
+                error!(target: MIGRATE, msg = "Error connecting Encryption Migrator to Proxy");
+            })?;
+        tokio::spawn(async move {
+            if let Err(err) = connection.await {
+                error!("Connection error: {}", err);
+            }
+        });
+
+        info!(
+            target: MIGRATE,
+            msg = "Connected to Database",
+            database = config.database.name,
+            host = config.server.host,
+            port = config.server.port,
+            username = config.database.username,
+        );
+
+        info!(target: MIGRATE, msg = "Encrypting table", table = self.table, columns = ?self.columns);
+
+        if !self.commit() {
+            warn!(msg = "Dry run is enabled");
+        }
+
+        let mut batch_count = 0;
+        let mut updated_count = 0;
+
+        let quoted_table = escape_identifier(&self.table);
+
+        let primary_key_idents = self
+            .primary_key
+            .iter()
+            .map(|pk| escape_identifier(pk))
+            .collect::<Vec<String>>()
+            .join(", ");
+
+        let column_idents = self
+            .columns
+            .iter()
+            .map(|(source_col, _target_col)| escape_identifier(source_col))
+            .collect::<Vec<String>>()
+            .join(", ");
+
+        let sql =
+        format!("SELECT {primary_key_idents}, {column_idents} FROM {quoted_table} ORDER BY {primary_key_idents}");
+
+        if self.commit() {
+            client.simple_query("BEGIN;").await?;
+        }
+
+        loop {
+            let offset = batch_count * self.batch_size;
+
+            let sql = format!("{sql} LIMIT {} OFFSET {offset} FOR UPDATE", self.batch_size);
+
+            if self.verbose {
+                info!(target: MIGRATE, msg = "Fetch records to encrypt", table = self.table,  columns = ?self.columns);
+            }
+            debug!(target: MIGRATE, msg = "Select", sql);
+
+            let rows = match client.simple_query(&sql).await {
+                Ok(rows) => rows,
+                Err(err) => {
+                    error!(target: MIGRATE, msg = "Error fetching records", table = self.table, error = err.to_string());
+                    std::process::exit(exitcode::SOFTWARE);
+                }
+            };
+
+            let row_count = rows.len() - 1; // Last row is always CommandComplete
+
+            // Batch by building a single statement string
+            let mut update_sql = String::from("");
+            let mut records = vec![];
+
+            for row in rows {
+                match row {
+                    tokio_postgres::SimpleQueryMessage::Row(row) => {
+                        let primary_key_vals = self
+                            .primary_key
+                            .iter()
+                            .map(|c| row.get(c.as_str()).unwrap_or("").to_owned())
+                            .collect::<Vec<String>>();
+
+                        // Get the plaintext value
+                        let column_vals = self
+                            .columns
+                            .iter()
+                            .map(|(source_col, _target_col)| {
+                                row.get(source_col.as_str()).unwrap_or("").to_owned()
+                            })
+                            .collect::<Vec<String>>();
+                        // Set the col to update to the encrypted column
+                        // And set the plaintext value to the p value
+                        let update_str = self
+                            .columns
+                            .iter()
+                            .zip(column_vals.iter())
+                            .map(|((_source_col, target_col), val)| {
+                                format!("\"{target_col}\"='{val}'")
+                            })
+                            .collect::<Vec<String>>()
+                            .join(", ");
+
+                        let where_str = self
+                            .primary_key
+                            .iter()
+                            .zip(primary_key_vals.iter())
+                            .map(|(col, val)| {
+                                let col = escape_identifier(col);
+                                let val = escape_literal(val);
+                                format!("{col}={val}")
+                            })
+                            .collect::<Vec<String>>()
+                            .join(" AND ");
+
+                        let sql = format!(
+                            "UPDATE {} SET {update_str} WHERE {where_str};\n",
+                            self.table
+                        );
+
+                        updated_count += 1;
+                        update_sql.push_str(&sql);
+                        records.extend(primary_key_vals.to_owned());
+                    }
+                    tokio_postgres::SimpleQueryMessage::CommandComplete(..) => {}
+                    tokio_postgres::SimpleQueryMessage::RowDescription(..) => {}
+                    _ => {
+                        error!(target: MIGRATE, msg = "Invalid row. You should not even be here.");
+                        unreachable!()
+                    }
+                }
+            }
+
+            if self.verbose {
+                info!(target: MIGRATE, msg = "Encrypting", ?records);
+            }
+
+            debug!(target: MIGRATE, msg = "Update", update_sql = update_sql);
+
+            if self.commit() {
+                {
+                    client.simple_query(&update_sql).await?;
+                    client.simple_query("COMMIT;").await?;
+                }
+            }
+
+            if row_count < self.batch_size {
+                info!(
+                    target: MIGRATE,
+                    msg = "Encryption complete",
+                    updated = updated_count,
+                    batches = batch_count+1,
+                );
+
+                println!();
+                break;
+            }
+
+            batch_count += 1;
+        }
+
+        Ok(())
+    }
+}

--- a/packages/cipherstash-proxy/src/cli/migrate/mod.rs
+++ b/packages/cipherstash-proxy/src/cli/migrate/mod.rs
@@ -198,7 +198,7 @@ impl Migrate {
                     tokio_postgres::SimpleQueryMessage::CommandComplete(..) => {}
                     tokio_postgres::SimpleQueryMessage::RowDescription(..) => {}
                     _ => {
-                        error!(target: MIGRATE, msg = "Invalid row. You should not even be here.");
+                        error!(target: MIGRATE, msg = "Invalid row. This should be impossible.");
                         unreachable!()
                     }
                 }

--- a/packages/cipherstash-proxy/src/cli/mod.rs
+++ b/packages/cipherstash-proxy/src/cli/mod.rs
@@ -7,8 +7,9 @@ use crate::{
     TandemConfig,
 };
 use clap::{Parser, Subcommand};
-use migrate::Migrate;
-use tracing::{debug, info};
+use tracing::debug;
+
+pub use migrate::Migrate;
 
 const DEFAULT_CONFIG_FILE: &str = "cipherstash-proxy.toml";
 
@@ -41,12 +42,12 @@ pub struct Args {
     pub log_format: LogFormat,
 
     #[command(subcommand)]
-    command: Option<Commands>,
+    pub command: Option<Commands>,
 }
 
 #[derive(Clone, Debug, Subcommand)]
 
-enum Commands {
+pub enum Commands {
     Encrypt(Migrate),
 }
 

--- a/packages/cipherstash-proxy/src/cli/mod.rs
+++ b/packages/cipherstash-proxy/src/cli/mod.rs
@@ -51,14 +51,17 @@ pub enum Commands {
     Encrypt(Migrate),
 }
 
-pub async fn run(args: Args, config: TandemConfig) -> Result<(), Error> {
+///
+/// Runs command specified in command line
+/// Returns Ok(true) if the caller should exit
+///
+pub async fn run(args: Args, config: TandemConfig) -> Result<bool, Error> {
     match args.command {
         Some(Commands::Encrypt(migrate)) => {
             debug!(target: MIGRATE, ?migrate);
             migrate.run(config).await?;
-            std::process::exit(exitcode::OK);
+            Ok(true)
         }
-        None => {}
+        None => Ok(false),
     }
-    Ok(())
 }

--- a/packages/cipherstash-proxy/src/cli/mod.rs
+++ b/packages/cipherstash-proxy/src/cli/mod.rs
@@ -26,19 +26,19 @@ pub struct Args {
     /// Default is "cipherstash-proxy.toml".
     /// Configuration is loaded from this file, if present.
     /// Environment variables are used instead of the file or to override any values defined in the file.
-    #[arg(short, long, default_value = DEFAULT_CONFIG_FILE, verbatim_doc_comment)]
-    pub config_file: String,
+    #[arg(short = 'p', long, default_value = DEFAULT_CONFIG_FILE, verbatim_doc_comment, global = true)]
+    pub config_file_path: String,
 
     ///
     /// Optional log level.
     ///
-    #[arg(short, long, value_enum, default_value_t = LogConfig::default_log_level(), env = "CS_LOG__LEVEL")]
+    #[arg(short, long, value_enum, default_value_t = LogConfig::default_log_level(), env = "CS_LOG__LEVEL", global = true)]
     pub log_level: LogLevel,
 
     ///
     /// Optional log format. Default level is "pretty" if running in a terminal session, otherwise "structured".
     ///
-    #[arg(short='f', long, value_enum, default_value_t = LogConfig::default_log_format(), env = "CS_LOG__FORMAT")]
+    #[arg(short='f', long, value_enum, default_value_t = LogConfig::default_log_format(), env = "CS_LOG__FORMAT", global = true)]
     pub log_format: LogFormat,
 
     #[command(subcommand)]

--- a/packages/cipherstash-proxy/src/config/tandem.rs
+++ b/packages/cipherstash-proxy/src/config/tandem.rs
@@ -190,6 +190,9 @@ pub struct LogConfig {
     pub authentication_level: LogLevel,
 
     #[serde(default = "LogConfig::default_log_level")]
+    pub config_level: LogLevel,
+
+    #[serde(default = "LogConfig::default_log_level")]
     pub context_level: LogLevel,
 
     #[serde(default = "LogConfig::default_log_level")]
@@ -205,6 +208,9 @@ pub struct LogConfig {
     pub keyset_level: LogLevel,
 
     #[serde(default = "LogConfig::default_log_level")]
+    pub migrate_level: LogLevel,
+
+    #[serde(default = "LogConfig::default_log_level")]
     pub protocol_level: LogLevel,
 
     #[serde(default = "LogConfig::default_log_level")]
@@ -212,9 +218,6 @@ pub struct LogConfig {
 
     #[serde(default = "LogConfig::default_log_level")]
     pub schema_level: LogLevel,
-
-    #[serde(default = "LogConfig::default_log_level")]
-    pub config_level: LogLevel,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, ValueEnum)]
@@ -550,6 +553,9 @@ impl DatabaseConfig {
     }
 }
 
+///
+/// Password is NEVER EVER displayed
+///
 impl Display for DatabaseConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -618,6 +624,7 @@ impl Default for LogConfig {
             encoding_level: LogConfig::default_log_level(),
             encrypt_config_level: LogConfig::default_log_level(),
             keyset_level: LogConfig::default_log_level(),
+            migrate_level: LogConfig::default_log_level(),
             protocol_level: LogConfig::default_log_level(),
             mapper_level: LogConfig::default_log_level(),
             schema_level: LogConfig::default_log_level(),
@@ -640,6 +647,7 @@ impl LogConfig {
             encrypt_level: level,
             encrypt_config_level: level,
             keyset_level: level,
+            migrate_level: level,
             protocol_level: level,
             mapper_level: level,
             schema_level: level,

--- a/packages/cipherstash-proxy/src/config/tandem.rs
+++ b/packages/cipherstash-proxy/src/config/tandem.rs
@@ -273,11 +273,14 @@ impl TandemConfig {
 
     pub fn load(args: &Args) -> Result<TandemConfig, Error> {
         // Log a warning to user that config file is missing
-        if !PathBuf::from(&args.config_file).exists() {
-            println!("Configuration file was not found: {}", args.config_file);
+        if !PathBuf::from(&args.config_file_path).exists() {
+            println!(
+                "Configuration file was not found: {}",
+                args.config_file_path
+            );
             println!("Loading config values from environment variables.");
         }
-        let mut config = TandemConfig::build(&args.config_file)?;
+        let mut config = TandemConfig::build(&args.config_file_path)?;
 
         // If log level is default, it has not been set by the user in config
         if config.log.level == LogConfig::default_log_level() {
@@ -656,6 +659,10 @@ impl LogConfig {
     }
 
     pub fn default_log_format() -> LogFormat {
+        debug!(
+            "default_log_format is_terminal {} ",
+            std::io::stdout().is_terminal()
+        );
         if std::io::stdout().is_terminal() {
             LogFormat::Pretty
         } else {

--- a/packages/cipherstash-proxy/src/eql/mod.rs
+++ b/packages/cipherstash-proxy/src/eql/mod.rs
@@ -18,7 +18,9 @@ pub struct Plaintext {
 }
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Identifier {
+    #[serde(rename = "t")]
     pub table: String,
+    #[serde(rename = "c")]
     pub column: String,
 }
 

--- a/packages/cipherstash-proxy/src/lib.rs
+++ b/packages/cipherstash-proxy/src/lib.rs
@@ -12,6 +12,7 @@ pub mod prometheus;
 pub mod tls;
 
 pub use crate::cli::Args;
+pub use crate::cli::Migrate;
 pub use crate::config::{DatabaseConfig, ServerConfig, TandemConfig, TlsConfig};
 pub use crate::encrypt::Encrypt;
 pub use crate::eql::{Encrypted, ForQuery, Identifier, Plaintext};

--- a/packages/cipherstash-proxy/src/log/mod.rs
+++ b/packages/cipherstash-proxy/src/log/mod.rs
@@ -15,16 +15,17 @@ use tracing_subscriber::{
 // If you add one, make sure `log_targets()` and `log_level_for()` functions are updated.
 pub const DEVELOPMENT: &str = "development"; // one for various hidden "development mode" messages
 pub const AUTHENTICATION: &str = "authentication";
+pub const CONFIG: &str = "config";
 pub const CONTEXT: &str = "context";
 pub const ENCRYPT: &str = "encrypt";
 pub const ENCODING: &str = "encoding";
 pub const ENCRYPT_CONFIG: &str = "encrypt_config";
 pub const KEYSET: &str = "keyset";
+pub const MIGRATE: &str = "migrate";
 pub const PARSER: &str = "parser";
 pub const PROTOCOL: &str = "protocol";
 pub const MAPPER: &str = "mapper";
 pub const SCHEMA: &str = "schema";
-pub const CONFIG: &str = "config";
 
 static INIT: Once = Once::new();
 
@@ -128,6 +129,7 @@ mod tests {
             encrypt_level: LogLevel::Error,
             encrypt_config_level: LogLevel::Error,
             keyset_level: LogLevel::Trace,
+            migrate_level: LogLevel::Trace,
             protocol_level: LogLevel::Info,
             mapper_level: LogLevel::Info,
             schema_level: LogLevel::Info,

--- a/packages/cipherstash-proxy/src/main.rs
+++ b/packages/cipherstash-proxy/src/main.rs
@@ -2,14 +2,15 @@ use cipherstash_proxy::config::TandemConfig;
 use cipherstash_proxy::connect::{self, AsyncStream};
 use cipherstash_proxy::encrypt::Encrypt;
 use cipherstash_proxy::error::Error;
+use cipherstash_proxy::log::DEVELOPMENT;
 use cipherstash_proxy::prometheus::CLIENTS_ACTIVE_CONNECTIONS;
-use cipherstash_proxy::{log, postgresql as pg, prometheus, tls, Args};
+use cipherstash_proxy::{cli, log, postgresql as pg, prometheus, tls, Args};
 use clap::Parser;
 use metrics::gauge;
 use tokio::net::TcpListener;
 use tokio::signal::unix::{signal, SignalKind};
 use tokio_util::task::TaskTracker;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
@@ -29,6 +30,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .thread_stack_size(config.thread_stack_size())
         .enable_all()
         .build()?;
+
+    // Run any CLI commands
+    let args_clone = args.clone();
+    let config_clone = config.clone();
+    runtime.block_on(async move {
+        match cli::run(args_clone, config_clone).await {
+            Ok(_) => {
+                debug!(target: DEVELOPMENT, "No command")
+            }
+            Err(err) => {
+                error!(msg = "Error running command", error = err.to_string());
+                std::process::exit(exitcode::USAGE);
+            }
+        }
+    });
 
     runtime.block_on(async move {
         let shutdown_timeout = &config.server.shutdown_timeout();

--- a/packages/cipherstash-proxy/src/main.rs
+++ b/packages/cipherstash-proxy/src/main.rs
@@ -2,7 +2,6 @@ use cipherstash_proxy::config::TandemConfig;
 use cipherstash_proxy::connect::{self, AsyncStream};
 use cipherstash_proxy::encrypt::Encrypt;
 use cipherstash_proxy::error::Error;
-use cipherstash_proxy::log::DEVELOPMENT;
 use cipherstash_proxy::prometheus::CLIENTS_ACTIVE_CONNECTIONS;
 use cipherstash_proxy::{cli, log, postgresql as pg, prometheus, tls, Args};
 use clap::Parser;
@@ -10,7 +9,7 @@ use metrics::gauge;
 use tokio::net::TcpListener;
 use tokio::signal::unix::{signal, SignalKind};
 use tokio_util::task::TaskTracker;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();

--- a/packages/cipherstash-proxy/src/main.rs
+++ b/packages/cipherstash-proxy/src/main.rs
@@ -36,9 +36,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config_clone = config.clone();
     runtime.block_on(async move {
         match cli::run(args_clone, config_clone).await {
-            Ok(_) => {
-                debug!(target: DEVELOPMENT, "No command")
+            Ok(exit) => {
+                if exit {
+                    std::process::exit(exitcode::OK);
+                }
             }
+
             Err(err) => {
                 error!(msg = "Error running command", error = err.to_string());
                 std::process::exit(exitcode::USAGE);

--- a/tests/tasks/test/integration/migrate.sh
+++ b/tests/tasks/test/integration/migrate.sh
@@ -6,6 +6,10 @@
 set -e
 
 
+docker exec -i postgres${CONTAINER_SUFFIX} psql postgresql://cipherstash:password@proxy:6432/cipherstash <<-EOF
+TRUNCATE encrypted;
+EOF
+
 # Connect to the proxy
 docker exec -i postgres${CONTAINER_SUFFIX} psql postgresql://cipherstash:password@proxy:6432/cipherstash <<-EOF
 INSERT INTO encrypted (id, plaintext) VALUES (1, 'One');
@@ -15,7 +19,7 @@ INSERT INTO encrypted (id, plaintext) VALUES (4, 'Four');
 INSERT INTO encrypted (id, plaintext) VALUES (5, 'Five');
 EOF
 
-docker exec -it proxy cipherstash-proxy encrypt --table encrypted --columns plaintext=encrypted_text  --verbose
+docker exec -i proxy cipherstash-proxy encrypt --table encrypted --columns plaintext=encrypted_text  --verbose
 
 docker exec -i postgres${CONTAINER_SUFFIX} psql postgresql://cipherstash:password@proxy:6432/cipherstash <<-EOF
 SELECT * FROM encrypted;

--- a/tests/tasks/test/integration/migrate.sh
+++ b/tests/tasks/test/integration/migrate.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#MISE description="Test Prometheus metrics are exported and updated"
+
+#!/bin/bash
+
+set -e
+
+
+# Connect to the proxy
+docker exec -i postgres${CONTAINER_SUFFIX} psql postgresql://cipherstash:password@proxy:6432/cipherstash <<-EOF
+INSERT INTO encrypted (id, plaintext) VALUES (1, 'One');
+INSERT INTO encrypted (id, plaintext) VALUES (2, 'Two');
+INSERT INTO encrypted (id, plaintext) VALUES (3, 'Three');
+INSERT INTO encrypted (id, plaintext) VALUES (4, 'Four');
+INSERT INTO encrypted (id, plaintext) VALUES (5, 'Five');
+EOF
+
+docker exec -it proxy cipherstash-proxy encrypt --table encrypted --columns plaintext=encrypted_text  --verbose
+
+docker exec -i postgres${CONTAINER_SUFFIX} psql postgresql://cipherstash:password@proxy:6432/cipherstash <<-EOF
+SELECT * FROM encrypted;
+EOF
+
+set +e
+OUTPUT="$(docker exec -i postgres${CONTAINER_SUFFIX} psql 'postgresql://cipherstash:password@proxy:6432/cipherstash?sslmode=disable' --command 'SELECT id FROM encrypted WHERE encrypted_text IS NULL' 2>&1)"
+retval=$?
+if echo ${OUTPUT} | grep -v '(0 rows)'; then
+    echo "error: did not see string in output: \"(0 rows)\""
+    exit 1
+fi
+
+docker exec -i postgres${CONTAINER_SUFFIX} psql postgresql://cipherstash:password@proxy:6432/cipherstash <<-EOF
+TRUNCATE encrypted;
+EOF
+
+set -e
+
+echo "----------------------------------"
+echo "Migrator tests complete"
+echo "----------------------------------"


### PR DESCRIPTION
Migrator command assumes a running proxy, and uses existing config to make the connection. 
Streamlines the migrate options, as only table and source/destination columns are required. 

- [x] Pull in code from migrator app
- [x] Enable as proxy subcommand
- [x] Integration tests
  - command line exec via docker 
  - rust integration test via direct call



Example usage
```bash
cipherstash-proxy encrypt --table encrypted --columns plaintext=encrypted_text
```