### PR TITLE
feat: Have the AWS RDS certificate bundle be optionally loaded into the system cert store.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -eu
+
+: "${CS_DATABASE__AWS_BUNDLE_PATH:=./aws-rds-global-bundle.pem}"
+
+# Optionally pull in the AWS RDS global certificate bundle. This is required
+# to communicate with AWS RDS instances, if they are not configured to use some
+# other certificates.
+# (This assumes that ca-certificates is installed, for csplit and update-ca-certificates.)
+case "${CS_DATABASE__INSTALL_AWS_RDS_CERT_BUNDLE:-}" in
+  # Have a guess at some common yaml-et-al encoding failures:
+  "") ;&
+  "false") ;&
+  "no") ;&
+  "0")
+    >&2 echo "Not installing AWS RDS certificate bundle."
+    ;;
+
+  # Okay, go ahead and install the bundle:
+  *)
+    set -x
+    if [ ! -f "$CS_DATABASE__AWS_BUNDLE_PATH" ]; then
+      >&2 echo "Unable to find AWS RDS certificate bundle at: $CS_DATABASE__AWS_BUNDLE_PATH"
+      exit 1
+    fi
+
+    >&2 echo "Installing AWS RDS certificate bundle..."
+    csplit --quiet --elide-empty-files --prefix /usr/local/share/ca-certificates/aws --suffix '.%d.crt' "$CS_DATABASE__AWS_BUNDLE_PATH" '/-----BEGIN CERTIFICATE-----/' '{*}'
+    update-ca-certificates
+    ;;
+esac
+
+exec cipherstash-proxy "$@"

--- a/proxy.Dockerfile
+++ b/proxy.Dockerfile
@@ -1,12 +1,18 @@
 FROM ubuntu:latest
 
-# Install TLS/SSL certs for https support, and PostgreSQL client (psql)
-RUN apt update && apt install -y ca-certificates postgresql-client
+# Install TLS/SSL certs for https support, PostgreSQL client (psql), and curl
+# for retrieving the certificate bundle.
+RUN apt update && apt install -y ca-certificates postgresql-client curl
 
 # Copy binary
 COPY cipherstash-proxy /usr/local/bin/cipherstash-proxy
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 # Copy EQL install scripts
 COPY cipherstash-eql.sql /opt/cipherstash-eql.sql
 
-ENTRYPOINT ["cipherstash-proxy"]
+# Make the AWS global bundle available for use in the docker-entrypoint.sh script.
+ENV CS_DATABASE__AWS_BUNDLE_PATH="./aws-rds-global-bundle.pem"
+RUN curl -ks "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" -o "$CS_DATABASE__AWS_BUNDLE_PATH"
+
+ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
AWS RDS instances use a separate SSL CA and set of certificates to the Amazon root CA:
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html

To connect via SSL to RDS, without changing the CA for the RDS instance, we need to pull in the AWS-provided certificate bundle.

To accomplish this, we have an entrypoint wrapper script (`cipherstash-proxy.sh`) that, at container start, optionally installs the bundle and then goes on to run the `cipherstash-proxy` binary. Set the `CS_DATABASE__INSTALL_AWS_RDS_CERT_BUNDLE` env var (eg. to `"true"`) for the container to load that bundle.

(The certificate bundle itself is fetched *at build time* for later run-time use; as long as the proxy image isn't extremely old, it should be fine.)

This PR builds on #159.