### PR TITLE
fix: don't use caches when building release artifacts

### DIFF
--- a/.github/workflows/release-aws-marketplace.yml
+++ b/.github/workflows/release-aws-marketplace.yml
@@ -67,7 +67,7 @@ jobs:
             version: 2                         # default
             verbose: false                     # default
             arch: arm64                        # allowed values: amd64, arm64
-  
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -82,17 +82,11 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-provider: ${{matrix.build.cache-provider}}
-          cache-all-crates: true
-
       - uses: jdx/mise-action@v2
         with:
           version: 2025.1.6 # [default: latest] mise version to install
           install: true # [default: true] run `mise install`
-          cache: true # [default: true] cache mise using GitHub's cache
+          cache: false # do not cache release builds
 
       - run: |
           mise run build --platform ${{matrix.build.arch}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
+        if: github.event_name == 'pull_request' # only cache in pull requests
         with:
           cache-provider: ${{matrix.build.cache-provider}}
           cache-all-crates: true
@@ -32,7 +33,7 @@ jobs:
         with:
           version: 2025.1.6 # [default: latest] mise version to install
           install: true # [default: true] run `mise install`
-          cache: true # [default: true] cache mise using GitHub's cache
+          cache: ${{ github.event_name != 'pull_request' }} # cache mise using GitHub's cache if running in a PR
       - run: |
           mise run build --platform ${{matrix.build.docker_platform}} --target ${{matrix.build.rust_target}}
 


### PR DESCRIPTION
Disable build caching when building release artifacts, specifically in these workflows:

- [`release.yml`](https://github.com/cipherstash/proxy/blob/8fef39821dd3ff0dcca162bc8ee72f06bdc567f2/.github/workflows/release.yml)
- [`release-aws-marketplace.yml`](https://github.com/cipherstash/proxy/blob/8fef39821dd3ff0dcca162bc8ee72f06bdc567f2/.github/workflows/release-aws-marketplace.yml)

### Background

Per [The Monsters in Your Build Cache - GitHub Actions Cache Poisoning](https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/):

> In order for a build to be considered SLSA L3 compliant, it must be within an [isolated](https://slsa.dev/spec/v1.0/requirements#isolated) build environment. On the topic of caching, SLSA requirements state the following:
>
> > It MUST NOT be possible for one build to inject false entries into a build cache used by another build, also known as “cache poisoning”. In other words, the output of the build MUST be identical whether or not the cache is used.
>
>Under these requirements, GitHub Actions release builds that use caching cannot be considered SLSA L3 compliant. Full stop.

When I [added the release workflow](https://github.com/cipherstash/proxy/commit/a62e66d31019757168c52153d4ab3c874d3118d2) in March, I copy-pasted the existing [test workflow](https://github.com/cipherstash/proxy/blob/8fef39821dd3ff0dcca162bc8ee72f06bdc567f2/.github/workflows/test.yml), which used build caching.

This change disables build caching when building release artifacts, but retains build caching in PRs. 

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
