### PR TITLE
Handle PostgreSQL OIDs for custom and domain types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,6 +793,7 @@ dependencies = [
  "clap",
  "fake 4.2.0",
  "hex",
+ "postgres-types",
  "rand 0.9.0",
  "recipher",
  "rustls",

--- a/packages/cipherstash-proxy-integration/Cargo.toml
+++ b/packages/cipherstash-proxy-integration/Cargo.toml
@@ -29,5 +29,6 @@ cipherstash-config = "0.2.3"
 clap = "4.5.32"
 fake = { version = "4", features = ["chrono", "derive"] }
 hex = "0.4.3"
+postgres-types = { version = "0.2.9", features = ["derive"] }
 tap = "1.0.1"
 uuid = { version = "1.11.0", features = ["serde", "v4"] }

--- a/packages/cipherstash-proxy-integration/src/common.rs
+++ b/packages/cipherstash-proxy-integration/src/common.rs
@@ -49,7 +49,11 @@ pub async fn clear() {
 }
 
 pub async fn reset_schema() {
-    let client = connect_with_tls(PROXY).await;
+    let port = std::env::var("CS_DATABASE__PORT")
+        .map(|s| s.parse().unwrap())
+        .unwrap_or(PG_LATEST);
+
+    let client = connect_with_tls(port).await;
     client.simple_query(TEST_SCHEMA_SQL).await.unwrap();
 }
 

--- a/packages/cipherstash-proxy-integration/src/decrypt/insert_returning.rs
+++ b/packages/cipherstash-proxy-integration/src/decrypt/insert_returning.rs
@@ -90,7 +90,7 @@ mod tests {
             let encrypted_text_result: String = row.get("encrypted_text");
             assert_eq!(encrypted_text, encrypted_text_result);
 
-            let encrypted_text_result: String = row.get(3);
+            let encrypted_text_result: String = row.get(4);
             assert_eq!(encrypted_text, encrypted_text_result);
         }
     }

--- a/packages/cipherstash-proxy-integration/src/insert/insert_domain_type.rs
+++ b/packages/cipherstash-proxy-integration/src/insert/insert_domain_type.rs
@@ -1,0 +1,62 @@
+#[cfg(test)]
+mod tests {
+    use crate::common::{connect_with_tls, insert, query_by, random_id, trace, PROXY};
+    use tokio_postgres::types::{FromSql, ToSql};
+
+    #[derive(Debug, ToSql, FromSql, PartialEq)]
+    #[postgres(name = "domain_type_with_check")]
+    pub struct Domain(String);
+
+    ///
+    /// Tests insertion of custom domain type
+    ///
+    #[tokio::test]
+    async fn insert_domain_type() {
+        trace();
+
+        let id = random_id();
+        let encrypted_domain = Domain("ZZ".to_string());
+
+        let sql = "INSERT INTO encrypted (id, plaintext_domain) VALUES ($1, $2)";
+        insert(sql, &[&id, &encrypted_domain]).await;
+
+        let sql = "SELECT plaintext_domain FROM encrypted WHERE id = $1";
+        let result = query_by::<Domain>(sql, &id).await;
+
+        let expected = vec![encrypted_domain];
+        assert_eq!(expected, result);
+    }
+
+    ///
+    /// Tests insertion of custom domain type with returned values
+    ///
+    #[tokio::test]
+    async fn insert_domain_type_with_encrypted_and_returning() {
+        trace();
+
+        let id = random_id();
+        let encrypted_domain = Domain("ZZ".to_string());
+        let encrypted_text = "blah-vtha".to_string();
+
+        let sql = "INSERT INTO encrypted (id, plaintext_domain, encrypted_text) VALUES ($1, $2, $3) RETURNING id, plaintext_domain, encrypted_text";
+
+        let client = connect_with_tls(PROXY).await;
+        let result = client
+            .query(sql, &[&id, &encrypted_domain, &encrypted_text])
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+
+        for row in result {
+            let result_id: i64 = row.get("id");
+            assert_eq!(id, result_id);
+
+            let result_encrypted_text: String = row.get("encrypted_text");
+            assert_eq!(encrypted_text, result_encrypted_text);
+
+            let result_domain: Domain = row.get("plaintext_domain");
+            assert_eq!(encrypted_domain, result_domain);
+        }
+    }
+}

--- a/packages/cipherstash-proxy-integration/src/insert/mod.rs
+++ b/packages/cipherstash-proxy-integration/src/insert/mod.rs
@@ -1,3 +1,4 @@
+mod insert_domain_type;
 mod insert_with_literal;
 mod insert_with_null_literal;
 mod insert_with_null_param;

--- a/packages/cipherstash-proxy-integration/src/map_unique_index.rs
+++ b/packages/cipherstash-proxy-integration/src/map_unique_index.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::common::{clear, connect_with_tls, random_id, reset_schema, trace, PROXY};
+    use crate::common::{clear, connect_with_tls, random_id, trace, PROXY};
     use chrono::NaiveDate;
 
     #[tokio::test]
