### PR TITLE
build: use faster x86_64 runners from BuildJet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - { os: ubuntu-latest-m,    docker_platform: linux/amd64, rust_target: "x86_64-unknown-linux-gnu",  cache-provider: github }
-          - { os: linux-arm64-public, docker_platform: linux/arm64, rust_target: "aarch64-unknown-linux-gnu", cache-provider: github }
+          - { os: buildjet-16vcpu-ubuntu-2204, docker_platform: linux/amd64, rust_target: "x86_64-unknown-linux-gnu",  cache-provider: buildjet }
+          - { os: linux-arm64-public,          docker_platform: linux/arm64, rust_target: "aarch64-unknown-linux-gnu", cache-provider: github }
     runs-on: ${{matrix.build.os}}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The release workflow running on the beefier GitHub Actions runners are taking [a really long time](https://github.com/cipherstash/proxy/actions/runs/15381882760/job/43273890921) (cancelled at 33 minutes). 

Switch to the BuildJet runners, which we know run much faster for x86_64 builds. 

<!-- Please provide a summary of what's being changed -->

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
