### PR TITLE
Tests for JSONB field access operator (`->`)

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -31,7 +31,7 @@ CS_PROXY__HOST = "proxy"
 # Misc
 DOCKER_CLI_HINTS = "false" # Please don't show us What's Next.
 
-CS_EQL_VERSION = "eql-2.1.0"
+CS_EQL_VERSION = "eql-2.1.1"
 
 [tools]
 "cargo:cargo-binstall" = "latest"

--- a/packages/cipherstash-proxy-integration/src/select/jsonb_get_field.rs
+++ b/packages/cipherstash-proxy-integration/src/select/jsonb_get_field.rs
@@ -1,0 +1,138 @@
+#[cfg(test)]
+mod tests {
+    use serde::de::DeserializeOwned;
+    use serde_json::Value;
+
+    use crate::{
+        common::{clear, insert_jsonb, query_by, simple_query, simple_query_with_null, trace},
+        support::assert::assert_expected,
+    };
+
+    async fn select_get_jsonb_field<T>(selector: &str, value: T)
+    where
+        T: DeserializeOwned,
+        serde_json::Value: From<T>,
+    {
+        let value = Value::from(value);
+        let expected = vec![value];
+
+        let sql = "SELECT encrypted_jsonb->$1 FROM encrypted LIMIT 1";
+        let actual = query_by::<Value>(sql, &selector).await;
+
+        assert_expected(&expected, &actual);
+
+        let sql = format!("SELECT encrypted_jsonb  -> '{selector}' FROM encrypted LIMIT 1");
+        let actual = simple_query::<Value>(&sql).await;
+
+        assert_expected(&expected, &actual);
+    }
+
+    #[tokio::test]
+    async fn jsonb_get_string_field() {
+        trace();
+
+        clear().await;
+        insert_jsonb().await;
+
+        let value = "hello".to_string();
+
+        select_get_jsonb_field("string", value.to_owned()).await;
+
+        // JSONPath selectors work with EQL fields
+        select_get_jsonb_field("$.string", value.to_owned()).await;
+    }
+
+    #[tokio::test]
+    async fn jsonb_get_numeric_field() {
+        trace();
+
+        clear().await;
+        insert_jsonb().await;
+
+        select_get_jsonb_field("number", 42).await;
+
+        // JSONPath selectors work with EQL fields
+        select_get_jsonb_field("$.number", 42).await;
+    }
+
+    #[tokio::test]
+    async fn jsonb_get_numeric_array_field() {
+        trace();
+
+        clear().await;
+        insert_jsonb().await;
+
+        let value = serde_json::json!([42, 84]);
+
+        select_get_jsonb_field("array_number", value.to_owned()).await;
+
+        select_get_jsonb_field("$.array_number", value.to_owned()).await;
+    }
+
+    #[tokio::test]
+    async fn jsonb_get_stringeric_array_field() {
+        trace();
+
+        clear().await;
+        insert_jsonb().await;
+
+        let value = serde_json::json!(["hello".to_string(), "world".to_string()]);
+
+        select_get_jsonb_field("array_string", value.to_owned()).await;
+
+        select_get_jsonb_field("$.array_string", value.to_owned()).await;
+    }
+
+    #[tokio::test]
+    async fn jsonb_get_object_field() {
+        trace();
+
+        clear().await;
+        insert_jsonb().await;
+
+        let value = serde_json::json!({
+            "number": 1815,
+            "string": "world",
+        });
+
+        select_get_jsonb_field("nested", value.to_owned()).await;
+
+        select_get_jsonb_field("$.nested", value.to_owned()).await;
+    }
+
+    #[tokio::test]
+    async fn jsonb_get_unknown_field() {
+        trace();
+
+        clear().await;
+        insert_jsonb().await;
+
+        let selector = "blahvtha";
+
+        let sql = "SELECT encrypted_jsonb->$1 FROM encrypted LIMIT 1";
+        let actual = query_by::<Option<Value>>(sql, &selector).await;
+
+        let expected = vec![None];
+        assert_expected(&expected, &actual);
+
+        let sql = format!("SELECT encrypted_jsonb  -> '{selector}' FROM encrypted LIMIT 1");
+        let actual = simple_query_with_null(&sql).await;
+
+        let expected = vec![None];
+        assert_expected(&expected, &actual);
+
+        let selector = "$.blahvtha";
+
+        let sql = "SELECT encrypted_jsonb->$1 FROM encrypted LIMIT 1";
+        let actual = query_by::<Option<Value>>(sql, &selector).await;
+
+        let expected = vec![None];
+        assert_expected(&expected, &actual);
+
+        let sql = format!("SELECT encrypted_jsonb  -> '{selector}' FROM encrypted LIMIT 1");
+        let actual = simple_query_with_null(&sql).await;
+
+        let expected = vec![None];
+        assert_expected(&expected, &actual);
+    }
+}

