### PR TITLE
chore: enable language-specific tests in test:integration

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -337,6 +337,15 @@ mise --env tls run proxy:up proxy-tls --extra-args "--detach --wait"
 mise --env tls run test:wait_for_postgres_to_quack --port 6432 --max-retries 20 --tls
 cargo nextest run --no-fail-fast --nocapture -E 'package(cipherstash-proxy-integration)'
 mise --env tls run proxy:down
+
+echo
+echo '###############################################'
+echo '# Test: Language-specific integration'
+echo '###############################################'
+echo
+mise run test:integration:lang:golang
+mise run test:integration:lang:python
+mise run test:integration:lang:elixir
 """
 
 [tasks."test:nextest"]


### PR DESCRIPTION
It looks like golang and python weren't present in mise.toml. Enabling all.
## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
