### PR TITLE
docs(getting-started): add steps for installing `stash`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,14 @@ Get up and running in local dev in < 5 minutes:
 git clone https://github.com/cipherstash/proxy
 cd proxy
 
+# Install the CipherStash CLI
+## macOS
+brew install cipherstash/tap/stash
+## Linux
+## Download from https://github.com/cipherstash/cli-releases/releases/latest
+
 # Setup your CipherStash configuration
 stash setup
-# TODO: get the config into a format cipherstash-proxy can read
 
 # Start the containers
 docker compose up


### PR DESCRIPTION
Fill out more of the README's getting started, now that [stash 1.6.0](https://github.com/cipherstash/cli-releases/releases/tag/release-1.6.0-20250317) is available. 