### PR TITLE
chore: fix all breakages due to type changes in sqlparser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-client"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9e8e35918bb0873f1b365a35345cfdd5482b8a2c0ab2330381972623e32274"
+checksum = "0168885dfe967dc3884a51e415ce15c82343b7fd8be36b08d39f25f4fc727064"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -2834,6 +2834,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2986,6 +2995,26 @@ dependencies = [
  "sha2",
  "thiserror 1.0.69",
  "zeroize",
+]
+
+[[package]]
+name = "recursive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0786a43debb760f491b1bc0269fe5e84155353c67482b9e60d0cfb596054b43e"
+dependencies = [
+ "recursive-proc-macro-impl",
+ "stacker",
+]
+
+[[package]]
+name = "recursive-proc-macro-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
+dependencies = [
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3645,9 +3674,9 @@ dependencies = [
 
 [[package]]
 name = "sqltk"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59da41aedffb29f4918178e6f6cff9293bd6329252cae89f422de55cd7982e09"
+checksum = "d903c7ebd3307b29813468417bbbe17dc9b5554626bbe4a6f9ba174a8a9c6783"
 dependencies = [
  "bigdecimal",
  "sqltk-parser",
@@ -3655,12 +3684,13 @@ dependencies = [
 
 [[package]]
 name = "sqltk-parser"
-version = "0.53.0-cipherstash.2"
+version = "0.56.0-cipherstash.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005a87eea1dc6e540f364fbc0c4942b2d57184554957f3efe87d700e286d0226"
+checksum = "fa2b20306e4a01dd981c051e0d3c566367327e82e5cb1408001441ed3d07a642"
 dependencies = [
  "bigdecimal",
  "log",
+ "recursive",
 ]
 
 [[package]]
@@ -3668,6 +3698,19 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stacker"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cddb07e32ddb770749da91081d8d0ac3a16f1a569a18b20348cd371f5dead06b"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ strip = "none"
 debug = true
 
 [workspace.dependencies]
-sqltk = { version = "0.8.0" }
+sqltk = { version = "0.9.0" }
 thiserror = "2.0.9"
 tokio = { version = "1.44.2", features = ["full"] }
 tracing = "0.1"

--- a/packages/eql-mapper/src/eql_mapper.rs
+++ b/packages/eql-mapper/src/eql_mapper.rs
@@ -169,13 +169,13 @@ impl<'ast> EqlMapper<'ast> {
                     node_types = %Fmt(&node_types)
                 );
 
-                Ok(TypeCheckedStatement {
+                Ok(TypeCheckedStatement::new(
                     statement,
                     projection,
                     params,
                     literals,
-                    node_types: Arc::new(node_types),
-                })
+                    Arc::new(node_types),
+                ))
             }
             Err(err) => {
                 {

--- a/packages/eql-mapper/src/inference/infer_type_impls/function.rs
+++ b/packages/eql-mapper/src/inference/infer_type_impls/function.rs
@@ -2,8 +2,7 @@ use eql_mapper_macros::trace_infer;
 use sqltk::parser::ast::{Function, FunctionArguments};
 
 use crate::{
-    get_sql_function_def, inference::infer_type::InferType, CompoundIdent, FunctionSig, TypeError,
-    TypeInferencer,
+    get_sql_function_def, inference::infer_type::InferType, FunctionSig, TypeError, TypeInferencer,
 };
 
 /// Looks up the function signature.
@@ -21,9 +20,8 @@ impl<'ast> InferType<'ast, Function> for TypeInferencer<'ast> {
         }
 
         let Function { name, args, .. } = function;
-        let fn_name = CompoundIdent::from(&name.0);
 
-        match get_sql_function_def(&fn_name, args) {
+        match get_sql_function_def(name, args) {
             Some(sql_fn) => {
                 sql_fn
                     .sig

--- a/packages/eql-mapper/src/inference/infer_type_impls/insert_statement.rs
+++ b/packages/eql-mapper/src/inference/infer_type_impls/insert_statement.rs
@@ -10,63 +10,64 @@ use crate::{
     ColumnKind, TableColumn, TypeInferencer,
 };
 use eql_mapper_macros::trace_infer;
-use sqltk::parser::ast::{Ident, Insert};
+use sqltk::parser::ast::{Insert, TableObject};
 
 #[trace_infer]
 impl<'ast> InferType<'ast, Insert> for TypeInferencer<'ast> {
     fn infer_enter(&mut self, insert: &'ast Insert) -> Result<(), TypeError> {
-        let Insert {
-            table_name,
+        if let Insert {
+            table: TableObject::TableName(table_name),
             table_alias,
             columns,
             source,
             ..
-        } = insert;
+        } = insert
+        {
+            if table_alias.is_some() {
+                return Err(TypeError::UnsupportedSqlFeature("INSERT with ALIAS".into()));
+            }
 
-        if table_alias.is_some() {
-            return Err(TypeError::UnsupportedSqlFeature("INSERT with ALIAS".into()));
-        }
+            let table_columns = if columns.is_empty() {
+                // When no columns are specified, the source must unify with a projection of ALL table columns.
+                self.table_resolver.resolve_table_columns(table_name)?
+            } else {
+                columns
+                    .iter()
+                    .map(|c| self.table_resolver.resolve_table_column(table_name, c))
+                    .collect::<Result<Vec<_>, _>>()?
+            };
 
-        let table_name: &Ident = table_name.0.last().unwrap();
+            let target_columns = Type::projection(
+                &table_columns
+                    .into_iter()
+                    .map(|stc| {
+                        let tc = TableColumn {
+                            table: stc.table.clone(),
+                            column: stc.column.clone(),
+                        };
 
-        let table_columns = if columns.is_empty() {
-            // When no columns are specified, the source must unify with a projection of ALL table columns.
-            self.table_resolver.resolve_table_columns(table_name)?
+                        let value_ty = if stc.kind == ColumnKind::Native {
+                            Value::Native(NativeValue(Some(tc.clone())))
+                        } else {
+                            Value::Eql(EqlValue(tc.clone()))
+                        };
+
+                        (
+                            Arc::new(Type::Constructor(Constructor::Value(value_ty))),
+                            Some(tc.column.clone()),
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+            );
+
+            if let Some(source) = source {
+                self.unify_node_with_type(&**source, target_columns)?;
+            }
+
+            Ok(())
         } else {
-            columns
-                .iter()
-                .map(|c| self.table_resolver.resolve_table_column(table_name, c))
-                .collect::<Result<Vec<_>, _>>()?
-        };
-
-        let target_columns = Type::projection(
-            &table_columns
-                .into_iter()
-                .map(|stc| {
-                    let tc = TableColumn {
-                        table: stc.table.clone(),
-                        column: stc.column.clone(),
-                    };
-
-                    let value_ty = if stc.kind == ColumnKind::Native {
-                        Value::Native(NativeValue(Some(tc.clone())))
-                    } else {
-                        Value::Eql(EqlValue(tc.clone()))
-                    };
-
-                    (
-                        Arc::new(Type::Constructor(Constructor::Value(value_ty))),
-                        Some(tc.column.clone()),
-                    )
-                })
-                .collect::<Vec<_>>(),
-        );
-
-        if let Some(source) = source {
-            self.unify_node_with_type(&**source, target_columns)?;
+            Err(TypeError::UnsupportedSqlFeature("table functions".into()))
         }
-
-        Ok(())
     }
 
     fn infer_exit(&mut self, insert: &'ast Insert) -> Result<(), TypeError> {

--- a/packages/eql-mapper/src/inference/infer_type_impls/select_item.rs
+++ b/packages/eql-mapper/src/inference/infer_type_impls/select_item.rs
@@ -1,5 +1,5 @@
 use eql_mapper_macros::trace_infer;
-use sqltk::parser::ast::SelectItem;
+use sqltk::parser::ast::{SelectItem, SelectItemQualifiedWildcardKind};
 
 use crate::{
     inference::{type_error::TypeError, InferType},
@@ -13,11 +13,19 @@ impl<'ast> InferType<'ast, SelectItem> for TypeInferencer<'ast> {
             SelectItem::UnnamedExpr(expr) | SelectItem::ExprWithAlias { expr, .. } => {
                 self.unify_node_with_type(select_item, self.get_node_type(expr))?;
             }
-            SelectItem::QualifiedWildcard(object_name, _) => {
+            SelectItem::QualifiedWildcard(
+                SelectItemQualifiedWildcardKind::ObjectName(object_name),
+                _,
+            ) => {
                 self.unify_node_with_type(
                     select_item,
-                    self.resolve_qualified_wildcard(&object_name.0)?,
+                    self.resolve_qualified_wildcard(object_name)?,
                 )?;
+            }
+            SelectItem::QualifiedWildcard(SelectItemQualifiedWildcardKind::Expr(_), _) => {
+                return Err(TypeError::UnsupportedSqlFeature(
+                    "qualified wildcards on arbitrary expressions".into(),
+                ))
             }
             SelectItem::Wildcard(_) => {
                 self.unify_node_with_type(select_item, self.resolve_wildcard()?)?;

--- a/packages/eql-mapper/src/inference/infer_type_impls/set_expr.rs
+++ b/packages/eql-mapper/src/inference/infer_type_impls/set_expr.rs
@@ -39,6 +39,10 @@ impl<'ast> InferType<'ast, SetExpr> for TypeInferencer<'ast> {
             SetExpr::Table(table) => {
                 self.unify_nodes(&**table, set_expr)?;
             }
+
+            SetExpr::Delete(statement) => {
+                self.unify_nodes(statement, set_expr)?;
+            }
         }
 
         Ok(())

--- a/packages/eql-mapper/src/inference/infer_type_impls/value.rs
+++ b/packages/eql-mapper/src/inference/infer_type_impls/value.rs
@@ -1,5 +1,5 @@
 use eql_mapper_macros::trace_infer;
-use sqltk::parser::ast::Value;
+use sqltk::parser::ast::{Value, ValueWithSpan};
 
 use crate::{
     inference::{type_error::TypeError, InferType},
@@ -17,6 +17,19 @@ impl<'ast> InferType<'ast, Value> for TypeInferencer<'ast> {
         } else {
             self.unify(self.get_node_type(value), self.fresh_tvar())?;
         }
+
+        Ok(())
+    }
+}
+
+/// Value nodes are wrapped in a [`ValueWithSpan`], so arrange for the type of the [`Value`] to propagate to the parent.
+#[trace_infer]
+impl<'ast> InferType<'ast, ValueWithSpan> for TypeInferencer<'ast> {
+    fn infer_exit(&mut self, value_with_span: &'ast ValueWithSpan) -> Result<(), TypeError> {
+        self.unify(
+            self.get_node_type(value_with_span),
+            self.get_node_type(&value_with_span.value),
+        )?;
 
         Ok(())
     }

--- a/packages/eql-mapper/src/model/table_resolver.rs
+++ b/packages/eql-mapper/src/model/table_resolver.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, RwLock};
 
-use sqltk::parser::ast::Ident;
+use sqltk::parser::ast::{Ident, ObjectName};
 
 use super::{Schema, SchemaError, SchemaTableColumn, SchemaWithEdits, Table};
 
@@ -35,7 +35,7 @@ impl TableResolver {
         }
     }
 
-    pub fn resolve_table(&self, name: &Ident) -> Result<Arc<Table>, SchemaError> {
+    pub fn resolve_table(&self, name: &ObjectName) -> Result<Arc<Table>, SchemaError> {
         match self {
             TableResolver::ViaSchema(schema) => schema.resolve_table(name),
             TableResolver::ViaSchemaWithEdits(schema_with_edits) => {
@@ -46,7 +46,7 @@ impl TableResolver {
 
     pub fn resolve_table_columns(
         &self,
-        table_name: &Ident,
+        table_name: &ObjectName,
     ) -> Result<Vec<SchemaTableColumn>, SchemaError> {
         match self {
             TableResolver::ViaSchema(schema) => schema.resolve_table_columns(table_name),
@@ -59,7 +59,7 @@ impl TableResolver {
 
     pub fn resolve_table_column(
         &self,
-        table_name: &Ident,
+        table_name: &ObjectName,
         column_name: &Ident,
     ) -> Result<SchemaTableColumn, SchemaError> {
         match self {

--- a/packages/eql-mapper/src/test_helpers.rs
+++ b/packages/eql-mapper/src/test_helpers.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, convert::Infallible, fmt::Debug, ops::ControlFlo
 
 use sqltk::{
     parser::{
-        ast::{self as ast, Statement, Value},
+        ast::{self as ast, ObjectNamePart, Statement, Value},
         dialect::PostgreSqlDialect,
         parser::Parser,
     },
@@ -36,6 +36,10 @@ pub(crate) fn parse(statement: &str) -> Statement {
 
 pub(crate) fn id(ident: &str) -> ast::Ident {
     ast::Ident::from(ident)
+}
+
+pub(crate) fn object_name(ident: &str) -> ast::ObjectName {
+    ast::ObjectName(vec![ObjectNamePart::Identifier(ast::Ident::from(ident))])
 }
 
 pub(crate) fn get_node_key_of_json_selector<'ast>(

--- a/packages/eql-mapper/src/transformation_rules/cast_params_as_encrypted.rs
+++ b/packages/eql-mapper/src/transformation_rules/cast_params_as_encrypted.rs
@@ -1,7 +1,8 @@
 use super::helpers::cast_as_encrypted;
 use super::TransformationRule;
 use crate::{EqlMapperError, Type};
-use sqltk::parser::ast::{Expr, Value};
+use sqltk::parser::ast::{Expr, Value, ValueWithSpan};
+use sqltk::parser::tokenizer::Span;
 use sqltk::{NodeKey, NodePath, Visitable};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -24,10 +25,26 @@ impl<'ast> TransformationRule<'ast> for CastParamsAsEncrypted<'ast> {
         target_node: &mut N,
     ) -> Result<bool, EqlMapperError> {
         if self.would_edit(node_path, target_node) {
-            if let Some(expr @ Expr::Value(Value::Placeholder(_))) = target_node.downcast_mut() {
-                let to_wrap = std::mem::replace(expr, Expr::Value(Value::Null));
-                let Expr::Value(value @ Value::Placeholder(_)) = to_wrap else {
-                    unreachable!("the Expr is known to be Expr::Value(Value::Placeholder(_))")
+            if let Some(
+                expr @ Expr::Value(ValueWithSpan {
+                    value: Value::Placeholder(_),
+                    ..
+                }),
+            ) = target_node.downcast_mut()
+            {
+                let to_wrap = std::mem::replace(
+                    expr,
+                    Expr::Value(ValueWithSpan {
+                        value: Value::Null,
+                        span: Span::empty(),
+                    }),
+                );
+                let Expr::Value(ValueWithSpan {
+                    value: value @ Value::Placeholder(_),
+                    ..
+                }) = to_wrap
+                else {
+                    unreachable!("the Expr is known to be Expr::Value(ValueWithSpan::{{ value: Value::Placeholder(_), .. }})")
                 };
 
                 *expr = cast_as_encrypted(value);
@@ -39,7 +56,13 @@ impl<'ast> TransformationRule<'ast> for CastParamsAsEncrypted<'ast> {
     }
 
     fn would_edit<N: Visitable>(&mut self, node_path: &NodePath<'ast>, _target_node: &N) -> bool {
-        if let Some((node @ Expr::Value(Value::Placeholder(_)),)) = node_path.last_1_as() {
+        if let Some((
+            node @ Expr::Value(ValueWithSpan {
+                value: Value::Placeholder(_),
+                ..
+            }),
+        )) = node_path.last_1_as()
+        {
             if let Some(Type::Value(crate::Value::Eql(_))) =
                 self.node_types.get(&NodeKey::new(node))
             {

--- a/packages/eql-mapper/src/transformation_rules/fail_on_placeholder_change.rs
+++ b/packages/eql-mapper/src/transformation_rules/fail_on_placeholder_change.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use sqltk::parser::ast::{Expr, Value};
+use sqltk::parser::ast::{Expr, Value, ValueWithSpan};
 
 use crate::EqlMapperError;
 
@@ -30,8 +30,15 @@ impl<'ast> FailOnPlaceholderChange<'ast> {
         if let Some((expr,)) = node_path.last_1_as::<Expr>() {
             let target_node = target_node.downcast_ref::<Expr>().unwrap();
 
-            if let (Expr::Value(source_value @ Value::Placeholder(_)), Expr::Value(target_value)) =
-                (expr, target_node)
+            if let (
+                Expr::Value(
+                    source_value @ ValueWithSpan {
+                        value: Value::Placeholder(_),
+                        ..
+                    },
+                ),
+                Expr::Value(target_value),
+            ) = (expr, target_node)
             {
                 if source_value != target_value {
                     return Err(EqlMapperError::InternalError(

--- a/packages/eql-mapper/src/transformation_rules/helpers.rs
+++ b/packages/eql-mapper/src/transformation_rules/helpers.rs
@@ -1,14 +1,22 @@
-use sqltk::parser::ast::{CastKind, DataType, Expr, Ident, ObjectName};
+use sqltk::parser::{
+    ast::{CastKind, DataType, Expr, Ident, ObjectName, ObjectNamePart},
+    tokenizer::Span,
+};
 
 pub(crate) fn cast_as_encrypted(wrapped: sqltk::parser::ast::Value) -> Expr {
     let cast_jsonb = Expr::Cast {
         kind: CastKind::DoubleColon,
-        expr: Box::new(Expr::Value(wrapped)),
+        expr: Box::new(Expr::Value(sqltk::parser::ast::ValueWithSpan {
+            value: wrapped,
+            span: Span::empty(),
+        })),
         data_type: DataType::JSONB,
         format: None,
     };
 
-    let encrypted_type = ObjectName(vec![Ident::new("eql_v2_encrypted")]);
+    let encrypted_type = ObjectName(vec![ObjectNamePart::Identifier(Ident::new(
+        "eql_v2_encrypted",
+    ))]);
 
     Expr::Cast {
         kind: CastKind::DoubleColon,

--- a/packages/eql-mapper/src/transformation_rules/preserve_effective_aliases.rs
+++ b/packages/eql-mapper/src/transformation_rules/preserve_effective_aliases.rs
@@ -1,5 +1,6 @@
 use std::mem;
 
+use sqltk::parser::ast::ObjectNamePart;
 use sqltk::parser::ast::{
     helpers::attached_token::AttachedToken, Expr, Function, Ident, Select, SelectItem,
 };
@@ -136,7 +137,10 @@ impl PreserveEffectiveAliases {
         match expr {
             Expr::Identifier(ident) => Some(ident.clone()),
             Expr::CompoundIdentifier(idents) => Some(idents.last().unwrap().clone()),
-            Expr::Function(Function { name, .. }) => Some(name.0.last().unwrap().clone()),
+            Expr::Function(Function { name, .. }) => {
+                let ObjectNamePart::Identifier(ident) = name.0.last().unwrap().clone();
+                Some(ident)
+            }
             Expr::Nested(expr) => Self::derive_effective_alias_for_expr(expr),
             _ => None,
         }

--- a/packages/eql-mapper/src/type_checked_statement.rs
+++ b/packages/eql-mapper/src/type_checked_statement.rs
@@ -39,12 +39,29 @@ pub struct TypeCheckedStatement<'ast> {
     /// [`Select`]: sqlparser::ast::Select
     /// [`SelectItem`]: sqlparser::ast::SelectItem
     /// [`Function`]: sqlparser::ast::Function
+    /// [`FunctionArgExpr`]: sqlparser::ast::FunctionArgExpr
     /// [`Values`]: sqlparser::ast::Values
     /// [`Value`]: sqlparser::ast::Value
     pub node_types: Arc<HashMap<NodeKey<'ast>, Type>>,
 }
 
 impl<'ast> TypeCheckedStatement<'ast> {
+    pub(crate) fn new(
+        statement: &'ast Statement,
+        projection: Projection,
+        params: Vec<(Param, Value)>,
+        literals: Vec<(EqlValue, &'ast ast::Value)>,
+        node_types: Arc<HashMap<NodeKey<'ast>, Type>>,
+    ) -> Self {
+        Self {
+            statement,
+            projection,
+            params,
+            literals,
+            node_types,
+        }
+    }
+
     /// Returns `true` if one or more SQL param placeholders in the body has an EQL type, otherwise returns `false`.
     pub fn params_contain_eql(&self) -> bool {
         self.params
@@ -130,7 +147,7 @@ impl<'ast> TypeCheckedStatement<'ast> {
     fn count_not_null_literals(&self) -> usize {
         self.literals
             .iter()
-            .filter(|(_, lit)| !matches!(lit, ast::Value::Null))
+            .filter(|(_, lit)| !matches!(lit, ast::Value::Null,))
             .count()
     }
 


### PR DESCRIPTION
This was a *mission*.

The main culprits were `ObjectName(Vec<Ident>)` changing to `ObjectName(Vec<ObjectNamePart>)` and `Expr::Value(Value)` changing to `Expr::Value(ValueWithSpan)`.

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
