### PR TITLE
Fix for "Error: insufficient data left in message" with null values

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -96,9 +96,18 @@ echo docker compose up {{arg(name="service",default="proxy")}} {{option(name="ex
 
 [tasks."proxy:psql"]
 description = "Run psql (interactively) against the proxy; assumes the proxy is already up"
+alias = "psql"
 run = """
 set -eu
 docker exec -it postgres${CONTAINER_SUFFIX:-} psql "postgresql://${CS_DATABASE__USERNAME}:${CS_DATABASE__PASSWORD_ESCAPED_FOR_TESTS}@${CS_PROXY__HOST}:6432/${CS_DATABASE__NAME}"
+"""
+
+[tasks."proxy:local:psql"]
+description = "Run psql (interactively) against a local (non docker) proxy; assumes the proxy is already up"
+alias = "lpsql"
+run = """
+set -eu
+psql "postgresql://${CS_DATABASE__USERNAME}:${CS_DATABASE__PASSWORD_ESCAPED_FOR_TESTS}@localhost:6432/${CS_DATABASE__NAME}"
 """
 
 [tasks."proxy:down"]

--- a/packages/cipherstash-proxy-integration/src/decrypt/insert_returning.rs
+++ b/packages/cipherstash-proxy-integration/src/decrypt/insert_returning.rs
@@ -1,0 +1,126 @@
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDate;
+
+    use crate::common::{clear, connect_with_tls, id, trace, PROXY};
+
+    #[tokio::test]
+    async fn decrypt_insert_returning_with_different_column_order() {
+        trace();
+
+        clear().await;
+
+        let client = connect_with_tls(PROXY).await;
+
+        let id = id();
+        let plaintext = "plaintext";
+        let plaintext_date: Option<NaiveDate> = None;
+        let encrypted_text = "hello@cipherstash.com";
+
+        let sql =
+            "INSERT INTO encrypted (id, plaintext, plaintext_date, encrypted_text) VALUES ($1, $2, $3, $4) RETURNING plaintext_date, id, plaintext, encrypted_text";
+        let rows = client
+            .query(sql, &[&id, &plaintext, &plaintext_date, &encrypted_text])
+            .await
+            .unwrap();
+
+        assert_eq!(rows.len(), 1);
+
+        for row in rows {
+            let id_result: i64 = row.get("id");
+            assert_eq!(id, id_result);
+
+            let id_result: i64 = row.get(1);
+            assert_eq!(id, id_result);
+
+            let plaintext_result: String = row.get("plaintext");
+            assert_eq!(plaintext, plaintext_result);
+
+            let plaintext_result: String = row.get(2);
+            assert_eq!(plaintext, plaintext_result);
+
+            let plaintext_date_result: Option<NaiveDate> = row.get("plaintext_date");
+            assert_eq!(None, plaintext_date_result);
+
+            let plaintext_date_result: Option<NaiveDate> = row.get(0);
+            assert_eq!(None, plaintext_date_result);
+
+            let encrypted_text_result: String = row.get("encrypted_text");
+            assert_eq!(encrypted_text, encrypted_text_result);
+
+            let encrypted_text_result: String = row.get(3);
+            assert_eq!(encrypted_text, encrypted_text_result);
+        }
+    }
+
+    #[tokio::test]
+    async fn decrypt_insert_returning_wildcard() {
+        trace();
+
+        clear().await;
+
+        let client = connect_with_tls(PROXY).await;
+
+        let id = id();
+        let plaintext = "plaintext";
+        let encrypted_text = "hello@cipherstash.com";
+
+        let sql =
+            "INSERT INTO encrypted (id, plaintext, encrypted_text) VALUES ($1, $2, $3) RETURNING *";
+        let rows = client
+            .query(sql, &[&id, &plaintext, &encrypted_text])
+            .await
+            .unwrap();
+
+        assert_eq!(rows.len(), 1);
+
+        for row in rows {
+            let id_result: i64 = row.get("id");
+            assert_eq!(id, id_result);
+
+            let id_result: i64 = row.get(0);
+            assert_eq!(id, id_result);
+
+            let plaintext_result: String = row.get("plaintext");
+            assert_eq!(plaintext, plaintext_result);
+
+            let plaintext_result: String = row.get(1);
+            assert_eq!(plaintext, plaintext_result);
+
+            let encrypted_text_result: String = row.get("encrypted_text");
+            assert_eq!(encrypted_text, encrypted_text_result);
+
+            let encrypted_text_result: String = row.get(3);
+            assert_eq!(encrypted_text, encrypted_text_result);
+        }
+    }
+
+    #[tokio::test]
+    async fn decrypt_insert_returning() {
+        trace();
+
+        clear().await;
+
+        let client = connect_with_tls(PROXY).await;
+
+        let id = id();
+        let plaintext = "plaintext";
+        let encrypted_text = "hello@cipherstash.com";
+
+        let sql = "INSERT INTO encrypted (id, plaintext, encrypted_text) VALUES ($1, $2, $3) RETURNING encrypted_text";
+        let rows = client
+            .query(sql, &[&id, &plaintext, &encrypted_text])
+            .await
+            .unwrap();
+
+        assert_eq!(rows.len(), 1);
+
+        for row in rows {
+            let encrypted_text_result: String = row.get("encrypted_text");
+            assert_eq!(encrypted_text, encrypted_text_result);
+
+            let encrypted_text_result: String = row.get(0);
+            assert_eq!(encrypted_text, encrypted_text_result);
+        }
+    }
+}

--- a/packages/cipherstash-proxy-integration/src/decrypt/mod.rs
+++ b/packages/cipherstash-proxy-integration/src/decrypt/mod.rs
@@ -1,0 +1,1 @@
+mod insert_returning;

--- a/packages/cipherstash-proxy-integration/src/lib.rs
+++ b/packages/cipherstash-proxy-integration/src/lib.rs
@@ -1,4 +1,5 @@
 mod common;
+mod decrypt;
 mod empty_result;
 mod extended_protocol_error_messages;
 mod map_concat;

--- a/packages/cipherstash-proxy-integration/src/map_nulls.rs
+++ b/packages/cipherstash-proxy-integration/src/map_nulls.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod tests {
-    use crate::common::{connect_with_tls, id, trace, PROXY};
+    use chrono::NaiveDate;
+
+    use crate::common::{clear, connect_with_tls, id, trace, PROXY};
 
     #[tokio::test]
     async fn map_insert_null_param() {
@@ -64,7 +66,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn map_insert_null_literal() {
+    async fn map_insert_encrypted_null_literal() {
         trace();
 
         let client = connect_with_tls(PROXY).await;
@@ -112,6 +114,58 @@ mod tests {
 
             let result_int: i16 = row.get("encrypted_int2");
             assert_eq!(encrypted_int2, result_int);
+
+            let result: Option<String> = row.get("encrypted_text");
+            assert!(result.is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn map_insert_with_multiple_null_params() {
+        trace();
+
+        clear().await;
+
+        let client = connect_with_tls(PROXY).await;
+
+        let id = id();
+        let plaintext: Option<String> = None;
+        let plaintext_date: Option<NaiveDate> = None;
+        let encrypted_text: Option<String> = None;
+
+        let sql =
+            "INSERT INTO encrypted (id, plaintext, plaintext_date, encrypted_text) VALUES ($1, $2, $3, $4) RETURNING plaintext, encrypted_text";
+        let rows = client
+            .query(sql, &[&id, &plaintext, &plaintext_date, &encrypted_text])
+            .await
+            .unwrap();
+
+        assert_eq!(rows.len(), 1);
+
+        // Rows from RETURNING clause
+        for row in rows {
+            let result: Option<String> = row.get("plaintext");
+            assert_eq!(None, result);
+
+            let result: Option<String> = row.get(0);
+            assert_eq!(None, result);
+
+            let result: Option<String> = row.get("encrypted_text");
+            assert_eq!(None, result);
+
+            let result: Option<String> = row.get(1);
+            assert_eq!(None, result);
+        }
+
+        // SELECT the NULL encrypted_text record
+        let sql = "SELECT id, encrypted_text FROM encrypted WHERE id = $1";
+        let rows = client.query(sql, &[&id]).await.unwrap();
+
+        assert_eq!(rows.len(), 1);
+
+        for row in rows {
+            let result_id: i64 = row.get("id");
+            assert_eq!(id, result_id);
 
             let result: Option<String> = row.get("encrypted_text");
             assert!(result.is_none());

--- a/packages/cipherstash-proxy/src/postgresql/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/frontend.rs
@@ -667,6 +667,8 @@ where
         let mut portal = Portal::passthrough();
 
         if let Some(statement) = self.context.get_statement(&bind.prepared_statement) {
+            debug!(target:MAPPER, client_id = self.context.client_id, ?statement);
+
             if statement.has_params() {
                 let encrypted = self.encrypt_params(&bind, &statement).await?;
                 bind.rewrite(encrypted)?;

--- a/tests/sql/schema.sql
+++ b/tests/sql/schema.sql
@@ -13,6 +13,7 @@ DROP TABLE IF EXISTS encrypted;
 CREATE TABLE encrypted (
     id bigint,
     plaintext text,
+    plaintext_date date,
     encrypted_text eql_v2_encrypted,
     encrypted_bool eql_v2_encrypted,
     encrypted_int2 eql_v2_encrypted,


### PR DESCRIPTION
Fixes issue with encoding `NULL` parameter values in Bind messages.

`NULL` params are of length 0, but the length is encoded in a Bind message as `-1`.