@@ -225,7 +225,7 @@ mod tests {
     async fn map_unique_index_all_with_wildcard() {
         trace();
 
-        reset_schema().await;
+        clear().await;
 
         let client = connect_with_tls(PROXY).await;
 

--- a/packages/cipherstash-proxy-integration/src/select/select_domain_type.rs
+++ b/packages/cipherstash-proxy-integration/src/select/select_domain_type.rs
@@ -1,0 +1,29 @@
+#[cfg(test)]
+mod tests {
+    use crate::common::{insert, query_by, random_id, trace};
+    use tokio_postgres::types::{FromSql, ToSql};
+
+    #[derive(Debug, ToSql, FromSql, PartialEq)]
+    #[postgres(name = "domain_type_with_check")]
+    pub struct Domain(String);
+
+    ///
+    /// Tests insertion of custom domain type
+    ///
+    #[tokio::test]
+    async fn select_domain_type() {
+        trace();
+
+        let id = random_id();
+        let encrypted_val = Domain("ZZ".to_string());
+
+        let insert_sql = "INSERT INTO encrypted (id, plaintext_domain) VALUES ($1, $2)";
+        insert(insert_sql, &[&id, &encrypted_val]).await;
+
+        let select_sql = "SELECT plaintext_domain FROM encrypted WHERE id = $1";
+        let result = query_by::<Domain>(select_sql, &id).await;
+
+        let expected = vec![encrypted_val];
+        assert_eq!(expected, result);
+    }
+}

--- a/packages/cipherstash-proxy/src/postgresql/backend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/backend.rs
@@ -355,6 +355,8 @@ where
     ) -> Result<Option<BytesMut>, Error> {
         let mut description = ParamDescription::try_from(bytes)?;
 
+        debug!(target: PROTOCOL, client_id = self.context.client_id, ParamDescription = ?description);
+
         if let Some(statement) = self.context.get_statement_from_describe() {
             let param_types = statement
                 .param_columns
@@ -388,6 +390,8 @@ where
         bytes: &BytesMut,
     ) -> Result<Option<BytesMut>, Error> {
         let mut description = RowDescription::try_from(bytes)?;
+
+        debug!(target: PROTOCOL, client_id = self.context.client_id, RowDescription = ?description);
 
         if let Some(statement) = self.context.get_statement_from_describe() {
             let projection_types = statement

--- a/packages/cipherstash-proxy/src/postgresql/messages/row_description.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/row_description.rs
@@ -21,7 +21,7 @@ pub struct RowDescriptionField {
     pub name: String,
     pub table_oid: i32,
     pub table_column: i16,
-    pub type_oid: postgres_types::Type,
+    pub type_oid: i32,
     pub type_size: i16,
     pub type_modifier: i32,
     pub format_code: FormatCode,
@@ -46,8 +46,8 @@ impl RowDescription {
 }
 
 impl RowDescriptionField {
-    pub fn rewrite_type_oid(&mut self, type_oid: postgres_types::Type) {
-        self.type_oid = type_oid;
+    pub fn rewrite_type_oid(&mut self, postgres_type: postgres_types::Type) {
+        self.type_oid = postgres_type.oid() as i32;
         self.dirty = true;
     }
 
@@ -124,9 +124,6 @@ impl TryFrom<&mut Cursor<&BytesMut>> for RowDescriptionField {
         let table_column = cursor.get_i16();
         let type_oid = cursor.get_i32();
 
-        let type_oid = postgres_types::Type::from_oid(type_oid as u32)
-            .unwrap_or(postgres_types::Type::UNKNOWN);
-
         let type_size = cursor.get_i16();
         let type_modifier = cursor.get_i32();
         let format_code = cursor.get_i16().into();
@@ -156,7 +153,7 @@ impl TryFrom<RowDescriptionField> for BytesMut {
         bytes.put_slice(name);
         bytes.put_i32(field.table_oid);
         bytes.put_i16(field.table_column);
-        bytes.put_i32(field.type_oid.oid() as i32);
+        bytes.put_i32(field.type_oid);
         bytes.put_i16(field.type_size);
         bytes.put_i32(field.type_modifier);
         bytes.put_i16(field.format_code.into());

--- a/tests/integration/golang/README.md
+++ b/tests/integration/golang/README.md
@@ -13,7 +13,7 @@ mise run postgres:setup
 mise run proxy:up
 
 # run the tests
-mise run test:integration:golang
+mise run test:integration:lang:golang
 ```
 
 This will run the tests inside a Docker container, which is networked with the `proxy` and `postgres` containers.

--- a/tests/sql/schema.sql
+++ b/tests/sql/schema.sql
@@ -1,3 +1,4 @@
+
 TRUNCATE TABLE public.eql_v2_configuration;
 
 -- Regular old table
@@ -8,12 +9,22 @@ CREATE TABLE plaintext (
     PRIMARY KEY(id)
 );
 
+DO $$
+  BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'domain_type_with_check') THEN
+      CREATE DOMAIN domain_type_with_check AS VARCHAR(2) CHECK (VALUE ~ '^[A-Z]{2}$');
+    END IF;
+  END
+$$;
+
+
 -- Exciting cipherstash table
 DROP TABLE IF EXISTS encrypted;
 CREATE TABLE encrypted (
     id bigint,
     plaintext text,
     plaintext_date date,
+    plaintext_domain domain_type_with_check,
     encrypted_text eql_v2_encrypted,
     encrypted_bool eql_v2_encrypted,
     encrypted_int2 eql_v2_encrypted,


### PR DESCRIPTION

Remove the mapping from PostgreSQL OID to a `postgres_types::Type`, with unknown types being `unknown`.
When the Param and Row Description messages where rewritten for encryptable statements, the conversion left the OID as unknown rather than the original value. 

OIDs are now kept as the original `i32` value. 

