### PR TITLE
chore(docker): upgrade Ubuntu base image to 24.10

### DIFF
--- a/proxy.Dockerfile
+++ b/proxy.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:24.10
 
 # Install TLS/SSL certs for https support, PostgreSQL client (psql), and curl
 # for retrieving the certificate bundle.


### PR DESCRIPTION
Docker Scout says this will eliminate 11 known vulnerabilities in package dependencies.

The base image for 24.04 has not been updated for several months, which is unusual for an LTS release.

<!-- Please provide a summary of what's being changed -->

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
