### PR TITLE
feat(proxy): output installed EQL version on startup

### DIFF
--- a/mise.local.example.toml
+++ b/mise.local.example.toml
@@ -14,6 +14,8 @@ CS_DEFAULT_KEYSET_ID = "default-keyset-id"
 CS_CLIENT_KEY = "client-key"
 CS_CLIENT_ID = "client-id"
 
+# The release of EQL that the proxy tests will use and releases will be built with
+CS_EQL_VERSION="eql-0.5.4"
 
 # TLS variables are required for providing TLS to Proxy's clients.
 # CS_TLS__TYPE can be either "Path" or "Pem" (case-sensitive).

--- a/mise.toml
+++ b/mise.toml
@@ -22,6 +22,7 @@ CS_DATABASE__PORT = "5532"
 CS_PROXY__HOST = "proxy"
 # Misc
 DOCKER_CLI_HINTS = "false" # Please don't show us What's Next.
+CS_EQL_VERSION="eql-0.5.4"
 
 [tools]
 "cargo:cargo-binstall" = "latest"
@@ -466,7 +467,7 @@ outputs = [
 run = """
 # install script
 if [ -z "$CS_EQL_PATH" ]; then
-  curl -sLo sql/cipherstash-encrypt.sql https://github.com/cipherstash/encrypt-query-language/releases/latest/download/cipherstash-encrypt.sql
+  curl -sLo sql/cipherstash-encrypt.sql https://github.com/cipherstash/encrypt-query-language/releases/download/${CS_EQL_VERSION}/cipherstash-encrypt.sql
 else
   echo "Using EQL: ${CS_EQL_PATH}"
   cp "$CS_EQL_PATH" sql/cipherstash-encrypt.sql
@@ -474,7 +475,7 @@ fi
 
 # uninstall script
 if [ -z "$CS_EQL_UNINSTALL_PATH" ]; then
-  curl -sLo sql/cipherstash-encrypt-uninstall.sql https://github.com/cipherstash/encrypt-query-language/releases/latest/download/cipherstash-encrypt-uninstall.sql
+  curl -sLo sql/cipherstash-encrypt-uninstall.sql https://github.com/cipherstash/encrypt-query-language/releases/download/${CS_EQL_VERSION}/cipherstash-encrypt-uninstall.sql
 else
   echo "Using EQL: ${CS_EQL_PATH}"
   cp "$CS_EQL_UNINSTALL_PATH" sql/cipherstash-encrypt-uninstall.sql
@@ -545,7 +546,7 @@ description = "Fetch the EQL installation script"
 run = """
 if [ ! -e "cipherstash-eql.sql" ]; then
   echo "Fetching: cipherstash-eql.sql"
-  curl -sLo cipherstash-eql.sql https://github.com/cipherstash/encrypt-query-language/releases/latest/download/cipherstash-encrypt.sql
+  curl -sLo cipherstash-eql.sql https://github.com/cipherstash/encrypt-query-language/releases/download/${CS_EQL_VERSION}/cipherstash-encrypt.sql
 else
   echo "Prefetched: cipherstash-eql.sql"
 fi

--- a/packages/cipherstash-proxy/src/main.rs
+++ b/packages/cipherstash-proxy/src/main.rs
@@ -217,6 +217,7 @@ async fn init(mut config: TandemConfig) -> Encrypt {
                 host = encrypt.config.database.host,
                 port = encrypt.config.database.port,
                 username = encrypt.config.database.username,
+                eql_version = encrypt.eql_version,
             );
             encrypt
         }


### PR DESCRIPTION
This queries the database with `select cs_eql_version();` (rather than the version at build time) for accuracy.

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
