### PR TITLE
Add details of StatementCouldNotBeMapped in errors.md

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -218,7 +218,7 @@ If the error persists, please contact CipherStash [support](https://cipherstash.
 ## Internal Mapper error <a id='mapping-internal-error'></a>
 
 An internal error occurred when attempting to type check or transform a SQL statement.
-This could be due to an internal invariant failure or because of a specific fragment of unsupported SQL syntax.
+This could be due to an internal invariant failure, or because of a specific fragment of unsupported SQL syntax.
 
 ### Error message
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -228,7 +228,7 @@ Statement encountered an internal error. This may be a bug in the statement mapp
 
 ### How to Fix
 
-Check that the installed version of CipherStash Proxy, and update to the latest version if possible.
+Check if you are running the latest version of CipherStash Proxy, and update to the latest version if not.
 
 If the error persists, please contact CipherStash [support](https://cipherstash.com/support).
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -187,7 +187,7 @@ The behaviour of Proxy depends on the `mapping_errors_enabled` configuration.
 
 When `mapping_errors_enabled` is `false` (the default), then type check errors are logged, and the statement is passed through to the database.
 
-When `mapping_errors_enabled == true` type check errors are raised and statement execution halts.
+When `mapping_errors_enabled` is `true`, then type check errors are raised, and statement execution halts.
 
 In our experience, most production systems have a relatively small number of columns that require protection.
 As SQL is large and complex, rather than block statements with false negative type check errors, the default behaviour is to allow the statement.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -193,7 +193,7 @@ In our experience, most production systems have a relatively small number of col
 As SQL is large and complex, instead of blocking statements with type check errors that are false negatives, the default behaviour of Proxy is to allow the statement.
 
 However, this does mean it is possible that a statement referencing encrypted columns cannot be type-checked and is passed through to the database.
-In this case, database column constraints (included in EQL) will catch the statement and return a PostgreSQL error.
+When a statement is passed through to the database, the database's column constraints (provided by EQL) will catch the statement, and return a PostgreSQL error.
 
 Example constraint error:
 ```sql

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -185,7 +185,7 @@ CipherStash Proxy checks SQL statements against the database schema to transpare
 
 The behaviour of Proxy depends on the `mapping_errors_enabled` configuration.
 
-When `mapping_errors_enabled == false` (the default) type check errors are logged, and the statement is passed through to the database.
+When `mapping_errors_enabled` is `false` (the default), then type check errors are logged, and the statement is passed through to the database.
 
 When `mapping_errors_enabled == true` type check errors are raised and statement execution halts.
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -192,7 +192,7 @@ When `mapping_errors_enabled` is `true`, then type check errors are raised, and 
 In our experience, most production systems have a relatively small number of columns that require protection.
 As SQL is large and complex, instead of blocking statements with type check errors that are false negatives, the default behaviour of Proxy is to allow the statement.
 
-However, this does mean it is possible that a statement referencing encrypted columns cannot be type-checked and is passed through to the database.
+However, this does mean it is possible that a statement that references encrypted columns cannot be type-checked, and it will be passed through to the database.
 When a statement is passed through to the database, the database's column constraints (provided by EQL) will catch the statement, and return a PostgreSQL error.
 
 Example constraint error:

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -206,7 +206,7 @@ SQL function "cs_check_encrypted_v1" statement 1
 
 In most cases, this error will occur if the statement contains invalid or unsupported syntax.
 
-Check that the installed version of CipherStash Proxy, and update to the latest version if possible.
+Check if you are running the latest version of CipherStash Proxy, and update to the latest version if not.
 
 If the error persists, please contact CipherStash [support](https://cipherstash.com/support).
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -12,6 +12,7 @@
   - [Invalid parameter](#mapping-invalid-parameter)
   - [Invalid SQL statement](#mapping-invalid-sql-statement)
   - [Unsupported parameter type](#mapping-unsupported-parameter-type)
+  - [Statement could not be type checked](#mapping-statement-could-not-be-mapped)
   - [Internal Error](#mapping-internal-error)
 
 - Encrypt Errors:
@@ -162,6 +163,29 @@ Encryption of PostgreSQL {name} (OID {oid}) types is not currently supported.
 Check the supported types for encrypted columns.
 
 <!-- TODO: link to doc -->
+
+
+
+<!-- ---------------------------------------------------------------------------------------------------- -->
+
+
+## Statement could not be type checked <a id='mapping-statement-could-not-be-mapped'></a>
+
+An error occurred when attempting to type check the SQL statement.
+
+### Error message
+
+```
+Statement could not be type checked: 'details'
+```
+
+### How to Fix
+
+In most cases, this error will occur if the statement contains invalid or unsupported syntax.
+
+This error will not be raised, unless you set `mapping_errors_enabled` to `true`.
+If mapping errors are not enabled, the statement will be passed through unchanged.
+The statement that is passed through may result in syntax errors from PostgreSQL.
 
 
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -190,7 +190,7 @@ When `mapping_errors_enabled` is `false` (the default), then type check errors a
 When `mapping_errors_enabled` is `true`, then type check errors are raised, and statement execution halts.
 
 In our experience, most production systems have a relatively small number of columns that require protection.
-As SQL is large and complex, rather than block statements with false negative type check errors, the default behaviour is to allow the statement.
+As SQL is large and complex, instead of blocking statements with type check errors that are false negatives, the default behaviour of Proxy is to allow the statement.
 
 However, this does mean it is possible that a statement referencing encrypted columns cannot be type-checked and is passed through to the database.
 In this case, database column constraints (included in EQL) will catch the statement and return a PostgreSQL error.

--- a/packages/cipherstash-proxy/src/error.rs
+++ b/packages/cipherstash-proxy/src/error.rs
@@ -80,8 +80,8 @@ pub enum MappingError {
     #[error("Encryption of PostgreSQL {name} (OID {oid}) types is not currently supported. For help visit {}#mapping-unsupported-parameter-type", ERROR_DOC_BASE_URL)]
     UnsupportedParameterType { name: String, oid: u32 },
 
-    #[error("Statement could not be type checked: {}. For help visit {}#mapping-statement-could-not-be-mapped", _0, ERROR_DOC_BASE_URL)]
-    StatementCouldNotBeMapped(String),
+    #[error("Statement could not be type checked: {}. For help visit {}#mapping-statement-could-not-be-type-checked", _0, ERROR_DOC_BASE_URL)]
+    StatementCouldNotBeTypeChecked(String),
 
     #[error("Statement could not be transformed: {0}")]
     StatementCouldNotBeTransformed(String),

--- a/packages/cipherstash-proxy/src/postgresql/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/frontend.rs
@@ -755,7 +755,7 @@ where
                     error = err.to_string(),
                 );
                 counter!(STATEMENTS_UNMAPPABLE_TOTAL).increment(1);
-                Err(MappingError::StatementCouldNotBeMapped(err.to_string()).into())
+                Err(MappingError::StatementCouldNotBeTypeChecked(err.to_string()).into())
             }
         }
     }

--- a/packages/eql-mapper/src/eql_mapper.rs
+++ b/packages/eql-mapper/src/eql_mapper.rs
@@ -127,9 +127,6 @@ pub enum EqlMapperError {
     #[error("Internal error: {}", _0)]
     InternalError(String),
 
-    #[error("Unsupported value variant: {}", _0)]
-    UnsupportedValueVariant(String),
-
     /// A lexical scope error
     #[error(transparent)]
     Scope(#[from] ScopeError),


### PR DESCRIPTION
This updates the `errors.md` and adds details for Statement could not be type checked or StatementCouldNotBeMapped.

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