--- a/packages/cipherstash-proxy-integration/src/select/jsonb_get_field.rs
+++ b/packages/cipherstash-proxy-integration/src/select/jsonb_get_field.rs
@@ -27,6 +27,20 @@ mod tests {
         assert_expected(&expected, &actual);
     }
 
+    async fn select_get_jsonb_field_null(selector: &str) {
+        let sql = "SELECT encrypted_jsonb->$1 FROM encrypted LIMIT 1";
+        let actual = query_by::<Option<Value>>(sql, &selector).await;
+
+        let expected = vec![None];
+        assert_expected(&expected, &actual);
+
+        let sql = format!("SELECT encrypted_jsonb  -> '{selector}' FROM encrypted LIMIT 1");
+        let actual = simple_query_with_null(&sql).await;
+
+        let expected = vec![None];
+        assert_expected(&expected, &actual);
+    }
+
     #[tokio::test]
     async fn jsonb_get_string_field() {
         trace();
@@ -107,32 +121,7 @@ mod tests {
         clear().await;
         insert_jsonb().await;
 
-        let selector = "blahvtha";
-
-        let sql = "SELECT encrypted_jsonb->$1 FROM encrypted LIMIT 1";
-        let actual = query_by::<Option<Value>>(sql, &selector).await;
-
-        let expected = vec![None];
-        assert_expected(&expected, &actual);
-
-        let sql = format!("SELECT encrypted_jsonb  -> '{selector}' FROM encrypted LIMIT 1");
-        let actual = simple_query_with_null(&sql).await;
-
-        let expected = vec![None];
-        assert_expected(&expected, &actual);
-
-        let selector = "$.blahvtha";
-
-        let sql = "SELECT encrypted_jsonb->$1 FROM encrypted LIMIT 1";
-        let actual = query_by::<Option<Value>>(sql, &selector).await;
-
-        let expected = vec![None];
-        assert_expected(&expected, &actual);
-
-        let sql = format!("SELECT encrypted_jsonb  -> '{selector}' FROM encrypted LIMIT 1");
-        let actual = simple_query_with_null(&sql).await;
-
-        let expected = vec![None];
-        assert_expected(&expected, &actual);
+        select_get_jsonb_field_null("blahvtha").await;
+        select_get_jsonb_field_null("$.blahvtha").await;
     }
 }

--- a/packages/cipherstash-proxy-integration/src/select/mod.rs
+++ b/packages/cipherstash-proxy-integration/src/select/mod.rs
@@ -1,6 +1,7 @@
 mod group_by;
 mod jsonb_contained_by;
 mod jsonb_contains;
+mod jsonb_get_field;
 mod jsonb_path_exists;
 mod jsonb_path_query;
 mod jsonb_path_query_first;

