### PR TITLE
Refactor error handling and expand tests

### DIFF
--- a/packages/cipherstash-proxy-integration/src/select/unmappable.rs
+++ b/packages/cipherstash-proxy-integration/src/select/unmappable.rs
@@ -10,10 +10,49 @@ mod tests {
     /// Test ensures that unmappable SQL statements return an error
     ///
     #[tokio::test]
-    async fn unmappable_error() {
+    async fn unmappable_table_not_found() {
         let client = connect_with_tls(PROXY).await;
 
         let sql = "SELECT blah FROM vtha";
+        let result = client.query(sql, &[]).await;
+
+        assert!(
+            result.is_err(),
+            "Expected unmappble SQL statement to return an error",
+        );
+    }
+
+    #[tokio::test]
+    async fn unmappable_column_not_found() {
+        let client = connect_with_tls(PROXY).await;
+
+        let sql = "SELECT blah FROM encrypted";
+        let result = client.query(sql, &[]).await;
+
+        assert!(
+            result.is_err(),
+            "Expected unmappble SQL statement to return an error",
+        );
+    }
+
+    #[tokio::test]
+    async fn unmappable_native_cannot_be_unified_with_encrypted() {
+        let client = connect_with_tls(PROXY).await;
+
+        let sql = "SELECT * FROM encrypted WHERE plaintext = encrypted_text";
+        let result = client.query(sql, &[]).await;
+
+        assert!(
+            result.is_err(),
+            "Expected unmappble SQL statement to return an error",
+        );
+    }
+
+    #[tokio::test]
+    async fn unmappable_syntax_error() {
+        let client = connect_with_tls(PROXY).await;
+
+        let sql = "SELECT *, FROM encrypted";
         let result = client.query(sql, &[]).await;
 
         assert!(

--- a/packages/cipherstash-proxy/src/postgresql/handler.rs
+++ b/packages/cipherstash-proxy/src/postgresql/handler.rs
@@ -138,7 +138,7 @@ pub async fn handler(
             let message = ProtocolError::ClientAuthenticationFailed.to_string();
             error!(msg = message);
 
-            let message = ErrorResponse::invalid_password(&message);
+            let message = ErrorResponse::invalid_password(message);
             let bytes = BytesMut::try_from(message)?;
             client_stream.write_all(&bytes).await?;
         }

--- a/packages/cipherstash-proxy/src/postgresql/messages/error_response.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/error_response.rs
@@ -17,6 +17,7 @@ pub const CODE_RAISE_EXCEPTION: &str = "P0001";
 pub const CODE_SYNTAX_ERROR: &str = "42601";
 pub const CODE_INVALID_TEXT_REPRESENTATION: &str = "22P02";
 pub const CODE_IDLE_SESSION_TIMEOUT: &str = "57P05";
+pub const CODE_SYSTEM_ERROR: &str = "58000";
 
 ///
 /// ErrorResponse (B)
@@ -82,7 +83,7 @@ impl ErrorResponse {
         }
     }
 
-    pub fn invalid_password(message: &str) -> Self {
+    pub fn invalid_password(message: String) -> Self {
         Self {
             fields: vec![
                 Field {
@@ -99,7 +100,7 @@ impl ErrorResponse {
                 },
                 Field {
                     code: ErrorResponseCode::Message,
-                    value: message.to_string(),
+                    value: message,
                 },
             ],
         }
@@ -233,6 +234,29 @@ impl ErrorResponse {
                 Field {
                     code: ErrorResponseCode::Routine,
                     value: "cipherstash-proxy".to_string(),
+                },
+            ],
+        }
+    }
+
+    pub fn system_error(message: String) -> Self {
+        Self {
+            fields: vec![
+                Field {
+                    code: ErrorResponseCode::Severity,
+                    value: "FATAL".to_string(),
+                },
+                Field {
+                    code: ErrorResponseCode::SeverityLegacy,
+                    value: "FATAL".to_string(),
+                },
+                Field {
+                    code: ErrorResponseCode::Code,
+                    value: CODE_SYSTEM_ERROR.to_string(),
+                },
+                Field {
+                    code: ErrorResponseCode::Message,
+                    value: message,
                 },
             ],
         }


### PR DESCRIPTION
Extract a shared `error_handler` for query and parse handlers. 

Makes all mapping errors return a client error, wrapped as a PostgreSQL system error. 

