### PR TITLE
Eql v2 decryption

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -22,8 +22,10 @@ CS_DATABASE__PORT = "5532"
 # Default configuration for dev cipherstash-proxy run using 'mise run proxy:up'
 CS_PROXY__HOST = "proxy"
 # Misc
-DOCKER_CLI_HINTS = "false"   # Please don't show us What's Next.
-CS_EQL_VERSION = "eql-1.0.1"
+DOCKER_CLI_HINTS = "false" # Please don't show us What's Next.
+
+# CS_EQL_VERSION = "eql-1.0.1"
+CS_EQL_VERSION = "eql-2.0.0-alpha.1"
 
 [tools]
 "cargo:cargo-binstall" = "latest"
@@ -502,6 +504,7 @@ outputs = [
 run = """
 # install script
 if [ -z "$CS_EQL_PATH" ]; then
+  echo "Downloading ${CS_EQL_VERSION} install"
   curl -sLo "{{config_root}}/cipherstash-encrypt.sql" https://github.com/cipherstash/encrypt-query-language/releases/download/${CS_EQL_VERSION}/cipherstash-encrypt.sql
 else
   echo "Using EQL: ${CS_EQL_PATH}/cipherstash-encrypt.sql"
@@ -510,6 +513,7 @@ fi
 
 # uninstall script
 if [ -z "$CS_EQL_PATH" ]; then
+  echo "Downloading ${CS_EQL_VERSION} uninstall"
   curl -sLo   "{{config_root}}/cipherstash-encrypt-uninstall.sql" https://github.com/cipherstash/encrypt-query-language/releases/download/${CS_EQL_VERSION}/cipherstash-encrypt-uninstall.sql
 else
   echo "Using EQL: ${CS_EQL_PATH}/cipherstash-encrypt-uninstall.sql"

--- a/packages/cipherstash-proxy/src/config/log.rs
+++ b/packages/cipherstash-proxy/src/config/log.rs
@@ -36,6 +36,9 @@ pub struct LogConfig {
     pub encrypt_level: LogLevel,
 
     #[serde(default = "LogConfig::default_log_level")]
+    pub decrypt_level: LogLevel,
+
+    #[serde(default = "LogConfig::default_log_level")]
     pub encrypt_config_level: LogLevel,
 
     #[serde(default = "LogConfig::default_log_level")]
@@ -107,24 +110,7 @@ impl Display for LogLevel {
 
 impl Default for LogConfig {
     fn default() -> Self {
-        LogConfig {
-            format: LogConfig::default_log_format(),
-            output: LogConfig::default_log_output(),
-            ansi_enabled: LogConfig::default_ansi_enabled(),
-            level: LogConfig::default_log_level(),
-            development_level: LogConfig::default_log_level(),
-            authentication_level: LogConfig::default_log_level(),
-            context_level: LogConfig::default_log_level(),
-            encrypt_level: LogConfig::default_log_level(),
-            encoding_level: LogConfig::default_log_level(),
-            encrypt_config_level: LogConfig::default_log_level(),
-            keyset_level: LogConfig::default_log_level(),
-            migrate_level: LogConfig::default_log_level(),
-            protocol_level: LogConfig::default_log_level(),
-            mapper_level: LogConfig::default_log_level(),
-            schema_level: LogConfig::default_log_level(),
-            config_level: LogConfig::default_log_level(),
-        }
+        Self::with_level(LogConfig::default_log_level())
     }
 }
 
@@ -141,6 +127,7 @@ impl LogConfig {
             encoding_level: level,
             encrypt_level: level,
             encrypt_config_level: level,
+            decrypt_level: level,
             keyset_level: level,
             migrate_level: level,
             protocol_level: level,

--- a/packages/cipherstash-proxy/src/error.rs
+++ b/packages/cipherstash-proxy/src/error.rs
@@ -202,6 +202,12 @@ pub enum EncryptError {
     #[error(transparent)]
     CiphertextCouldNotBeSerialised(#[from] serde_json::Error),
 
+    #[error("Encrypted column could not be parsed")]
+    ColumnCouldNotBeParsed,
+
+    #[error("Column '{column}' in table '{table}' could not be deserialised. For help visit {}#encrypt-column-could-not-be-deserialised", ERROR_DOC_BASE_URL)]
+    ColumnCouldNotBeDeserialised { table: String, column: String },
+
     #[error("Column '{column}' in table '{table}' could not be encrypted. For help visit {}#encrypt-column-could-not-be-encrypted", ERROR_DOC_BASE_URL)]
     ColumnCouldNotBeEncrypted { table: String, column: String },
 

--- a/packages/cipherstash-proxy/src/log/mod.rs
+++ b/packages/cipherstash-proxy/src/log/mod.rs
@@ -18,6 +18,7 @@ pub const AUTHENTICATION: &str = "authentication";
 pub const CONFIG: &str = "config";
 pub const CONTEXT: &str = "context";
 pub const ENCRYPT: &str = "encrypt";
+pub const DECRYPT: &str = "decrypt";
 pub const ENCODING: &str = "encoding";
 pub const ENCRYPT_CONFIG: &str = "encrypt_config";
 pub const KEYSET: &str = "keyset";
@@ -128,6 +129,7 @@ mod tests {
             encoding_level: LogLevel::Error,
             encrypt_level: LogLevel::Error,
             encrypt_config_level: LogLevel::Error,
+            decrypt_level: LogLevel::Error,
             keyset_level: LogLevel::Trace,
             migrate_level: LogLevel::Trace,
             protocol_level: LogLevel::Info,

--- a/packages/cipherstash-proxy/src/log/subscriber.rs
+++ b/packages/cipherstash-proxy/src/log/subscriber.rs
@@ -6,11 +6,14 @@ use tracing_subscriber::fmt::writer::BoxMakeWriter;
 use tracing_subscriber::fmt::SubscriberBuilder;
 use tracing_subscriber::FmtSubscriber;
 
+use super::DECRYPT;
+
 fn log_targets() -> Vec<&'static str> {
     vec![
         DEVELOPMENT,
         AUTHENTICATION,
         CONTEXT,
+        DECRYPT,
         ENCRYPT,
         KEYSET,
         PROTOCOL,
@@ -24,6 +27,7 @@ fn log_level_for(config: &LogConfig, target: &str) -> LogLevel {
         DEVELOPMENT => config.development_level,
         AUTHENTICATION => config.authentication_level,
         CONTEXT => config.context_level,
+        DECRYPT => config.decrypt_level,
         ENCRYPT => config.encrypt_level,
         KEYSET => config.keyset_level,
         PROTOCOL => config.protocol_level,

--- a/packages/cipherstash-proxy/src/postgresql/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/frontend.rs
@@ -35,6 +35,7 @@ use sqltk::parser::dialect::PostgreSqlDialect;
 use sqltk::parser::parser::Parser;
 use sqltk::NodeKey;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Instant;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tracing::{debug, error, warn};
@@ -311,7 +312,7 @@ where
                     counter!(STATEMENTS_ENCRYPTED_TOTAL).increment(1);
 
                     // Set Encrypted portal
-                    portal = Portal::encrypted_text();
+                    portal = Portal::encrypted(Arc::new(statement));
                 }
                 None => {
                     debug!(target: MAPPER,
@@ -671,7 +672,10 @@ where
                 bind.rewrite(encrypted)?;
             }
             if statement.has_projection() {
-                portal = Portal::encrypted(statement, bind.result_columns_format_codes.to_owned());
+                portal = Portal::encrypted_with_format_codes(
+                    statement,
+                    bind.result_columns_format_codes.to_owned(),
+                );
             }
         };
 

--- a/packages/cipherstash-proxy/src/postgresql/messages/data_row.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/data_row.rs
@@ -1,12 +1,13 @@
-use super::{maybe_json, maybe_jsonb, BackendCode, NULL};
+use super::{BackendCode, NULL};
 use crate::{
     eql,
-    error::{Error, ProtocolError},
-    log::MAPPER,
+    error::{EncryptError, Error, ProtocolError},
+    log::DECRYPT,
+    postgresql::Column,
 };
 use bytes::{Buf, BufMut, BytesMut};
 use std::io::Cursor;
-use tracing::debug;
+use tracing::{debug, error};
 
 #[derive(Debug, Clone)]
 pub struct DataRow {
@@ -19,8 +20,31 @@ pub struct DataColumn {
 }
 
 impl DataRow {
-    pub fn to_ciphertext(&self) -> Result<Vec<Option<eql::EqlEncrypted>>, Error> {
-        Ok(self.columns.iter().map(|col| col.into()).collect())
+    pub fn to_ciphertext(
+        &self,
+        column_configuration: &Vec<Option<Column>>,
+    ) -> Vec<Option<eql::EqlEncrypted>> {
+        let mut result = vec![];
+        for (data_column, column_config) in self.columns.iter().zip(column_configuration) {
+            let encrypted = column_config
+                .as_ref()
+                .filter(|_| data_column.is_not_null())
+                .and_then(|config| {
+                    data_column
+                        .try_into()
+                        .inspect_err(|_| {
+                            let err = EncryptError::ColumnCouldNotBeDeserialised {
+                                table: config.identifier.table.to_owned(),
+                                column: config.identifier.column.to_owned(),
+                            };
+                            error!(target: DECRYPT, msg = err.to_string());
+                        })
+                        .ok()
+                });
+            result.push(encrypted);
+        }
+
+        result
     }
 
     pub fn column_count(&self) -> usize {
@@ -47,14 +71,8 @@ impl DataRow {
 }
 
 impl DataColumn {
-    pub fn get_data(&self) -> Option<Vec<u8>> {
-        self.bytes.as_ref().map(|b| b.to_vec())
-    }
-
-    pub fn maybe_ciphertext(&self) -> bool {
-        self.bytes
-            .as_ref()
-            .is_some_and(|b| maybe_jsonb(b) || maybe_json(b))
+    pub fn is_not_null(&self) -> bool {
+        self.bytes.is_some()
     }
 
     pub fn rewrite(&mut self, b: &[u8]) {
@@ -62,21 +80,6 @@ impl DataColumn {
             bytes.clear();
             bytes.extend_from_slice(b);
         }
-    }
-
-    ///
-    /// If the json format looks binary, returns a reference to the bytes without the jsonb header byte
-    ///
-    pub fn json_bytes(&self) -> Option<&[u8]> {
-        self.bytes.as_ref().and_then(|b| {
-            if maybe_jsonb(b) {
-                Some(&b[1..])
-            } else if maybe_json(b) {
-                Some(&b[0..])
-            } else {
-                None
-            }
-        })
     }
 }
 
@@ -108,9 +111,11 @@ impl TryFrom<&BytesMut> for DataRow {
                 columns.push(DataColumn { bytes: None });
             } else {
                 let len = len as usize;
+
                 let mut bytes = BytesMut::with_capacity(len);
                 bytes.resize(len, 0);
                 cursor.copy_to_slice(&mut bytes);
+
                 columns.push(DataColumn { bytes: Some(bytes) });
             }
         }
@@ -159,108 +164,94 @@ impl TryFrom<DataColumn> for BytesMut {
     }
 }
 
-impl From<&DataColumn> for Option<eql::EqlEncrypted> {
-    fn from(col: &DataColumn) -> Self {
-        debug!(target: MAPPER, data_column = ?col);
-        match col.json_bytes() {
-            Some(bytes) => match serde_json::from_slice(bytes) {
-                Ok(ct) => Some(ct),
+impl TryFrom<&DataColumn> for eql::EqlEncrypted {
+    type Error = Error;
+
+    fn try_from(col: &DataColumn) -> Result<Self, Error> {
+        if let Some(bytes) = &col.bytes {
+            // Encrypted record is in the form ("{}")
+            // json data can be extracted by dropping the first and last two bytes to remove (" and ")
+            let start = 2;
+            let end = bytes.len() - 2;
+            let sliced = &bytes[start..end];
+
+            let input = String::from_utf8_lossy(sliced).to_string();
+            let input = input.replace("\"\"", "\"");
+
+            match serde_json::from_str(&input) {
+                Ok(e) => return Ok(e),
                 Err(err) => {
-                    debug!(target: MAPPER, msg = "Could not convert DataColumn to Ciphertext", error = err.to_string());
-                    None
+                    debug!(target: DECRYPT, error = err.to_string());
+                    return Err(err.into());
                 }
-            },
-            None => None,
+            }
         }
+
+        Err(EncryptError::ColumnCouldNotBeParsed.into())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::DataRow;
-    use crate::{config::LogConfig, log, postgresql::messages::data_row::DataColumn};
-    use bytes::{Buf, BytesMut};
-    use cipherstash_client::zerokms::EncryptedRecord;
-    use recipher::key::Iv;
-    use tracing::info;
-    use uuid::Uuid;
+    use crate::{
+        config::{LogConfig, LogLevel},
+        log,
+        postgresql::messages::data_row::DataColumn,
+    };
+    use crate::{EqlEncrypted, Identifier};
+    use bytes::BytesMut;
 
     fn to_message(s: &[u8]) -> BytesMut {
         BytesMut::from(s)
     }
 
-    fn record() -> EncryptedRecord {
-        EncryptedRecord {
-            iv: Iv::default(),
-            ciphertext: vec![1; 32],
-            tag: vec![1; 16],
-            descriptor: "users/name".to_string(),
-            dataset_id: Some(Uuid::new_v4()),
-        }
-    }
-
     #[test]
-    pub fn data_row_to_ciphertext() {
-        log::init(LogConfig::default());
+    pub fn parse_encrypted_column() {
+        log::init(LogConfig::with_level(LogLevel::Debug));
 
-        let record = record();
+        // SELECT encrypted_jsonb FROM encrypted LIMIT 1
+        let bytes = to_message(b"D\0\0\x03\xba\0\x01\0\0\x03\xb0(\"{\"\"b\"\": null, \"\"c\"\": \"\"mBbLR(BvRN1BF^PAFs!B^`U;mA>uOUiFLgDpZXhU#s#%c4wyi&Z7`(d0IxUty-cI#Yp%o~QFF39^sRf>4*EG{zlk;}ArEQ}NQHa9@;T73aPOSTpuh\"\", \"\"i\"\": {\"\"c\"\": \"\"encrypted_jsonb\"\", \"\"t\"\": \"\"encrypted\"\"}, \"\"m\"\": null, \"\"o\"\": null, \"\"s\"\": null, \"\"u\"\": null, \"\"v\"\": 1, \"\"sv\"\": [{\"\"b\"\": \"\"8067db44a848ab32c3056a3dbe4edf16\"\", \"\"c\"\": \"\"mBbLR(BvRN1BF^PAFs!B^`U;mA>uOUiFLgDpZXhU#s#%c4wyi&Z7`(d0IxUty-cI#Yp%o~QFF39^sRf>4*EG{zlk;}ArEQ}NQHa9@;T73aPOSTpuh\"\", \"\"m\"\": null, \"\"o\"\": null, \"\"s\"\": \"\"9493d6010fe7845d52149b697729c745\"\", \"\"u\"\": null, \"\"sv\"\": null, \"\"ocf\"\": null, \"\"ocv\"\": null}, {\"\"b\"\": null, \"\"c\"\": \"\"mBbLR(BvRN1BF^PAFs!B^`U;m8QkTKr|h>Q`^NbW(CC|>SD}UM=o%mz(Fw#LQFF39^sRf>4*EG{zlk;}ArEQ}NQHa9@;T73aPOSTpuh\"\", \"\"m\"\": null, \"\"o\"\": null, \"\"s\"\": \"\"b1f0e4bb3855bc33936ef1fddf532765\"\", \"\"u\"\": null, \"\"sv\"\": null, \"\"ocf\"\": null, \"\"ocv\"\": \"\"fbc7a11fc81f2a31c904c5b05572b054824e3b5f5ece78f1b711f93175f0a4a9726157cea247e107\"\"}], \"\"ocf\"\": null, \"\"ocv\"\": null}\")");
+        let data_row = DataRow::try_from(&bytes).unwrap();
 
-        let s = record.to_mp_base85().unwrap();
-        info!("{:?}", s);
+        let col = data_row.columns.first().unwrap();
+        let e: EqlEncrypted = col.try_into().unwrap();
 
-        // "{\"c\": \"mBbKx=EbyVyx>mNt9E<k5A&(S8?o+de4F^|i^}7e3l4YE2r(f|W`0Und}s4|#2_A>;-h3xf8wDrq~v|IvQ=jXYG!u4Uu9SI)@Q+xmSd+PWo=<;Y$Ct\",\"k\": \"ct\",\"i\": {\"t\": \"\"users\"\",\"c\": \"\"email\"\"},\"v\": 1}";
+        let expected = Identifier::new("encrypted", "encrypted_jsonb");
 
-        let bytes = to_message(b"D\0\0\0i\0\x01\0\0\0_\x01{\"c\": \"mBbKx=EbyVyx>mNt9E<k5A&(S8?o+de4F^|i^}7e3l4YE2r(f|W`0Und}s4|#2_A>;-h3xf8wDrq~v|IvQ=jXYG!u4Uu9SI)@Q+xmSd+PWo=<;Y$Ct\",\"k\": \"ct\",\"i\": {\"t\": \"\"users\"\",\"c\": \"\"email\"\"},\"v\": 1}");
-        // let expected = bytes.clone();
+        assert_eq!(e.identifier, expected);
 
-        let _data_row = DataRow::try_from(&bytes).unwrap();
+        // SELECT * FROM encrypted WHERE id = $1;
+        // Only encrypted_text is NOT NULL
+        let bytes = to_message(b"D\0\0\n\x91\0\n\0\0\0\n1297231342\xff\xff\xff\xff\0\0\nY(\"{\"\"b\"\": null, \"\"c\"\": \"\"mBbJ;S^xMu<v?;UyTSS~VfK;4C(U~uOiKbWSK*!hB3vi!C$luW$k`K6>@++(U20{lxK;qYYaDYF#30N~x;wyOUMoFOB9K!>A_9g9j@+M6V3wENqu#H8gDb9OZewzJaCBv4Uvy=7bie\"\", \"\"i\"\": {\"\"c\"\": \"\"encrypted_text\"\", \"\"t\"\": \"\"encrypted\"\"}, \"\"m\"\": [369, 381, 1758, 403, 35, 609, 1181, 1098, 1347, 1633, 1150, 815, 1997, 234, 1858, 656, 1335, 936, 1204, 630, 1764, 1328, 1649, 1396, 113, 1149, 1499, 1147, 586, 1942, 901, 1256, 1226, 1045, 637, 279, 1162, 1077, 1340, 1336, 1448, 700, 176, 1849, 1915, 1389, 71, 515, 633, 388, 1877, 1339, 1239, 638, 1365, 1380, 1273, 581, 1792, 1716, 145, 512, 814, 272, 1333, 1775, 1572, 1744, 2018, 433, 1641, 1529, 647, 1317, 652, 1606, 1737, 470, 826, 80, 929, 1700, 1619, 1253, 358, 1589, 1971, 1019, 1533, 1624, 573, 1684, 1287, 575, 1761, 527, 404, 1369, 894, 18, 1101, 986, 1772, 1090, 1506, 2015, 1988, 205, 141, 445, 1982], \"\"o\"\": [\"\"faa1f63cb6d36094d1aa50db6c0217eb447a987071119bb127f677b6a7ee0b4fe40eed7cd84e96e8a11bbe3ea14331f3ec4c8f149ce9d2b0253b4676c86557fcec4a5f8ca4e1ee081c66bf0a3cb594c6b5739f77f62fc5e76991869c23a97f01816cde3dfc24b2ca2fbb12b50fde324f18aa51718d681772bf9caf3c059a6748cbcaf4dd1c4fa02645d74699d7d265faf938c339f6cc8f57db9bd4cff8e03cae9e5d21a651b33525e86e335dff61520e8f23d7002f05fa186075a335fb7b2c740133b5a72760ccd216127d69983aa31a090a3b6ca56a48b6372cab60c979465d84dc94e5452c92517b643882fa82c22a26b4feaaa1b0ae8fcb989b10d0351fb3c9c5e56e719f820442612a67fff334438f3f5d35ff6db1b5f7a50670c7fec014f6fc19c352eb011911faf62a230e10c2d16f6c84b46cf9ee7eb1afb9c61a523891e31da2a18b445769d75c11873566dc8196d77e985423226bd1db10e4ce9eb10c2f69db7ce57d47281401617978d2bcfca23b9015b9e705615b8bf773daa87a18417f86e5338a7929fa4f10c6864af09870bfd9ddfb7848\"\", \"\"b41d89a196a35252a965ce3c330eac369ead56e9f06e2016da4d6971fe0b8d6e677e1018e7a1bd2fa0b2c1faaa12650d678352ecc81f6be879213fe78b8004b87dd7dcadec59df4dcafdb3c9aa55dcb2cc2bcf2193574b201c9a1c14764d69716f63b0c1aa30a2846696f2a1c790ca2cb26370d7e20904a8748ea98a95ee3cbb95c5f342de4e71bbf0262e84d59188ea72fe4449a16e7c73f88ed06b9cb724902a85d063c03e9b1a63dd18b9604625ca3cb8110d9c8f93e1771525c51b6ee092d554e84d61df5b557994f32191bb2b6801d9727fb707d5287e6c83d6b16763a6e66526baf80765a58d36df744be7872d2750eb28a86a519a21ee710f618c09cb2bd45f21e805ae4e11eb2987d7be31c32164d4f828fc35c389d516d0d6a54e25041985cffcb6124b4d3fa5b0ba91e19d60e3102370e9c1c768df1b427c682304a1dfdea2d3e514db22057f43d8121b8daf7c434831e5b618bbca9f4e198741927bdc168e4703fb1f703957f7b70491e06bec4adee19d29ef5e938695e1d49ef50ceef0a9c3e46bd8fe309e013e5ea0d35c5ebf3dddd97573\"\"], \"\"s\"\": null, \"\"u\"\": \"\"962d77dfaf892b596b3255c022359e54f3e8dc8b21c3d1b32ebd05555f433192\"\", \"\"v\"\": 1, \"\"sv\"\": null, \"\"ocf\"\": null, \"\"ocv\"\": null}\")\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff");
+        let data_row = DataRow::try_from(&bytes).unwrap();
 
-        // let ciphertext = data_row.to_ciphertext().expect("ok");
+        // let e = DataColumn::parse(bytes).unwrap();
+        let col = &data_row.columns[2];
+        let e: EqlEncrypted = col.try_into().unwrap();
+        let expected = Identifier::new("encrypted", "encrypted_text");
 
-        // let ct = ciphertext.first();
-        // assert!(ct.is_some());
-
-        // info!("{:?}", ciphertext.first());
-
-        // let column = ciphertext.first().unwrap().as_ref().unwrap();
-
-        // assert_eq!(column.kind, "ct");
+        assert_eq!(e.identifier, expected);
     }
-
-    // #[test]
-    // pub fn data_column_to_json_bytes() {
-    //     log::init(&None);
-    //     let bytes = to_message(b"D\0\0\0i\0\x01\0\0\0_\x01{\"c\": \"51b72947dc25481880175ef53a35af34\", \"i\": {\"c\": \"name\", \"t\": \"users\"}, \"k\": \"ct\", \"v\": 1}");
-    //     // let expected = bytes.clone();
-
-    //     let data_row = DataRow::try_from(&bytes).expect("ok");
-
-    //     let ciphertext = data_row.to_ciphertext().expect("ok");
-
-    //     info!("{:?}", data_row);
-
-    //     // info!("{:?}", ciphertext.first());
-
-    //     // let column = ciphertext.first().unwrap().as_ref().unwrap();
-
-    //     // assert_eq!(column.kind, "ct");
-    // }
 
     #[test]
     pub fn parse_data_row() {
-        let bytes = to_message(b"D\0\0\0\x0e\0\x01\0\0\0\x04\0\0\x1e\xa2");
-        let expected = bytes.clone();
+        log::init(LogConfig::with_level(LogLevel::Debug));
 
-        let data_row = DataRow::try_from(&bytes).unwrap();
+        let messages = vec![
+            to_message(b"D\0\0\0\x0e\0\x01\0\0\0\x04\0\0\x1e\xa2"),
+            // SELECT encrypted_jsonb FROM encrypted LIMIT 1
+            to_message(b"D\0\0\x03\xba\0\x01\0\0\x03\xb0(\"{\"\"b\"\": null, \"\"c\"\": \"\"mBbLR(BvRN1BF^PAFs!B^`U;mA>uOUiFLgDpZXhU#s#%c4wyi&Z7`(d0IxUty-cI#Yp%o~QFF39^sRf>4*EG{zlk;}ArEQ}NQHa9@;T73aPOSTpuh\"\", \"\"i\"\": {\"\"c\"\": \"\"encrypted_jsonb\"\", \"\"t\"\": \"\"encrypted\"\"}, \"\"m\"\": null, \"\"o\"\": null, \"\"s\"\": null, \"\"u\"\": null, \"\"v\"\": 1, \"\"sv\"\": [{\"\"b\"\": \"\"8067db44a848ab32c3056a3dbe4edf16\"\", \"\"c\"\": \"\"mBbLR(BvRN1BF^PAFs!B^`U;mA>uOUiFLgDpZXhU#s#%c4wyi&Z7`(d0IxUty-cI#Yp%o~QFF39^sRf>4*EG{zlk;}ArEQ}NQHa9@;T73aPOSTpuh\"\", \"\"m\"\": null, \"\"o\"\": null, \"\"s\"\": \"\"9493d6010fe7845d52149b697729c745\"\", \"\"u\"\": null, \"\"sv\"\": null, \"\"ocf\"\": null, \"\"ocv\"\": null}, {\"\"b\"\": null, \"\"c\"\": \"\"mBbLR(BvRN1BF^PAFs!B^`U;m8QkTKr|h>Q`^NbW(CC|>SD}UM=o%mz(Fw#LQFF39^sRf>4*EG{zlk;}ArEQ}NQHa9@;T73aPOSTpuh\"\", \"\"m\"\": null, \"\"o\"\": null, \"\"s\"\": \"\"b1f0e4bb3855bc33936ef1fddf532765\"\", \"\"u\"\": null, \"\"sv\"\": null, \"\"ocf\"\": null, \"\"ocv\"\": \"\"fbc7a11fc81f2a31c904c5b05572b054824e3b5f5ece78f1b711f93175f0a4a9726157cea247e107\"\"}], \"\"ocf\"\": null, \"\"ocv\"\": null}\")"),
+        ];
 
-        let data_col = data_row.columns.first().unwrap();
+        for bytes in messages {
+            let expected = bytes.clone();
 
-        let mut buf: &[u8] = data_col.bytes.as_ref().unwrap();
-        let value = buf.get_i32();
-        assert_eq!(value, 7842);
+            let data_row = DataRow::try_from(&bytes).unwrap();
 
-        let bytes = BytesMut::try_from(data_row).unwrap();
-        assert_eq!(bytes, expected);
+            let bytes = BytesMut::try_from(data_row).unwrap();
+            assert_eq!(bytes, expected);
+        }
     }
 
     #[test]


### PR DESCRIPTION
EQL 2.0 changes the internal type representation of encrypted records to use a PostgreSQL composite type.
Returned values are wrapped as a tuple `("{ ... }")`
When decrypting returned records, the json needs to be extracted. 




