### PR TITLE
build: send version string on requests to ZeroKMS/CTS

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -552,6 +552,14 @@ if [[ "{{option(name="target", default=default_target)}}" =~ "linux" ]]; then
 fi
 {% endif %}
 
+# set a user agent
+if [[ -n "${GITHUB_REF_NAME}" ]]; then
+  export BUILD_VERSION="${GITHUB_REF_NAME}"
+else
+  export BUILD_VERSION="$(git rev-parse HEAD)$(git diff-index --quiet HEAD -- || echo '+untracked')"
+fi
+export CIPHERSTASH_CLIENT_SECONDARY_USER_AGENT="cipherstash-proxy/${BUILD_VERSION}"
+
 # cross-compile
 rustup update
 rustup target add --toolchain stable {{ target }}


### PR DESCRIPTION
Adds an additional version string to cipherstash-client's user agent header, to identify the version of CipherStash Proxy in use.

HTTP requests now look like this:

```
POST /load-dataset HTTP/1.1
content-type: application/json
authorization: Bearer eyJhbGciOiJS...
accept: */*
user-agent: cipherstash-client/0.22.2 (macos aarch64 cipherstash-proxy/v2.0.7)
host: ap-southeast-2.aws.viturhosted.net
content-length: 104

{"client_id":"8b6b222e-bbf5-4fda-ab50-67118d343a31","dataset_id":"a850f55e-b95f-4c1c-ba3e-a8a85349d999"}
```

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
