### PR TITLE
build(mise): DEBUG flag now has the `build:docker` task retain its build output.

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -513,9 +513,12 @@ depends = ["build:docker:fetch_eql"]
 description = "Build a Docker image for cipherstash-proxy"
 run = """
 {% set default_platform = "linux/" ~ arch() | replace(from="x86_64", to="amd64") %}
+[ -n "${DEBUG}" ] && PROGRESS_FLAG="--progress=plain" || PROGRESS_FLAG=""
+
 docker build . \
   --tag cipherstash/proxy:latest \
   --file proxy.Dockerfile \
+  ${PROGRESS_FLAG} \
   --platform {{option(name="platform",default=default_platform)}} \
 """
 


### PR DESCRIPTION
Has the `mise run build:docker` task print its Docker build output (with `--progress=plain`), so it's possible to see said output after the run has finished.