### PR TITLE
Chore: add template for docs issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/docs-feedback.yml
@@ -1,0 +1,41 @@
+name: Docs feedback
+description: Feedback to help make our docs more effective.
+title: "[Docs]: "
+labels: ["docs", "triage"]
+assignees:
+  - kateandrews
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to give us feedback!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact details
+      description: How can we get in touch with you if we need more info?
+      placeholder: you@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: what-problem
+    attributes:
+      label: What problem were you trying to solve?
+      placeholder: Tell us what you were looking for in our docs.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Anything else you'd like us to know?
+      placeholder: Let us know if you've got any additional feedback.
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of conduct
+      description: By submitting this issue, you agree to follow our [Code of conduct](https://github.com/cipherstash/proxy/blob/main/CODE_OF_CONDUCT.md). 
+      options:
+        - label: I agree to follow this project's Code of conduct
+          required: true


### PR DESCRIPTION
Added a template to collect feedback on docs.

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
