### PR TITLE
fix(tests): missing table in teardown & order of schema & EQL teardown

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -405,8 +405,8 @@ run = """
 cd tests
 mise run postgres:fail_if_not_running
 mise run postgres:eql:download
-cat sql/cipherstash-encrypt-uninstall.sql | docker exec -i postgres${CONTAINER_SUFFIX} psql postgresql://${CS_DATABASE__USERNAME}:${CS_DATABASE__PASSWORD}@${CS_DATABASE__HOST}:${CS_DATABASE__PORT}/${CS_DATABASE__NAME} -f-
 cat sql/schema-uninstall.sql | docker exec -i postgres${CONTAINER_SUFFIX} psql postgresql://${CS_DATABASE__USERNAME}:${CS_DATABASE__PASSWORD}@${CS_DATABASE__HOST}:${CS_DATABASE__PORT}/${CS_DATABASE__NAME} -f-
+cat sql/cipherstash-encrypt-uninstall.sql | docker exec -i postgres${CONTAINER_SUFFIX} psql postgresql://${CS_DATABASE__USERNAME}:${CS_DATABASE__PASSWORD}@${CS_DATABASE__HOST}:${CS_DATABASE__PORT}/${CS_DATABASE__NAME} -f-
 """
 
 [tasks."postgres:up"]

--- a/tests/sql/schema-uninstall.sql
+++ b/tests/sql/schema-uninstall.sql
@@ -6,3 +6,5 @@ DROP TABLE IF EXISTS plaintext;
 -- Exciting cipherstash table
 DROP TABLE IF EXISTS encrypted;
 
+DROP TABLE IF EXISTS unconfigured;
+


### PR DESCRIPTION
Ensure `unconfigured` table is torn down at the end of test runs and also swap order of schema & EQL teardown to prevent teardown failures when EQL types are still referenced.

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
