### PR TITLE
build: trigger release workflow on release event

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+  release:
+    types: [published]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Previously the [release workflow](https://github.com/cipherstash/proxy/actions/workflows/release.yml) would only run on push to `main` (triggering a push to the `main` tag on Docker Hub), or when it was manually invoked. 

Because we're using GitHub Releases to [cut new releases of Proxy](https://github.com/cipherstash/proxy/releases), we can eliminate the extra manual workflow invocation step. 

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
