### PR TITLE
chore: remove release on branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Per #234:

- We build Docker images for all PRs
- We publish Docker images tagged with the PR number [to Docker Hub](https://hub.docker.com/r/cipherstash/proxy/tags?name=pr-). 

This can be helpful for people testing out changes in PRs, but with these downsides:

- There are a lot of different image tags on Docker Hub, which can confuse users
- These builds end up costing a fair bit in build minutes

This PR changes the behaviour of GitHub Actions:

- We will not build and publish Docker images on PR branches
- We can still manually trigger the release workflow when we need to