### PR TITLE
Add source schema to table resolution

### DIFF
--- a/packages/cipherstash-proxy/src/encrypt/schema/manager.rs
+++ b/packages/cipherstash-proxy/src/encrypt/schema/manager.rs
@@ -129,12 +129,13 @@ pub async fn load_schema(config: &DatabaseConfig) -> Result<Schema, Error> {
     };
 
     for table in tables {
+        let table_schema: String = table.get("table_schema");
         let table_name: String = table.get("table_name");
         let primary_keys: Vec<Option<String>> = table.get("primary_keys");
         let columns: Vec<String> = table.get("columns");
         let column_type_names: Vec<Option<String>> = table.get("column_type_names");
 
-        let mut table = Table::new(Ident::new(&table_name));
+        let mut table = Table::new(Ident::new(&table_name), Ident::new(&table_schema));
 
         columns.iter().zip(column_type_names).for_each(|(col, column_type_name)| {
             let is_primary_key = primary_keys.contains(&Some(col.to_string()));

--- a/packages/eql-mapper/src/model/table_resolver.rs
+++ b/packages/eql-mapper/src/model/table_resolver.rs
@@ -35,41 +35,50 @@ impl TableResolver {
         }
     }
 
-    pub fn resolve_table(&self, name: &Ident) -> Result<Arc<Table>, SchemaError> {
+    pub fn resolve_table(
+        &self,
+        table_name: &Ident,
+        source_schema: &Ident,
+    ) -> Result<Arc<Table>, SchemaError> {
         match self {
-            TableResolver::ViaSchema(schema) => schema.resolve_table(name),
-            TableResolver::ViaSchemaWithEdits(schema_with_edits) => {
-                schema_with_edits.read().unwrap().resolve_table(name)
-            }
+            TableResolver::ViaSchema(schema) => schema.resolve_table(table_name, source_schema),
+            TableResolver::ViaSchemaWithEdits(schema_with_edits) => schema_with_edits
+                .read()
+                .unwrap()
+                .resolve_table(table_name, source_schema),
         }
     }
 
     pub fn resolve_table_columns(
         &self,
         table_name: &Ident,
+        source_schema: &Ident,
     ) -> Result<Vec<SchemaTableColumn>, SchemaError> {
         match self {
-            TableResolver::ViaSchema(schema) => schema.resolve_table_columns(table_name),
+            TableResolver::ViaSchema(schema) => {
+                schema.resolve_table_columns(table_name, source_schema)
+            }
             TableResolver::ViaSchemaWithEdits(schema_with_edits) => schema_with_edits
                 .read()
                 .unwrap()
-                .resolve_table_columns(table_name),
+                .resolve_table_columns(table_name, source_schema),
         }
     }
 
     pub fn resolve_table_column(
         &self,
         table_name: &Ident,
+        source_schema: &Ident,
         column_name: &Ident,
     ) -> Result<SchemaTableColumn, SchemaError> {
         match self {
             TableResolver::ViaSchema(schema) => {
-                schema.resolve_table_column(table_name, column_name)
+                schema.resolve_table_column(table_name, source_schema, column_name)
             }
             TableResolver::ViaSchemaWithEdits(schema_with_edits) => schema_with_edits
                 .read()
                 .unwrap()
-                .resolve_table_column(table_name, column_name),
+                .resolve_table_column(table_name, source_schema, column_name),
         }
     }
 }


### PR DESCRIPTION
Adds the "source schema" to table resolution so that tables can be unambiguously identified

The source_schema is the schema that the table "physically" belongs to.
The schema that defines access to database objects can provide access across many source schemas.

The "information_schema" and "pg_catalog" schemas are both included in the baseline public schema and are required for some operations (like finding information about custom types. 
