### PR TITLE
fix(mapper): support named arrays

### DIFF
--- a/packages/eql-mapper/src/inference/infer_type_impls/expr.rs
+++ b/packages/eql-mapper/src/inference/infer_type_impls/expr.rs
@@ -436,17 +436,12 @@ impl<'ast> InferType<'ast, Expr> for TypeInferencer<'ast> {
                 self.unify_node_with_type(this_expr, elem_ty)?;
             }
 
-            Expr::Array(Array { elem, named: false }) => {
+            Expr::Array(Array { elem, named: _ }) => {
                 // Constrain all elements of the array to be the same type.
                 let elem_ty = self.unify_all_with_type(elem, self.fresh_tvar())?;
                 let array_ty = Type::array(elem_ty);
                 self.unify_node_with_type(this_expr, array_ty)?;
             }
-
-            Expr::Array(Array {
-                elem: _,
-                named: true,
-            }) => Err(TypeError::UnsupportedSqlFeature("named arrays".to_string()))?,
 
             // interval is unmapped, value is unmapped
             Expr::Interval(interval) => {

--- a/packages/eql-mapper/src/lib.rs
+++ b/packages/eql-mapper/src/lib.rs
@@ -1351,4 +1351,16 @@ mod test {
             Err(err) => panic!("type check failed: {err}"),
         }
     }
+
+    #[test]
+    fn supports_named_arrays() {
+        let schema = resolver(schema! {
+            tables: {
+            }
+        });
+
+        let statement = parse("SELECT ARRAY[1, 2, 3]");
+
+        type_check(schema, &statement).expect("named arrays should be supported");
+    }
 }


### PR DESCRIPTION
A "named" array (in `sqlparser` parlance) is an array value with syntax like `ARRAY[1, 2, 3]` as opposed to `[1, 2, 3]`.

That's it.

I must have thought it meant something exotic at the time I wrote the original code.

<!-- Please provide a summary of what's being changed -->

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
