### PR TITLE
feat: update eql-2.1.0

### DIFF
--- a/docs/getting-started/schema-example.sql
+++ b/docs/getting-started/schema-example.sql
@@ -43,6 +43,3 @@ SELECT eql_v2.add_search_config(
   'ore',
   'date'
 );
-
-SELECT cs_encrypt_v1();
-SELECT cs_activate_v1();

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -222,16 +222,6 @@ SELECT eql_v2.add_search_config(
 The first SQL statement adds a `match` index, which is used for partial matches with `LIKE`.
 The second SQL statement adds an `ore` index, which is used for ordering with `ORDER BY`.
 
-Now that the indexes has been added, you must activate them:
-
-```sql
-SELECT cs_encrypt_v1();
-SELECT cs_activate_v1();
-```
-
-This loads and activates the encrypted indexes.
-
-You must run the `cs_encrypt_v1()` and `cs_activate_v1()` functions after any modifications to the encrypted indexes.
 
 > ![IMPORTANT]
 > Adding, updating, or deleting encrypted indexes on columns that already contain encrypted data will not re-index that data. To use the new indexes, you must `SELECT` the data out of the column, and `UPDATE` it again.

--- a/mise.toml
+++ b/mise.toml
@@ -31,7 +31,7 @@ CS_PROXY__HOST = "proxy"
 # Misc
 DOCKER_CLI_HINTS = "false" # Please don't show us What's Next.
 
-CS_EQL_VERSION = "eql-2.0.6"
+CS_EQL_VERSION = "eql-2.1.0"
 
 [tools]
 "cargo:cargo-binstall" = "latest"

--- a/tests/benchmark/sql/benchmark-schema.sql
+++ b/tests/benchmark/sql/benchmark-schema.sql
@@ -19,8 +19,3 @@ SELECT eql_v2.add_column(
   'email'
 );
 
--- SELECT eql_v2.encrypt();
--- SELECT eql_v2.activate();
-
-SELECT eql_v2.migrate_config();
-SELECT eql_v2.activate_config();

--- a/tests/sql/schema.sql
+++ b/tests/sql/schema.sql
@@ -157,6 +157,8 @@ SELECT eql_v2.add_search_config(
   '{"prefix": "encrypted/encrypted_jsonb"}'
 );
 
+SELECT eql_v2.add_encrypted_constraint('encrypted', 'encrypted_text');
+
 
 -- This is the exact same schema as above but using a database-generated primary key.
 -- It is required to remove flake form the Elixir integration test suite.
@@ -298,4 +300,6 @@ SELECT eql_v2.add_search_config(
   'jsonb',
   '{"prefix": "encrypted/encrypted_jsonb"}'
 );
+
+SELECT eql_v2.add_encrypted_constraint('encrypted_elixir', 'encrypted_text');
 

--- a/tests/sql/schema.sql
+++ b/tests/sql/schema.sql
@@ -158,11 +158,6 @@ SELECT eql_v2.add_search_config(
 );
 
 
-SELECT eql_v2.add_encrypted_constraint('encrypted', 'encrypted_text');
-
-SELECT eql_v2.migrate_config();
-SELECT eql_v2.activate_config();
-
 -- This is the exact same schema as above but using a database-generated primary key.
 -- It is required to remove flake form the Elixir integration test suite.
 -- TODO: port all the rest of our integration tests to this schema.
@@ -304,7 +299,3 @@ SELECT eql_v2.add_search_config(
   '{"prefix": "encrypted/encrypted_jsonb"}'
 );
 
-SELECT eql_v2.add_encrypted_constraint('encrypted_elixir', 'encrypted_text');
-
-SELECT eql_v2.migrate_config();
-SELECT eql_v2.activate_config();


### PR DESCRIPTION
Update to use `eql-2.1.0`

Makes the unused zero-downtime workflow optional and **disabled** by default.
Adding new search configuration no longer requires calling the `encrypt` and `activate` functions to move from `pending` to `active` config states.

```
-- No longer required
SELECT eql_v2.encrypt();
SELECT eql_v2.activate();
```