### PR TITLE
feat: check column configuration against encrypted column before decrypt

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -21,6 +21,7 @@
   - [Unknown column](#encrypt-unknown-column)
   - [Unknown table](#encrypt-unknown-table)
   - [Unknown index term](#encrypt-unknown-index-term)
+  - [Column configuration mismatch](#encrypt-column-config-mismatch)
 
 - Decrypt errors:
    - [Column could not be deserialised](#encrypt-column-could-not-be-deserialised)
@@ -390,6 +391,34 @@ Unknown Index Term for column '{column_name}' in table '{table_name}'.
 1. Check the Encrypt configuration for the column.
 2. Define the encrypted configuration using [EQL](https://github.com/cipherstash/encrypt-query-language).
 
+
+<!-- ---------------------------------------------------------------------------------------------------- -->
+<!-- ---------------------------------------------------------------------------------------------------- -->
+
+
+## Column configuration mismatch <a id='encrypt-column-config-mismatch'></a>
+
+A returned encrypted column does not match the column configuration.
+
+### Error message
+
+```
+Column configuration for column '{column_name}' in table '{table_name}' does not match the encrypted column.
+```
+
+### Notes
+
+CipherStash Proxy validates that encrypted columns match the configuration before decrypting any data.
+If the table and column are not the same, this error is returned.
+The check is there to help prevent "confused deputy" issues and the error should *never* appear during normal operation.
+
+If the error persists, please contact CipherStash [support](https://cipherstash.com/support).
+
+
+### Further reading
+
+[AWS: The confused deputy problem](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html)
+[Wikipedia: Confused deputy problem](https://en.wikipedia.org/wiki/Confused_deputy_problem)
 
 <!-- ---------------------------------------------------------------------------------------------------- -->
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -163,7 +163,7 @@ This will output the version of EQL installed.
 In your existing PostgreSQL database, you store your data in tables and columns.
 Those columns have types like `integer`, `text`, `timestamp`, and `boolean`.
 When storing encrypted data in PostgreSQL with Proxy, you use a special column type called `eql_v1_encrypted`, which is [provided by EQL](#setting-up-the-database-schema).
-`eql_v1_encrypted` is a container column type that can be used for any type of encrypted data you want to store or search, whether they are numbers (`int`, `small_int`, `big_int`), text (`text`), dates and times (`date`), or booleans (`boolean`).
+`eql_v1_encrypted` is a container column type that can be used for any type of encrypted data you want to store or search, whether they are numbers (`int`, `small_int`, `big_int`), text (`text`), dates and times (`date`. `timestamp`), or booleans (`boolean`).
 
 Create a table with an encrypted column for `email`:
 

--- a/packages/cipherstash-proxy/src/error.rs
+++ b/packages/cipherstash-proxy/src/error.rs
@@ -214,6 +214,9 @@ pub enum EncryptError {
     #[error("Column '{column}' in table '{table}' could not be encrypted. For help visit {}#encrypt-column-could-not-be-encrypted", ERROR_DOC_BASE_URL)]
     ColumnCouldNotBeEncrypted { table: String, column: String },
 
+    #[error("Column configuration for column '{column}' in table '{table}' does not match the encrypted column. For help visit {}#encrypt-column-config-mismatch", ERROR_DOC_BASE_URL)]
+    ColumnConfigurationMismatch { table: String, column: String },
+
     /// This should in practice be unreachable
     #[error("Missing encrypt configuration for column type `{plaintext_type}`. For help visit {}#encrypt-missing-encrypt-configuration", ERROR_DOC_BASE_URL)]
     MissingEncryptConfiguration { plaintext_type: String },


### PR DESCRIPTION
Check the identifier in the returned ciphertext matches the identifier in the column configuration before decryption. 
Returns an error if a mismatch is detected. 
Helps protect against confused deputy attacks.