### PR TITLE
chore: upgrade container base image to Ubuntu 25.10

### DIFF
--- a/proxy.Dockerfile
+++ b/proxy.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.10
+FROM ubuntu:25.10
 
 # Install TLS/SSL certs for https support, PostgreSQL client (psql), and curl
 # for retrieving the certificate bundle.


### PR DESCRIPTION
According to Docker Scout:

- Image is smaller by 1.5 MB
- Image contains 10 fewer packages
- Tag was pushed more recently
- Image introduces no new vulnerability but removes 10
- Major OS version update

<!-- Please provide a summary of what's being changed -->

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
