### PR TITLE
Fix/update python test

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -492,11 +492,14 @@ else
 fi
 """
 
-[tasks."python:test"]
+[tasks."test:integration:lang:python"]
 dir = "{{config_root}}/tests"
 description = "Runs python tests"
 run = """
 set -e
+mise --env tls run postgres:up --extra-args "--detach --wait"
+mise --env tls run postgres:setup
+mise --env tls run proxy:up proxy-tls --extra-args "--detach --wait"
 echo docker compose run --rm --no-TTY --build python {{option(name="extra-args",default="")}} | bash
 """
 

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -81,7 +81,7 @@ services:
 
   proxy-tls:
     image: cipherstash/proxy:latest
-    container_name: proxy
+    container_name: proxy-tls
     ports:
       - 6432:6432
     environment:

--- a/tests/python/tests/test_async.py
+++ b/tests/python/tests/test_async.py
@@ -5,13 +5,16 @@ from psycopg.types import TypeInfo
 import random
 import pytest
 
-username = os.environ.get("CS_DATABASE__USERNAME")
-password = os.environ.get("CS_DATABASE__PASSWORD")
-database = os.environ.get("CS_DATABASE__NAME")
-host = os.environ.get("CS_DATABASE__HOST")
-port = 6432
 
-connection_str = "postgres://{}:{}@{}:{}/{}".format(username, password, host, port, database)
+conn_params = {
+    "user": os.environ.get("CS_DATABASE__USERNAME"),
+    "password": os.environ.get("CS_DATABASE__PASSWORD"),
+    "dbname": os.environ.get("CS_DATABASE__NAME"),
+    "host": os.environ.get("CS_DATABASE__HOST"),
+    "port": 6432,
+}
+
+connection_str = psycopg.conninfo.make_conninfo(**conn_params)
 print("Connection to Tandem with {}".format(connection_str))
 
 

--- a/tests/python/tests/test_error_messages.py
+++ b/tests/python/tests/test_error_messages.py
@@ -9,15 +9,15 @@ from psycopg.types.json import Jsonb
 import pytest
 import random
 
+conn_params = {
+    "user": os.environ.get("CS_DATABASE__USERNAME"),
+    "password": os.environ.get("CS_DATABASE__PASSWORD"),
+    "dbname": os.environ.get("CS_DATABASE__NAME"),
+    "host": os.environ.get("CS_DATABASE__HOST"),
+    "port": 6432,
+}
 
-username = os.environ.get("CS_DATABASE__USERNAME")
-password = os.environ.get("CS_DATABASE__PASSWORD")
-database = os.environ.get("CS_DATABASE__NAME")
-host = os.environ.get("CS_DATABASE__HOST")
-port = 6432
-# port = 5432
-
-connection_str = "postgres://{}:{}@{}:{}/{}".format(username, password, host, port, database)
+connection_str = psycopg.conninfo.make_conninfo(**conn_params)
 print("Connection to Tandem with {}".format(connection_str))
 
 def make_id():

--- a/tests/python/tests/test_mapping_params.py
+++ b/tests/python/tests/test_mapping_params.py
@@ -8,13 +8,16 @@ from psycopg.types.json import Json
 from psycopg.types.json import Jsonb
 import random
 
-username = os.environ.get("CS_DATABASE__USERNAME")
-password = os.environ.get("CS_DATABASE__PASSWORD")
-database = os.environ.get("CS_DATABASE__NAME")
-host = os.environ.get("CS_DATABASE__HOST")
-port = 6432
+conn_params = {
+    "user": os.environ.get("CS_DATABASE__USERNAME"),
+    "password": os.environ.get("CS_DATABASE__PASSWORD"),
+    "dbname": os.environ.get("CS_DATABASE__NAME"),
+    "host": os.environ.get("CS_DATABASE__HOST"),
+    "port": 6432,
+}
 
-connection_str = "postgres://{}:{}@{}:{}/{}".format(username, password, host, port, database)
+connection_str = psycopg.conninfo.make_conninfo(**conn_params)
+
 print("Connection to Tandem with {}".format(connection_str))
 
 def make_id():

--- a/tests/tasks/test/integration/psql-tls.sh
+++ b/tests/tasks/test/integration/psql-tls.sh
@@ -15,19 +15,19 @@ docker exec -i postgres${CONTAINER_SUFFIX} psql postgresql://${CS_DATABASE__USER
 SELECT 1;
 EOF
 
-# Connect to the proxy
-docker exec -i postgres${CONTAINER_SUFFIX} psql postgresql://cipherstash:${encoded_password}@proxy:6432/cipherstash <<-EOF
+# Connect to the proxy-tls
+docker exec -i postgres${CONTAINER_SUFFIX} psql postgresql://cipherstash:${encoded_password}@proxy-tls:6432/cipherstash <<-EOF
 SELECT 1;
 EOF
 
-# Connect to the proxy forcing TLS
-docker exec -i postgres${CONTAINER_SUFFIX} psql postgresql://cipherstash:${encoded_password}@proxy:6432/cipherstash?sslmode=require <<-EOF
+# Connect to the proxy-tls forcing TLS
+docker exec -i postgres${CONTAINER_SUFFIX} psql postgresql://cipherstash:${encoded_password}@proxy-tls:6432/cipherstash?sslmode=require <<-EOF
 SELECT 1;
 EOF
 
 # Connect without TLS
 set +e
-OUTPUT="$(docker exec -i postgres${CONTAINER_SUFFIX} psql postgresql://cipherstash:${encoded_password}@proxy:6432/cipherstash?sslmode=disable --command 'SELECT 1' 2>&1)"
+OUTPUT="$(docker exec -i postgres${CONTAINER_SUFFIX} psql postgresql://cipherstash:${encoded_password}@proxy-tls:6432/cipherstash?sslmode=disable --command 'SELECT 1' 2>&1)"
 retval=$?
 if echo ${OUTPUT} | grep -v 'Transport Layer Security (TLS) connection is required'; then
     echo "error: did not see string in output: \"Transport Layer Security (TLS) connection is required\""
@@ -39,7 +39,7 @@ if [ $retval -ne 2 ]; then # 2 is the return value when psql fails to connect wi
 fi
 
 # Attempt with an invalid password
-docker exec -i postgres${CONTAINER_SUFFIX} psql postgresql://cipherstash:not-the-p%40ssword@proxy:6432/cipherstash <<-EOF
+docker exec -i postgres${CONTAINER_SUFFIX} psql postgresql://cipherstash:not-the-p%40ssword@proxy-tls:6432/cipherstash <<-EOF
 SELECT 1;
 EOF
 


### PR DESCRIPTION
This changes the way we run Python tests - instead of starting Postgres, setup, Proxy, then running `mise run python:test`, we can now run `mise run test:integration:lang:python` without setup steps.

It also fixes updates to test scripts so they can handle connection strings containing special characters.

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