--- a/packages/cipherstash-proxy/src/postgresql/context/column.rs
+++ b/packages/cipherstash-proxy/src/postgresql/context/column.rs
@@ -20,7 +20,7 @@ impl Column {
         eql_term: EqlTermVariant,
     ) -> Column {
         let postgres_type =
-            postgres_type.unwrap_or(column_type_to_postgres_type(&config.cast_type));
+            postgres_type.unwrap_or(column_type_to_postgres_type(&config.cast_type, eql_term));
 
         Column {
             identifier,
@@ -58,18 +58,27 @@ impl Column {
     }
 }
 
-fn column_type_to_postgres_type(col_type: &ColumnType) -> postgres_types::Type {
-    match col_type {
-        ColumnType::Boolean => postgres_types::Type::BOOL,
-        ColumnType::BigInt => postgres_types::Type::INT8,
-        ColumnType::BigUInt => postgres_types::Type::INT8,
-        ColumnType::Date => postgres_types::Type::DATE,
-        ColumnType::Decimal => postgres_types::Type::NUMERIC,
-        ColumnType::Float => postgres_types::Type::FLOAT8,
-        ColumnType::Int => postgres_types::Type::INT4,
-        ColumnType::SmallInt => postgres_types::Type::INT2,
-        ColumnType::Timestamp => postgres_types::Type::TIMESTAMPTZ,
-        ColumnType::Utf8Str => postgres_types::Type::TEXT,
-        ColumnType::JsonB => postgres_types::Type::JSONB,
+///
+/// Maps a configured index type to a Postgres Type
+///
+/// JSONAccessors are mapped to a string for the client, but are JSONB for the server
+///
+fn column_type_to_postgres_type(
+    col_type: &ColumnType,
+    eql_term: EqlTermVariant,
+) -> postgres_types::Type {
+    match (col_type, eql_term) {
+        (ColumnType::Boolean, _) => postgres_types::Type::BOOL,
+        (ColumnType::BigInt, _) => postgres_types::Type::INT8,
+        (ColumnType::BigUInt, _) => postgres_types::Type::INT8,
+        (ColumnType::Date, _) => postgres_types::Type::DATE,
+        (ColumnType::Decimal, _) => postgres_types::Type::NUMERIC,
+        (ColumnType::Float, _) => postgres_types::Type::FLOAT8,
+        (ColumnType::Int, _) => postgres_types::Type::INT4,
+        (ColumnType::SmallInt, _) => postgres_types::Type::INT2,
+        (ColumnType::Timestamp, _) => postgres_types::Type::TIMESTAMPTZ,
+        (ColumnType::Utf8Str, _) => postgres_types::Type::TEXT,
+        (ColumnType::JsonB, EqlTermVariant::JsonAccessor) => postgres_types::Type::TEXT,
+        (ColumnType::JsonB, _) => postgres_types::Type::JSONB,
     }
 }

--- a/packages/cipherstash-proxy/src/postgresql/data/from_sql.rs
+++ b/packages/cipherstash-proxy/src/postgresql/data/from_sql.rs
@@ -172,7 +172,7 @@ fn text_from_sql(
             let val = if val.starts_with("$.") {
                 val.to_string()
             } else {
-                format!("$.{}", val)
+                format!("$.{val}")
             };
             Ok(Plaintext::new(val))
         }
@@ -258,7 +258,7 @@ fn binary_from_sql(
                 let val = if val.starts_with("$.") {
                     val
                 } else {
-                    format!("$.{}", val)
+                    format!("$.{val}")
                 };
                 Plaintext::new(val)
             })
@@ -268,7 +268,7 @@ fn binary_from_sql(
                 let val = if val.starts_with("$.") {
                     val
                 } else {
-                    format!("$.{}", val)
+                    format!("$.{val}")
                 };
                 Plaintext::new(val)
             })

--- a/packages/cipherstash-proxy/src/postgresql/messages/bind.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/bind.rs
@@ -63,8 +63,6 @@ impl Bind {
                         col = ?col, bound_param_type = ?bound_param_type
                     );
 
-                    // if matches!(bound_param_type, Type::)
-
                     // Convert param bytes into a Plaintext wrapping a Value
                     // If the param type is different, will convert the bound type to the correct Plaintext variant identified by the cast_type
                     let plaintext = bind_param_from_sql(

--- a/packages/cipherstash-proxy/src/postgresql/messages/data_row.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/data_row.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use bytes::{Buf, BufMut, BytesMut};
 use std::io::Cursor;
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 #[derive(Debug, Clone)]
 pub struct DataRow {
@@ -26,7 +26,6 @@ impl DataRow {
     ) -> Vec<Option<eql::EqlEncrypted>> {
         let mut result = vec![];
         for (data_column, column_config) in self.columns.iter_mut().zip(column_configuration) {
-            info!(target: DECRYPT, ?column_config, ?data_column);
             let encrypted = column_config
                 .as_ref()
                 .filter(|_| data_column.is_not_null())
@@ -181,8 +180,6 @@ impl TryFrom<&mut DataColumn> for eql::EqlEncrypted {
 
     fn try_from(col: &mut DataColumn) -> Result<Self, Error> {
         if let Some(bytes) = &col.bytes {
-            info!(target: DECRYPT, ?bytes);
-
             if &bytes[0..=1] == b"(\"" {
                 // Text encoding
                 // Encrypted record is in the form ("{}")
@@ -226,7 +223,6 @@ impl TryFrom<&mut DataColumn> for eql::EqlEncrypted {
 
                 match serde_json::from_slice(sliced) {
                     Ok(e) => {
-                        info!(target: DECRYPT, ?e);
                         return Ok(e);
                     }
                     Err(err) => {


### PR DESCRIPTION
Adds tests for JSONB field access operators (`->`)

Converts field names into a JSONPath selector for compatibility with `cipherstash-client`.
