### PR TITLE
Cast literals and params to `eql_v1_encrypted`

### DIFF
--- a/packages/cipherstash-proxy-integration/src/map_concat.rs
+++ b/packages/cipherstash-proxy-integration/src/map_concat.rs
@@ -1,10 +1,18 @@
 #[cfg(test)]
 mod tests {
-    use crate::common::{connect_with_tls, PROXY};
+    use crate::common::{clear, connect_with_tls, id, PROXY};
 
     #[tokio::test]
     async fn map_concat_regression() {
         let client = connect_with_tls(PROXY).await;
+
+        clear().await;
+
+        let id = id();
+        let encrypted_text = "hello@cipherstash.com";
+
+        let sql = "INSERT INTO encrypted (id, encrypted_text) VALUES ($1, $2)";
+        client.query(sql, &[&id, &encrypted_text]).await.unwrap();
 
         let sql = "UPDATE encrypted SET encrypted_text = encrypted_text || 'suffix';";
 

--- a/packages/cipherstash-proxy/src/encrypt/mod.rs
+++ b/packages/cipherstash-proxy/src/encrypt/mod.rs
@@ -60,7 +60,6 @@ impl Encrypt {
             let rows = client
                 .query("SELECT eql_v1.version() AS version;", &[])
                 .await;
-            // let rows = client.query("SELECT 'WAT' AS version;", &[]).await;
 
             match rows {
                 Ok(rows) => rows.first().map(|row| row.get("version")),

--- a/packages/cipherstash-proxy/src/eql/mod.rs
+++ b/packages/cipherstash-proxy/src/eql/mod.rs
@@ -84,25 +84,25 @@ pub struct EqlEncryptedBody {
 
 #[derive(Debug, Deserialize, Serialize, Default)]
 pub struct EqlEncryptedIndexes {
-    #[serde(rename = "o")]
+    #[serde(rename = "o", skip_serializing_if = "Option::is_none")]
     pub(crate) ore_index: Option<Vec<String>>,
-    #[serde(rename = "m")]
+    #[serde(rename = "m", skip_serializing_if = "Option::is_none")]
     pub(crate) match_index: Option<Vec<u16>>,
-    #[serde(rename = "u")]
+    #[serde(rename = "u", skip_serializing_if = "Option::is_none")]
     pub(crate) unique_index: Option<String>,
 
-    #[serde(rename = "s")]
+    #[serde(rename = "s", skip_serializing_if = "Option::is_none")]
     pub(crate) selector: Option<String>,
 
-    #[serde(rename = "b")]
+    #[serde(rename = "b", skip_serializing_if = "Option::is_none")]
     pub(crate) blake3_index: Option<String>,
 
-    #[serde(rename = "ocf")]
+    #[serde(rename = "ocf", skip_serializing_if = "Option::is_none")]
     pub(crate) ore_cclw_fixed_index: Option<String>,
-    #[serde(rename = "ocv")]
+    #[serde(rename = "ocv", skip_serializing_if = "Option::is_none")]
     pub(crate) ore_cclw_var_index: Option<String>,
 
-    #[serde(rename = "sv")]
+    #[serde(rename = "sv", skip_serializing_if = "Option::is_none")]
     pub(crate) ste_vec_index: Option<Vec<EqlEncryptedBody>>,
 }
 

--- a/packages/cipherstash-proxy/src/postgresql/backend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/backend.rs
@@ -265,7 +265,7 @@ where
         // Each row is converted into Vec<Option<CipherText>>
         let ciphertexts: Vec<Option<EqlEncrypted>> = rows
             .iter_mut()
-            .flat_map(|row| row.to_ciphertext(projection_columns))
+            .flat_map(|row| row.as_ciphertext(projection_columns))
             .collect::<Vec<_>>();
 
         let start = Instant::now();

--- a/packages/cipherstash-proxy/src/postgresql/messages/data_row.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/data_row.rs
@@ -20,7 +20,7 @@ pub struct DataColumn {
 }
 
 impl DataRow {
-    pub fn to_ciphertext(
+    pub fn as_ciphertext(
         &mut self,
         column_configuration: &Vec<Option<Column>>,
     ) -> Vec<Option<eql::EqlEncrypted>> {
@@ -240,7 +240,7 @@ mod tests {
     use crate::{
         config::{LogConfig, LogLevel},
         log,
-        postgresql::{data, messages::data_row::DataColumn, Column},
+        postgresql::{messages::data_row::DataColumn, Column},
     };
     use bytes::BytesMut;
     use cipherstash_client::schema::{ColumnConfig, ColumnType};
@@ -270,7 +270,7 @@ mod tests {
         let mut data_row = DataRow::try_from(&bytes).unwrap();
 
         let column_config = column_config_with_id("encrypted_text");
-        let encrypted = data_row.to_ciphertext(&column_config);
+        let encrypted = data_row.as_ciphertext(&column_config);
 
         assert_eq!(encrypted.len(), 2);
 
@@ -299,7 +299,7 @@ mod tests {
         assert!(data_row.columns[1].bytes.is_some());
 
         let column_config = column_config_with_id("encrypted_text");
-        let encrypted = data_row.to_ciphertext(&column_config);
+        let encrypted = data_row.as_ciphertext(&column_config);
 
         assert_eq!(encrypted.len(), 2);
 
@@ -322,7 +322,7 @@ mod tests {
         assert!(data_row.columns[0].bytes.is_some());
 
         let column_config = vec![column_config("encrypted_jsonb")];
-        let encrypted = data_row.to_ciphertext(&column_config);
+        let encrypted = data_row.as_ciphertext(&column_config);
 
         assert_eq!(encrypted.len(), 1);
         assert!(encrypted[0].is_some());
@@ -358,7 +358,7 @@ mod tests {
             column_config("encrypted_jsonb"),
         ];
 
-        let encrypted = data_row.to_ciphertext(&column_config);
+        let encrypted = data_row.as_ciphertext(&column_config);
 
         assert_eq!(encrypted.len(), 10);
 

--- a/packages/eql-mapper/src/transformation_rules/cast_params_as_encrypted.rs
+++ b/packages/eql-mapper/src/transformation_rules/cast_params_as_encrypted.rs
@@ -1,26 +1,23 @@
+use super::helpers::cast_as_encrypted;
+use super::TransformationRule;
+use crate::{EqlMapperError, Type};
+use sqltk::parser::ast::{Expr, Value};
+use sqltk::{NodeKey, NodePath, Visitable};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use sqltk::parser::ast::{Expr, Value};
-use sqltk::{NodeKey, NodePath, Visitable};
-
-use crate::{EqlMapperError, Type};
-
-use super::helpers::make_row_expression;
-use super::TransformationRule;
-
 #[derive(Debug)]
-pub struct WrapEqlParamsInRow<'ast> {
+pub struct CastParamsAsEncrypted<'ast> {
     node_types: Arc<HashMap<NodeKey<'ast>, Type>>,
 }
 
-impl<'ast> WrapEqlParamsInRow<'ast> {
+impl<'ast> CastParamsAsEncrypted<'ast> {
     pub fn new(node_types: Arc<HashMap<NodeKey<'ast>, Type>>) -> Self {
         Self { node_types }
     }
 }
 
-impl<'ast> TransformationRule<'ast> for WrapEqlParamsInRow<'ast> {
+impl<'ast> TransformationRule<'ast> for CastParamsAsEncrypted<'ast> {
     fn apply<N: Visitable>(
         &mut self,
         node_path: &NodePath<'ast>,
@@ -33,7 +30,7 @@ impl<'ast> TransformationRule<'ast> for WrapEqlParamsInRow<'ast> {
                     unreachable!("the Expr is known to be Expr::Value(Value::Placeholder(_))")
                 };
 
-                *expr = make_row_expression(value);
+                *expr = cast_as_encrypted(value);
                 return Ok(true);
             }
         }

--- a/packages/eql-mapper/src/transformation_rules/helpers.rs
+++ b/packages/eql-mapper/src/transformation_rules/helpers.rs
@@ -48,26 +48,22 @@ pub(crate) fn wrap_in_1_arg_function(expr: Expr, name: ObjectName) -> Expr {
     })
 }
 
-pub(crate) fn make_row_expression(wrapped: sqltk::parser::ast::Value) -> Expr {
-    Expr::Function(Function {
-        name: ObjectName(vec![Ident::new("ROW")]),
-        uses_odbc_syntax: false,
-        parameters: FunctionArguments::None,
-        args: FunctionArguments::List(FunctionArgumentList {
-            duplicate_treatment: None,
-            clauses: vec![],
-            args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Cast {
-                kind: CastKind::DoubleColon,
-                expr: Box::new(Expr::Value(wrapped)),
-                data_type: DataType::JSONB,
-                format: None,
-            }))],
-        }),
-        filter: None,
-        null_treatment: None,
-        over: None,
-        within_group: vec![],
-    })
+pub(crate) fn cast_as_encrypted(wrapped: sqltk::parser::ast::Value) -> Expr {
+    let cast_jsonb = Expr::Cast {
+        kind: CastKind::DoubleColon,
+        expr: Box::new(Expr::Value(wrapped)),
+        data_type: DataType::JSONB,
+        format: None,
+    };
+
+    let encrypted_type = ObjectName(vec![Ident::new("eql_v1_encrypted")]);
+
+    Expr::Cast {
+        kind: CastKind::DoubleColon,
+        expr: Box::new(cast_jsonb),
+        data_type: DataType::Custom(encrypted_type, vec![]),
+        format: None,
+    }
 }
 
 struct ContainsExprWithType<'ast, 't> {

--- a/packages/eql-mapper/src/transformation_rules/mod.rs
+++ b/packages/eql-mapper/src/transformation_rules/mod.rs
@@ -11,24 +11,24 @@
 
 mod helpers;
 
+mod cast_literals_as_encrypted;
+mod cast_params_as_encrypted;
 mod fail_on_placeholder_change;
 mod group_by_eql_col;
 mod preserve_effective_aliases;
-mod replace_plaintext_eql_literals;
 mod rewrite_standard_sql_fns_on_eql_types;
 mod wrap_eql_cols_in_order_by_with_ore_fn;
-mod wrap_eql_params_in_row;
 mod wrap_grouped_eql_col_in_aggregate_fn;
 
 use std::marker::PhantomData;
 
+pub(crate) use cast_literals_as_encrypted::*;
+pub(crate) use cast_params_as_encrypted::*;
 pub(crate) use fail_on_placeholder_change::*;
 pub(crate) use group_by_eql_col::*;
 pub(crate) use preserve_effective_aliases::*;
-pub(crate) use replace_plaintext_eql_literals::*;
 pub(crate) use rewrite_standard_sql_fns_on_eql_types::*;
 pub(crate) use wrap_eql_cols_in_order_by_with_ore_fn::*;
-pub(crate) use wrap_eql_params_in_row::*;
 pub(crate) use wrap_grouped_eql_col_in_aggregate_fn::*;
 
 use crate::EqlMapperError;

--- a/packages/eql-mapper/src/type_checked_statement.rs
+++ b/packages/eql-mapper/src/type_checked_statement.rs
@@ -4,10 +4,10 @@ use sqltk::parser::ast::{self, Statement};
 use sqltk::{AsNodeKey, NodeKey, Transformable};
 
 use crate::{
-    DryRunnable, EqlMapperError, EqlValue, FailOnPlaceholderChange, GroupByEqlCol, Param,
-    PreserveEffectiveAliases, Projection, ReplacePlaintextEqlLiterals,
+    CastLiteralsAsEncrypted, CastParamsAsEncrypted, DryRunnable, EqlMapperError, EqlValue,
+    FailOnPlaceholderChange, GroupByEqlCol, Param, PreserveEffectiveAliases, Projection,
     RewriteStandardSqlFnsOnEqlTypes, TransformationRule, Type, Value,
-    WrapEqlColsInOrderByWithOreFn, WrapEqlParamsInRow, WrapGroupedEqlColInAggregateFn,
+    WrapEqlColsInOrderByWithOreFn, WrapGroupedEqlColInAggregateFn,
 };
 
 /// A `TypeCheckedStatement` is returned from a successful call to [`crate::type_check`].
@@ -145,9 +145,9 @@ impl<'ast> TypeCheckedStatement<'ast> {
             GroupByEqlCol::new(Arc::clone(&self.node_types)),
             WrapEqlColsInOrderByWithOreFn::new(Arc::clone(&self.node_types)),
             PreserveEffectiveAliases,
-            ReplacePlaintextEqlLiterals::new(encrypted_literals),
+            CastLiteralsAsEncrypted::new(encrypted_literals),
             FailOnPlaceholderChange::new(),
-            WrapEqlParamsInRow::new(Arc::clone(&self.node_types)),
+            CastParamsAsEncrypted::new(Arc::clone(&self.node_types)),
         ))
     }
 }


### PR DESCRIPTION
Fix for SQL error when using `ore` or `unique` index terms:
```
  operator is not unique: eql_v1_encrypted > record
```

Encrypted parameters and literals are currently being wrapped into a `ROW` which create a value of type `record`.

This explicitly casts literals and params as `::jsonb::eql_v1_encrypted`