### PR TITLE
Warn if result column is of type cs encrypted v1

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -48,7 +48,7 @@ Check the configured username and password are correct and can connect to the da
 
 Check the database is using a supported authentication method.
 
-CipherStash Proxy supportsseveral PostgreSQL password authentication methods:
+CipherStash Proxy supports several PostgreSQL password authentication methods:
 
  - password
  - md5
@@ -178,7 +178,7 @@ An error occurred when attempting to type check the SQL statement.
 ### Error message
 
 ```
-Statement could not be type checked: '{type-check-erro-message}'
+Statement could not be type checked: '{type-check-error-message}'
 ```
 
 ### Notes

--- a/packages/cipherstash-proxy/src/log/mod.rs
+++ b/packages/cipherstash-proxy/src/log/mod.rs
@@ -56,8 +56,8 @@ pub fn set_format(
 mod tests {
     use crate::config::LogLevel;
 
-    use super::*;
     use super::log_test_helper::MockMakeWriter;
+    use super::*;
     use tracing::dispatcher::set_default;
     use tracing::{debug, error, info, trace, warn};
 

--- a/packages/cipherstash-proxy/src/log/mod.rs
+++ b/packages/cipherstash-proxy/src/log/mod.rs
@@ -57,14 +57,9 @@ mod tests {
     use crate::config::LogLevel;
 
     use super::*;
-    use std::sync::{Arc, Mutex};
-    use std::{
-        io,
-        sync::{MutexGuard, TryLockError},
-    };
+    use super::log_test_helper::MockMakeWriter;
     use tracing::dispatcher::set_default;
     use tracing::{debug, error, info, trace, warn};
-    use tracing_subscriber::fmt::MakeWriter;
 
     #[test]
     fn test_simple_log() {
@@ -211,7 +206,17 @@ mod tests {
 
         assert!(log_contents.contains(r#"fields":{"msg":"message","value":42}"#));
     }
+}
 
+#[cfg(test)]
+pub mod log_test_helper {
+    use std::sync::{Arc, Mutex};
+    use std::{
+        io,
+        sync::{MutexGuard, TryLockError},
+    };
+
+    use tracing_subscriber::fmt::MakeWriter;
     // Mock Writer for flexibly testing the logging behaviour, copy-pasted from
     // tracing_subscriber's internal test code (with JSON functionality deleted).
     // https://github.com/tokio-rs/tracing/blob/b02a700ba6850ad813f77e65144114f866074a8f/tracing-subscriber/src/fmt/mod.rs#L1247-L1314

--- a/packages/cipherstash-proxy/src/postgresql/backend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/backend.rs
@@ -8,7 +8,7 @@ use crate::connect::Sender;
 use crate::encrypt::Encrypt;
 use crate::eql::Encrypted;
 use crate::error::Error;
-use crate::log::{DEVELOPMENT, MAPPER, PROTOCOL};
+use crate::log::{CONFIG, DEVELOPMENT, MAPPER, PROTOCOL};
 use crate::postgresql::context::Portal;
 use crate::postgresql::messages::data_row::DataRow;
 use crate::postgresql::messages::param_description::ParamDescription;
@@ -23,7 +23,7 @@ use itertools::Itertools;
 use metrics::{counter, histogram};
 use std::time::Instant;
 use tokio::io::AsyncRead;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 pub struct Backend<R>
 where
@@ -90,6 +90,8 @@ where
 
         let sent: u64 = bytes.len() as u64;
         counter!(SERVER_BYTES_RECEIVED_TOTAL).increment(sent);
+
+        self.warn_if_encrypted_value_with_no_config(&code, &bytes)?;
 
         if self.encrypt.is_passthrough() {
             debug!(target: DEVELOPMENT,
@@ -396,5 +398,168 @@ where
                 Ok(false)
             }
         }
+    }
+
+    // Wrapper method for the struct-level function
+    fn warn_if_encrypted_value_with_no_config(
+        &self,
+        code: &u8,
+        bytes: &BytesMut,
+    ) -> Result<(), Error> {
+        Self::_warn_if_encrypted_value_with_no_config(
+            code,
+            &self.context.client_id,
+            bytes,
+            self.encrypt.encrypt_config.is_empty(),
+            self.encrypt.config.mapping_disabled(),
+        )
+    }
+
+    // Actual logic for warning when a column looks like encrypted with no encrypt config.
+    // This is a struct function so it can be called without setting up a full backend.
+    fn _warn_if_encrypted_value_with_no_config(
+        code: &u8,
+        client_id: &i32,
+        bytes: &BytesMut,
+        config_empty: bool,
+        mapping_disabled: bool,
+    ) -> Result<(), Error> {
+        // if explicitly disabled, no warning
+        // if config is not missing, no warning
+        if mapping_disabled || !config_empty {
+            return Ok(());
+        }
+
+        if let BackendCode::DataRow = (*code).into() {
+            let data_row = DataRow::try_from(bytes)?;
+            let has_encrypted_field = data_row
+                .columns
+                .iter()
+                .any(|c| Option::<crate::eql::Encrypted>::from(c).is_some());
+
+            if has_encrypted_field {
+                warn!(target: CONFIG,
+                    client_id = client_id,
+                    msg = "WARNING: Possible encrypted column with no encrypt config found",
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::BytesMut;
+    use tracing::dispatcher::set_default;
+    use tracing::subscriber::DefaultGuard;
+
+    use crate::config::{LogConfig, LogLevel};
+    use crate::connect::AsyncStream;
+    use crate::log::log_test_helper::MockMakeWriter;
+    use crate::log::set_format;
+    use crate::log::subscriber;
+    use crate::postgresql::backend::Backend;
+    use crate::postgresql::messages::BackendCode;
+    use tracing_subscriber::fmt::writer::BoxMakeWriter;
+
+    fn test_bytes() -> BytesMut {
+        let bytes_source: &[u8] = b"D\0\0\x04V\0\x01\0\0\x04L{\"c\": \"mBbM1A=57k7WyKj<{Oo&6@OyH6Sh<!B`<ojz7ZzjCB?I>rIm=D#2_crSAUhqS4lSrCHR79sChoeo8k6Nu_>VX$0_*@q-U;WZewzJaCBv4Ut(`>Y`_\", \"i\": {\"c\": \"encrypted_bool\", \"t\": \"encrypted\"}, \"k\": \"ct\", \"m\": null, \"o\": [\"ccccccccccccccccd23d6a4c3eee512713175e673c6d995ff5d9b1d3492fe8eb289c3eb95029025f5b71fc6e06632b4a1302980e433361c7999724dbdd052739258d9444b0fbd43cc41f1f3e8ace7a5639afaea11d4dc3e5e4d846418a11c5a7fb7d32dbdbe843787ed8b61267cb3e59b064dc5f935da02b578fcc54c40a053de6c833086a62f23e49e7a041882ceea1a1e65d327911526f0667c1f6f343839f16fd5731089ca29d278398461c8a95fe1158e7b78d64ccd5d181c2b0c65ccbd7b71ca28251a0393a65fb79a90ed19063e2b5e30155c7940c70ac570a17d516fbc19dd2d6a27ab15f5cd6e2bc11c356a83e36f5f19528d192874d6a13e94492d9f4732056057be16ce9d5480073a71eed887195646eb9f76bdf769a3188fdd3528c39738390dd5f02c4476b317be1a55fa77d531e39469ca26e800b0f766d84c2f8a78ca8c3e7afc52e7bfd52d67be2bdc7655f8207af9a2f72141dde6e2148b1eaad7235caee1fd3bb3ac62993a62c411e31c87ae65a00defff305a99223740356d5e596fb01f83fe30ad8e2d8d67aaee128615bf2a9f43b\"], \"u\": \"cceee631ea969008d5ffd4233002dc76da162d99a66107eed2d4fdc9c9dbd2d5\", \"v\": 1}";
+        BytesMut::from(bytes_source)
+    }
+
+    fn set_up_logging(make_writer: &MockMakeWriter) -> DefaultGuard {
+        let config = LogConfig::with_level(LogLevel::Warn);
+        let subscriber =
+            subscriber::builder(&config).with_writer(BoxMakeWriter::new(make_writer.clone()));
+        let subscriber = set_format(&config, subscriber);
+        set_default(&subscriber.into())
+    }
+
+    // warning is emitted if encrypt config is missing (implicitly passthrough) and mapping is not explicitly disabled
+    #[test]
+    fn warn_if_encrypt_config_missing_and_mapping_not_disabled() {
+        let make_writer = MockMakeWriter::default();
+        let _logging = set_up_logging(&make_writer);
+        let bytes = test_bytes();
+
+        let results = Backend::<AsyncStream>::_warn_if_encrypted_value_with_no_config(
+            &BackendCode::DataRow.into(),
+            &123,
+            &bytes,
+            true,
+            false,
+        );
+
+        assert!(results.is_ok());
+
+        let log_contents = make_writer.get_string();
+        assert!(log_contents
+            .contains("WARNING: Possible encrypted column with no encrypt config found"));
+    }
+
+    // warning is not emitted if encryption is explicitly disabled
+    #[test]
+    fn no_warn_if_encryption_is_explicitly_disabled() {
+        let make_writer = MockMakeWriter::default();
+        let _logging = set_up_logging(&make_writer);
+        let bytes = test_bytes();
+
+        let results = Backend::<AsyncStream>::_warn_if_encrypted_value_with_no_config(
+            &BackendCode::DataRow.into(),
+            &123,
+            &bytes,
+            false,
+            true,
+        );
+
+        assert!(results.is_ok());
+
+        let log_contents = make_writer.get_string();
+        assert!(log_contents.is_empty());
+    }
+
+    // warning is not emitted if encrypt config is present and mapping is not disabled
+    #[test]
+    fn no_warn_if_encrypt_config_present_and_mapping_not_disabled() {
+        let make_writer = MockMakeWriter::default();
+        let _logging = set_up_logging(&make_writer);
+        let bytes = test_bytes();
+
+        let results = Backend::<AsyncStream>::_warn_if_encrypted_value_with_no_config(
+            &BackendCode::DataRow.into(),
+            &123,
+            &bytes,
+            false,
+            false,
+        );
+
+        assert!(results.is_ok());
+
+        let log_contents = make_writer.get_string();
+        assert!(log_contents.is_empty());
+    }
+
+    // warning is not emitted if it does not look like an encrypted column (regular JSONB)
+    #[test]
+    fn no_warn_if_value_does_not_look_like_an_encrypted_column() {
+        let make_writer = MockMakeWriter::default();
+        let _logging = set_up_logging(&make_writer);
+        let bytes_source: &[u8] =
+            b"D\0\0\x04V\0\x01\0\0\0\x1E{\"id\": \"123\", \"name\": \"Alice\"}";
+        let bytes = BytesMut::from(bytes_source);
+
+        let results = Backend::<AsyncStream>::_warn_if_encrypted_value_with_no_config(
+            &BackendCode::DataRow.into(),
+            &123,
+            &bytes,
+            true,
+            false,
+        );
+
+        assert!(results.is_ok());
+
+        let log_contents = make_writer.get_string();
+        assert!(log_contents.is_empty());
     }
 }

--- a/packages/cipherstash-proxy/src/postgresql/backend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/backend.rs
@@ -435,13 +435,11 @@ where
             let possible_encrypted_fields: Vec<_> = data_row
                 .columns
                 .iter()
-                .filter_map(|c|
-                    match Option::<crate::eql::Encrypted>::from(c) {
-                        Some(Encrypted::Ciphertext { identifier, .. }) => Some(identifier),
-                        Some(Encrypted::SteVec { identifier, .. }) => Some(identifier),
-                        None => None,
-                    }
-                )
+                .filter_map(|c| match Option::<crate::eql::Encrypted>::from(c) {
+                    Some(Encrypted::Ciphertext { identifier, .. }) => Some(identifier),
+                    Some(Encrypted::SteVec { identifier, .. }) => Some(identifier),
+                    None => None,
+                })
                 .collect();
 
             for identifier in possible_encrypted_fields {


### PR DESCRIPTION
This warns if there is what looks like an encrypted column but no encrypt config for the column.

It differenciates between implicit passthrough (encrypt config missing) and explicitly set passthrough (mapping disabled) and does not warn if explicitly set t passthrough.

Originally the idea was to warn the user when the column type is the domain type `cs_encrypted_v1` but as far as I can tell, in `RowDescription` messages, we see the type oid for JSONB, not the domain.

So instead, we attempt to parse the column value as `cs_encrypted_v1` and warn the user if that is successful but with no encrypt config.

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
