### PR TITLE
fix: make connection timeout optional

### DIFF
--- a/packages/cipherstash-proxy/src/config/database.rs
+++ b/packages/cipherstash-proxy/src/config/database.rs
@@ -19,8 +19,7 @@ pub struct DatabaseConfig {
     #[serde(deserialize_with = "protected_string_deserializer")]
     password: Protected<String>,
 
-    #[serde(default = "DatabaseConfig::default_connection_timeout")]
-    pub connection_timeout: u64,
+    pub connection_timeout: Option<u64>,
 
     #[serde(default)]
     pub with_tls_verification: bool,
@@ -39,11 +38,6 @@ impl DatabaseConfig {
 
     pub const fn default_port() -> u16 {
         5432
-    }
-
-    // 5 minutes
-    pub const fn default_connection_timeout() -> u64 {
-        1000 * 60 * 5
     }
 
     pub const fn default_config_reload_interval() -> u64 {
@@ -73,8 +67,8 @@ impl DatabaseConfig {
         self.password.to_owned().risky_unwrap()
     }
 
-    pub fn connection_timeout(&self) -> Duration {
-        Duration::from_millis(self.connection_timeout)
+    pub fn connection_timeout(&self) -> Option<Duration> {
+        self.connection_timeout.map(Duration::from_millis)
     }
 
     pub fn server_name(&self) -> Result<ServerName, Error> {

--- a/packages/cipherstash-proxy/src/error.rs
+++ b/packages/cipherstash-proxy/src/error.rs
@@ -2,9 +2,8 @@ use crate::{postgresql::Column, Identifier};
 use bytes::BytesMut;
 use cipherstash_client::encryption;
 use metrics_exporter_prometheus::BuildError;
-use std::io;
+use std::{io, time::Duration};
 use thiserror::Error;
-use tokio::time::error::Elapsed;
 
 const ERROR_DOC_BASE_URL: &str = "https://github.com/cipherstash/proxy/docs/errors.md";
 
@@ -25,8 +24,8 @@ pub enum Error {
     #[error("Connection closed by client")]
     ConnectionClosed,
 
-    #[error("Connection timed out")]
-    ConnectionTimeout(#[from] Elapsed),
+    #[error("Connection timed out after {} ms", duration.as_secs())]
+    ConnectionTimeout { duration: Duration },
 
     #[error("Error creating connection")]
     DatabaseConnection,

--- a/packages/cipherstash-proxy/src/main.rs
+++ b/packages/cipherstash-proxy/src/main.rs
@@ -111,8 +111,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     Error::CancelRequest => {
                                         info!(msg = "Database connection closed after cancel request");
                                     }
-                                    Error::ConnectionTimeout(_) => {
-                                        warn!(msg = "Database connection timeout");
+                                    Error::ConnectionTimeout{..} => {
+                                        warn!(msg = "Database connection timeout", error = err.to_string());
                                     }
                                     _ => {
                                         error!(msg = "Database connection error", error = err.to_string());

--- a/packages/cipherstash-proxy/src/postgresql/backend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/backend.rs
@@ -81,7 +81,7 @@ where
     pub async fn rewrite(&mut self) -> Result<(), Error> {
         let connection_timeout = self.encrypt.config.database.connection_timeout();
 
-        let (code, mut bytes) = protocol::read_message_with_timeout(
+        let (code, mut bytes) = protocol::read_message(
             &mut self.server_reader,
             self.context.client_id,
             connection_timeout,

--- a/packages/cipherstash-proxy/src/postgresql/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/frontend.rs
@@ -76,7 +76,7 @@ where
 
     pub async fn rewrite(&mut self) -> Result<(), Error> {
         let connection_timeout = self.encrypt.config.database.connection_timeout();
-        let (code, mut bytes) = protocol::read_message_with_timeout(
+        let (code, mut bytes) = protocol::read_message(
             &mut self.client_reader,
             self.context.client_id,
             connection_timeout,

--- a/packages/cipherstash-proxy/src/postgresql/handler.rs
+++ b/packages/cipherstash-proxy/src/postgresql/handler.rs
@@ -70,7 +70,7 @@ pub async fn handler(
     );
 
     loop {
-        let startup_message = startup::read_message_with_timeout(
+        let startup_message = startup::read_message(
             &mut client_stream,
             encrypt.config.database.connection_timeout(),
         )
@@ -125,8 +125,7 @@ pub async fn handler(
 
         let connection_timeout = encrypt.config.database.connection_timeout();
         let (_code, bytes) =
-            protocol::read_message_with_timeout(&mut client_stream, client_id, connection_timeout)
-                .await?;
+            protocol::read_message(&mut client_stream, client_id, connection_timeout).await?;
 
         let password_message = PasswordMessage::try_from(&bytes)?;
 

--- a/packages/cipherstash-proxy/src/postgresql/messages/error_response.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/error_response.rs
@@ -16,6 +16,7 @@ pub const CODE_INVALID_PASSWORD: &str = "28P01";
 pub const CODE_RAISE_EXCEPTION: &str = "P0001";
 pub const CODE_SYNTAX_ERROR: &str = "42601";
 pub const CODE_INVALID_TEXT_REPRESENTATION: &str = "22P02";
+pub const CODE_IDLE_SESSION_TIMEOUT: &str = "57P05";
 
 ///
 /// ErrorResponse (B)
@@ -58,6 +59,29 @@ pub enum ErrorResponseCode {
 }
 
 impl ErrorResponse {
+    pub fn connection_timeout() -> Self {
+        Self {
+            fields: vec![
+                Field {
+                    code: ErrorResponseCode::Severity,
+                    value: "FATAL".to_string(),
+                },
+                Field {
+                    code: ErrorResponseCode::SeverityLegacy,
+                    value: "FATAL".to_string(),
+                },
+                Field {
+                    code: ErrorResponseCode::Code,
+                    value: CODE_IDLE_SESSION_TIMEOUT.to_string(),
+                },
+                Field {
+                    code: ErrorResponseCode::Message,
+                    value: "Connection timeout".to_string(),
+                },
+            ],
+        }
+    }
+
     pub fn invalid_password(message: &str) -> Self {
         Self {
             fields: vec![


### PR DESCRIPTION
Replicate postgres behaviour by making connection timeout optional. 

Timeout is still configurable, but default is no timeout. 