### PR TITLE
docs: explain how to add encrypted columns to schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ This will output the version of EQL installed.
 In your existing PostgreSQL database, you store your data in tables and columns.
 Those columns have types like `integer`, `text`, `timestamp`, and `boolean`.
 When storing encrypted data in PostgreSQL with Proxy, you use a special column type called `cs_encrypted_v1`, which is [provided by EQL](#setting-up-the-database-schema).
-`cs_encrypted_v1` is a container column type that can be used for any type of encrypted data you want to store or search, whether they be numbers (`int`, `small_int`, `big_int`), text (`text`), dates and times (`date`), or booleans (`boolean`).
+`cs_encrypted_v1` is a container column type that can be used for any type of encrypted data you want to store or search, whether they are numbers (`int`, `small_int`, `big_int`), text (`text`), dates and times (`date`), or booleans (`boolean`).
 
 Create a table with an encrypted column for `email`:
 
@@ -391,7 +391,7 @@ This creates a `users` table with two columns:
  - `id`, an autoincrementing integer column that is the primary key for the record
  - `email`, a `cs_encrypted_v1` column
 
-There is one important difference between the plaintext columns you've traditionally used in PostgreSQL and encrypted columns with CipherStash Proxy:
+There are important differences between the plaintext columns you've traditionally used in PostgreSQL and encrypted columns with CipherStash Proxy:
 
 - **Plaintext columns can be searched if they don't have an index**, albeit with the performance cost of a full table scan.
 - **Encrypted columns cannot be searched without an encrypted index**, and the encrypted indexes you define determine what kind of searches you can do on encrypted data.
@@ -448,11 +448,11 @@ You must run the `cs_encrypt_v1()` and `cs_activate_v1()` functions after any mo
 > ![IMPORTANT]
 > Adding, updating, or deleting encrypted indexes on columns that already contain encrypted data will not re-index that data. To use the new indexes, you must `SELECT` the data out of the column, and `UPDATE` it again.
 
-To learn how to use encrypted indexes for other encrypted data types like `text`, `int`, `boolean`, `date`, and `jsonb`, [see the EQL documentation](https://github.com/cipherstash/encrypt-query-language/blob/main/docs/reference/INDEX.md).
+To learn how to use encrypted indexes for other encrypted data types like `text`, `int`, `boolean`, `date`, and `jsonb`, see the [EQL documentation](https://github.com/cipherstash/encrypt-query-language/blob/main/docs/reference/INDEX.md).
 
 When deploying CipherStash Proxy into production environments with real data, we recommend that you apply these database schema changes with the normal tools and process you use for making changes to your database schema.
 
-To see more examples of how to modify your database schema, check out [the example schema](./docs/getting-started/schema-example.sql) from [getting started](#getting-started).
+To see more examples of how to modify your database schema, check out [the example schema](./docs/getting-started/schema-example.sql) from [Getting started](#getting-started).
 
 ## Encrypting data in an existing database
 

--- a/README.md
+++ b/README.md
@@ -484,16 +484,9 @@ The process is idempotent and can be run repeatedly.
 
 ### Configuring the `encrypt` tool
 
-The CipherStash Proxy `encrypt` tool reuses the CipherStash Proxy configuration for the Proxy connection details. See [`encrypt` tool config options](#encrypt-tool-config-options) for the available options.
-
-{% callout title="Connection" %}
-Connection to CipherStash Proxy reuses Proxy configuration:
- - server host
- - server port
- - database username
- - database password
- - database name
-{% /callout %}
+The CipherStash Proxy `encrypt` tool reuses the CipherStash Proxy configuration for the Proxy connection details.
+This configuration includes database server host, port, username, password, and database name.
+See [`encrypt` tool config options](#encrypt-tool-config-options) for the available options.
 
 ### Example `encrypt` tool usage
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,8 @@ services:
 ```
 
 
-For a fully-working example, go to [`docker-compose.yml`](./docker-compose.yml). Follow the steps in [Getting started](#getting-started) to see it in action.
+For a fully-working example, go to [`docker-compose.yml`](./docker-compose.yml).
+Follow the steps in [Getting started](#getting-started) to see it in action.
 
 Once you have set up a `docker-compose.yml`, start the Proxy container:
 


### PR DESCRIPTION
Explain how to set up the database schema to add encrypted columns. 

Also: small fixes to syntax and improve docs maintainability.

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.