### PR TITLE
feat: improve error message for internal errors

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -170,13 +170,13 @@ Check the supported types for encrypted columns.
 
 ## Internal Mapper error <a id='mapping-internal-error'></a>
 
-An error that is internal to the EQL Mapper module. This may be a defect or a limitation of the current EQL Mapper.
-
+An internal error occurred when attempting to rewrite the SQL statement.
+This could be due to an internal invariant failure or because of a specific fragment of unsupported SQL syntax.
 
 ### Error message
 
 ```
-Internal error: 'internal details'
+Statement encountered an internal error. This may be a bug in the statement mapping module of CipherStash Proxy.
 ```
 
 ### How to Fix

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -12,6 +12,7 @@
   - [Invalid parameter](#mapping-invalid-parameter)
   - [Invalid SQL statement](#mapping-invalid-sql-statement)
   - [Unsupported parameter type](#mapping-unsupported-parameter-type)
+  - [Internal Error](#mapping-internal-error)
 
 - Encrypt Errors:
   - [Column could not be encrypted](#encrypt-column-could-not-be-encrypted)
@@ -161,6 +162,28 @@ Encryption of PostgreSQL {name} (OID {oid}) types is not currently supported.
 Check the supported types for encrypted columns.
 
 <!-- TODO: link to doc -->
+
+
+
+<!-- ---------------------------------------------------------------------------------------------------- -->
+
+
+## Internal Mapper error <a id='mapping-internal-error'></a>
+
+An error that is internal to the EQL Mapper module. This may be a defect or a limitation of the current EQL Mapper.
+
+
+### Error message
+
+```
+Internal error: 'internal details'
+```
+
+### How to Fix
+
+If you are running an older version of CipherStash Proxy, please update to the latest version.
+
+If the error persists, please contact CipherStash [support](https://cipherstash.com/support).
 
 
 

--- a/packages/cipherstash-proxy-integration/src/extended_protocol_error_messages.rs
+++ b/packages/cipherstash-proxy-integration/src/extended_protocol_error_messages.rs
@@ -66,7 +66,7 @@ mod tests {
         if let Err(err) = result {
             let msg = err.to_string();
 
-            assert_eq!(msg, "db error: ERROR: Column 'encrypted_unconfigured' in table 'unconfigured' has no Encrypt configuration. For help visit https://github.com/cipherstash/proxy/docs/errors.md#encrypt-unknown-column");
+            assert_eq!(msg, "db error: ERROR: Column 'encrypted_unconfigured' in table 'unconfigured' has no Encrypt configuration. For help visit https://github.com/cipherstash/proxy/blob/main/docs/errors.md#encrypt-unknown-column");
         } else {
             unreachable!();
         }
@@ -122,7 +122,7 @@ mod tests {
         if let Err(err) = result {
             let msg = err.to_string();
             info!("{}", msg);
-            assert_eq!(msg, "db error: ERROR: sql parser error: Expected: SELECT, VALUES, or a subquery in the query body, found: id at Line: 1, Column: 23. For help visit https://github.com/cipherstash/proxy/docs/errors.md#mapping-invalid-sql-statement");
+            assert_eq!(msg, "db error: ERROR: sql parser error: Expected: SELECT, VALUES, or a subquery in the query body, found: id at Line: 1, Column: 23. For help visit https://github.com/cipherstash/proxy/blob/main/docs/errors.md#mapping-invalid-sql-statement");
         } else {
             unreachable!();
         }

--- a/packages/cipherstash-proxy/src/error.rs
+++ b/packages/cipherstash-proxy/src/error.rs
@@ -6,7 +6,7 @@ use std::io;
 use thiserror::Error;
 use tokio::time::error::Elapsed;
 
-const ERROR_DOC_BASE_URL: &str = "https://github.com/cipherstash/proxy/docs/errors.md";
+const ERROR_DOC_BASE_URL: &str = "https://github.com/cipherstash/proxy/blob/main/docs/errors.md";
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -89,6 +89,9 @@ pub enum MappingError {
 
     #[error("Could not parse parameter")]
     CouldNotParseParameter,
+
+    #[error("Statement encountered an internal error. This may be a bug in the current CipherStash EqlMapper module. Please visit {}#mapping-internal-error for more information.", ERROR_DOC_BASE_URL)]
+    Internal(String),
 }
 
 #[derive(Error, Debug)]
@@ -302,5 +305,18 @@ impl From<rust_decimal::Error> for Error {
 impl From<chrono::ParseError> for Error {
     fn from(_e: chrono::ParseError) -> Self {
         MappingError::CouldNotParseParameter.into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_internal_error_message() {
+        let error = MappingError::Internal("unexpected bug encounterd".to_string());
+        let message = error.to_string();
+
+        assert_eq!(format!("Statement encountered an internal error. This may be a bug in the current CipherStash EqlMapper module. Please visit {}#mapping-internal-error for more information.", ERROR_DOC_BASE_URL), message);
     }
 }

--- a/packages/cipherstash-proxy/src/error.rs
+++ b/packages/cipherstash-proxy/src/error.rs
@@ -90,7 +90,7 @@ pub enum MappingError {
     #[error("Could not parse parameter")]
     CouldNotParseParameter,
 
-    #[error("Statement encountered an internal error. This may be a bug in the current CipherStash EqlMapper module. Please visit {}#mapping-internal-error for more information.", ERROR_DOC_BASE_URL)]
+    #[error("Statement encountered an internal error. This may be a bug in the statement mapping module of CipherStash Proxy. Please visit {}#mapping-internal-error for more information.", ERROR_DOC_BASE_URL)]
     Internal(String),
 }
 
@@ -317,6 +317,6 @@ mod tests {
         let error = MappingError::Internal("unexpected bug encounterd".to_string());
         let message = error.to_string();
 
-        assert_eq!(format!("Statement encountered an internal error. This may be a bug in the current CipherStash EqlMapper module. Please visit {}#mapping-internal-error for more information.", ERROR_DOC_BASE_URL), message);
+        assert_eq!(format!("Statement encountered an internal error. This may be a bug in the statement mapping module of CipherStash Proxy. Please visit {}#mapping-internal-error for more information.", ERROR_DOC_BASE_URL), message);
     }
 }


### PR DESCRIPTION
This changes error mapping target of EqlMapper::InternalError from `MappingError::StatementCouldNotBeMapped` to a newly created error type `MappingError::Internal`. Also adds a new section in the docs.

I think this is better as "statement could not be mapped" can be user-side issue (like 4XX errors in HTTP), but internal error is server-side (like 5XX in HTTP).

It still does the same logging and counting as `StatementCouldNotBeMapped` but the raised (mapped) error and its messages are distinct from `StatementCouldNotBeMapped`.

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
