### PR TITLE
feat(proxy): emit warning when proxy build-time and runtime versions of EQL differ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ rust-toolchain.toml
 # release artifacts
 /cipherstash-proxy
 /cipherstash-eql.sql
+/packages/cipherstash-proxy/eql-version-at-build-time.txt
 
 # credentials for local dev
 .env.proxy.docker

--- a/packages/cipherstash-proxy/build.rs
+++ b/packages/cipherstash-proxy/build.rs
@@ -1,0 +1,10 @@
+use std::env;
+
+fn main() {
+    if let Ok(eql_version) = env::var("CS_EQL_VERSION") {
+        println!(
+            "cargo:rustc-env=EQL_VERSION_AT_BUILD_TIME={}",
+            eql_version.trim()
+        );
+    }
+}

--- a/packages/cipherstash-proxy/src/main.rs
+++ b/packages/cipherstash-proxy/src/main.rs
@@ -11,6 +11,8 @@ use tokio::signal::unix::{signal, SignalKind};
 use tokio_util::task::TaskTracker;
 use tracing::{error, info, warn};
 
+const EQL_VERSION_AT_BUILD_TIME: Option<&'static str> = option_env!("EQL_VERSION_AT_BUILD_TIME");
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
@@ -219,6 +221,13 @@ async fn init(mut config: TandemConfig) -> Encrypt {
                 username = encrypt.config.database.username,
                 eql_version = encrypt.eql_version,
             );
+            if encrypt.eql_version.as_deref() != EQL_VERSION_AT_BUILD_TIME {
+                warn!(
+                    msg = "installed version of EQL is different to the version that Proxy was built with",
+                    eql_build_version = EQL_VERSION_AT_BUILD_TIME,
+                    eql_installed_version = encrypt.eql_version,
+                );
+            }
             encrypt
         }
         Err(err) => {


### PR DESCRIPTION
1. mise.toml downloads the EQL version specified in `CS_EQL_VERSION`

2. `cipherstash-proxy` now has a `build.rs` file that reads `CS_EQL_VERSION` at compile time.

3. The env var is consumed (at compile time) in `cipherstash-proxy`'s `main.rs` and stored in a constant

4. When `Encrypt` is initialised the version from the database is compared with the version from compile time and a `warn!(..)` is issued when they differ.

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
