### PR TITLE
Adds JSONB tests to the Python integration suite

### DIFF
--- a/tests/python/tests/test_jsonb_array_elements.py
+++ b/tests/python/tests/test_jsonb_array_elements.py
@@ -1,0 +1,99 @@
+import json
+import os
+import psycopg
+import random
+from itertools import product
+
+import pytest
+
+conn_params = {
+    "user": os.environ.get("CS_DATABASE__USERNAME"),
+    "password": os.environ.get("CS_DATABASE__PASSWORD"),
+    "dbname": os.environ.get("CS_DATABASE__NAME"),
+    "host": os.environ.get("CS_DATABASE__HOST"),
+    "port": 6432,
+}
+
+connection_str = psycopg.conninfo.make_conninfo(**conn_params)
+
+print("Connection to Proxy with {}".format(connection_str))
+
+# Common test data
+val = {
+    "key": "value",
+    "number": 42,
+    "array_number": [3, 2, 1],
+    "array_string": ["hello", "world"],
+    "nested": {"foo": "bar", "number": 1312},
+}
+
+
+def test_numbers():
+    select_jsonb("encrypted_jsonb", val, "$.array_number[@]",
+                 [3, 2, 1])
+
+
+def test_strings():
+    select_jsonb("encrypted_jsonb", val, "$.array_string[@]",
+                 ["hello", "world"])
+
+
+def test_with_unknown():
+    select_jsonb("encrypted_jsonb", val, "$.nonexistent",
+                 [])
+
+
+def select_jsonb(column, value, selector, expected, alias=None):
+    alias = "AS {}".format(alias) if alias is not None else ""
+    tests = [
+        ("jsonb_array_elements(jsonb_path_query({}, '{}')) {}".format(column, selector, alias), []),
+        ("jsonb_array_elements(jsonb_path_query({}, %s)) {}".format(column, alias), [selector]),
+    ]
+
+    for (select_fragment, params) in tests:
+        print("Testing fragment: {}, params: {}, expecting: {}".format(
+            select_fragment, params, expected))
+
+        for (binary, prepare) in product([None, True], repeat=2):
+            execute(json.dumps(value), column,
+                    select_fragment=select_fragment,
+                    select_params=params,
+                    expected=expected,
+                    binary=binary,
+                    prepare=prepare)
+
+
+def make_id():
+    return random.randrange(1, 1000000000)
+
+
+def execute(val, column, binary=None, prepare=None, expected=None,
+            select_fragment=None, select_params=[]):
+    with psycopg.connect(connection_str, autocommit=True) as conn:
+
+        with conn.cursor() as cursor:
+
+            with conn.transaction():
+                id = make_id()
+
+                print("... for column {}, with binary: {}, prepare: {}".format(
+                    column, binary, prepare))
+
+                sql = "INSERT INTO encrypted (id, {}) VALUES (%s, %s)".format(
+                    column)
+
+                cursor.execute(sql, [id, val], binary=binary, prepare=prepare)
+
+                sql = "SELECT {} FROM encrypted WHERE id = %s".format(
+                    select_fragment)
+                cursor.execute(
+                    sql, (select_params + [id]),
+                    binary=binary, prepare=prepare)
+
+                rows = list(map(
+                    lambda row_tuple: row_tuple[0], cursor.fetchall()))
+
+                rows.sort()
+                expected.sort()
+
+                assert rows == expected

--- a/tests/python/tests/test_jsonb_array_length.py
+++ b/tests/python/tests/test_jsonb_array_length.py
@@ -1,0 +1,97 @@
+import json
+import os
+import psycopg
+import random
+from itertools import product
+
+conn_params = {
+    "user": os.environ.get("CS_DATABASE__USERNAME"),
+    "password": os.environ.get("CS_DATABASE__PASSWORD"),
+    "dbname": os.environ.get("CS_DATABASE__NAME"),
+    "host": os.environ.get("CS_DATABASE__HOST"),
+    "port": 6432,
+}
+
+connection_str = psycopg.conninfo.make_conninfo(**conn_params)
+
+print("Connection to Proxy with {}".format(connection_str))
+
+# Common test data
+val = {
+    "key": "value",
+    "number": 42,
+    "array_number": [3, 2, 1],
+    "array_string": ["hello", "world"],
+    "nested": {"foo": "bar", "number": 1312},
+}
+
+
+def test_length_with_number():
+    select_jsonb("encrypted_jsonb", val, "$.array_number[@]", 3)
+
+
+def test_length_with_string():
+    select_jsonb("encrypted_jsonb", val, "$.array_string[@]", 2)
+
+
+def test_with_unknown():
+    select_jsonb("encrypted_jsonb", val, "$.nonexistent", None)
+
+
+def select_jsonb(column, value, selector, expected, alias=None):
+    alias = "AS {}".format(alias) if alias is not None else ""
+    tests = [
+        ("jsonb_array_length(jsonb_path_query({}, '{}')) {}".format(column, selector, alias), []),
+        ("jsonb_array_length(jsonb_path_query({}, %s)) {}".format(column, alias), [selector]),
+    ]
+
+    for (select_fragment, params) in tests:
+        print("Testing fragment: {}, params: {}, expecting: {}".format(
+            select_fragment, params, expected))
+
+        for (binary, prepare) in product([True, None], repeat=2):
+            execute(json.dumps(value), column,
+                    select_fragment=select_fragment,
+                    select_params=params,
+                    expected=expected,
+                    binary=binary,
+                    prepare=prepare)
+
+
+def make_id():
+    return random.randrange(1, 1000000000)
+
+
+def execute(val, column, binary=None, prepare=None, expected=None,
+            select_fragment=None, select_params=[]):
+    with psycopg.connect(connection_str, autocommit=True) as conn:
+
+        with conn.cursor() as cursor:
+
+            with conn.transaction():
+                id = make_id()
+
+                print("... for column {}, with binary: {}, prepare: {}".format(
+                    column, binary, prepare))
+
+                sql = "INSERT INTO encrypted (id, {}) VALUES (%s, %s)".format(
+                    column)
+
+                cursor.execute(sql, [id, val], binary=binary, prepare=prepare)
+
+                sql = "SELECT id, {} FROM encrypted WHERE id = %s".format(
+                    select_fragment)
+                cursor.execute(
+                    sql, (select_params + [id]),
+                    binary=binary, prepare=prepare)
+
+                row = cursor.fetchone()
+
+                # If expected is None, we mean that there is no result.
+                # If expected is not None, we mean that we expect a row.
+                if expected is None:
+                    assert row == expected
+                else:
+                    (result_id, result) = row
+                    assert result_id == id
+                    assert result == expected

--- a/tests/python/tests/test_jsonb_ops.py
+++ b/tests/python/tests/test_jsonb_ops.py
@@ -1,0 +1,160 @@
+import json
+import os
+import psycopg
+import random
+from itertools import product
+
+conn_params = {
+    "user": os.environ.get("CS_DATABASE__USERNAME"),
+    "password": os.environ.get("CS_DATABASE__PASSWORD"),
+    "dbname": os.environ.get("CS_DATABASE__NAME"),
+    "host": os.environ.get("CS_DATABASE__HOST"),
+    "port": 6432,
+}
+
+connection_str = psycopg.conninfo.make_conninfo(**conn_params)
+
+print("Connection to Proxy with {}".format(connection_str))
+
+
+def test_jsonb_contained_by():
+    val = {"key": "value"}
+    column = "encrypted_jsonb"
+    select_fragment = "%s <@ encrypted_jsonb"
+    tests = [
+        (val, True),
+        ({"key": "different value"}, False)
+    ]
+
+    for (param, expected) in tests:
+        params = [json.dumps(param)]
+        print("Testing params: {}, expecting: {}".format(
+            params, expected))
+
+        for (binary, prepare) in product([True, None], repeat=2):
+            execute(json.dumps(val), column,
+                    select_fragment=select_fragment,
+                    select_params=params,
+                    expected=expected,
+                    binary=binary,
+                    prepare=prepare)
+
+
+def test_jsonb_contains():
+    val = {"key": "value"}
+    column = "encrypted_jsonb"
+    select_fragment = "encrypted_jsonb @> %s"
+    tests = [
+        (val, True),
+        ({"key": "different value"}, False)
+    ]
+
+    for (param, expected) in tests:
+        params = [json.dumps(param)]
+        print("Testing params: {}, expecting: {}".format(
+            params, expected))
+
+        for (binary, prepare) in product([True, None], repeat=2):
+            execute(json.dumps(val), column,
+                    select_fragment=select_fragment,
+                    select_params=params,
+                    expected=expected,
+                    binary=binary,
+                    prepare=prepare)
+
+
+def test_jsonb_extract_simple():
+    expected = "value"
+    val = {"key": expected}
+    column = "encrypted_jsonb"
+    select_fragment_template = "{}->'{}'"
+    accessors = [
+        'key',
+        '$.key',  # Undocumented JSONPath selector
+    ]
+
+    for accessor in accessors:
+        select_fragment = select_fragment_template.format(column, accessor)
+
+        print("Testing field: {}, expecting: {}".format(
+            accessor, expected))
+
+        for (binary, prepare) in product([True, None], repeat=2):
+            execute(json.dumps(val), column,
+                    select_fragment=select_fragment,
+                    select_params=[],
+                    expected=expected,
+                    binary=binary,
+                    prepare=prepare)
+
+
+def test_jsonb_extract_parameterised():
+    val = {
+        "string": "hello",
+        "number": 42,
+        "nested": {
+            "number": 1815,
+            "string": "world",
+        },
+        "array_string": ["hello", "world"],
+        "array_number": [42, 84],
+    }
+    column = "encrypted_jsonb"
+    select_fragment = "encrypted_jsonb->%s"
+    tests = [
+        ("string", "hello"),
+        ("number", 42),
+        ("array_string", ["hello", "world"]),
+        ("array_number", [42, 84]),
+        ("nested", {"number": 1815, "string": "world"}),
+        # TODO: Test ("nonexistentkey", None)
+    ]
+
+    for (param, expected) in tests:
+        # JSONPath selectors *also* work with EQL extract, but are undocumented
+        for accessor in [param, "$." + param]:
+            print("Testing accessor: {}, expecting: {}".format(accessor, expected))
+
+            for (binary, prepare) in product([True, None], repeat=2):
+                execute(json.dumps(val), column,
+                        select_fragment=select_fragment,
+                        select_params=[accessor],
+                        expected=expected,
+                        binary=binary,
+                        prepare=prepare)
+
+
+def make_id():
+    return random.randrange(1, 1000000000)
+
+
+def execute(val, column, binary=None, prepare=None, expected=None,
+            select_fragment=None, select_params=[]):
+    with psycopg.connect(connection_str, autocommit=True) as conn:
+
+        with conn.cursor() as cursor:
+
+            with conn.transaction():
+                id = make_id()
+
+                print("... for column {}, with binary: {}, prepare: {}".format(
+                    column, binary, prepare))
+
+                sql = "INSERT INTO encrypted (id, {}) VALUES (%s, %s)".format(
+                    column)
+
+                cursor.execute(sql, [id, val], binary=binary, prepare=prepare)
+
+                sql = "SELECT id, {} FROM encrypted WHERE id = %s".format(
+                    select_fragment)
+                cursor.execute(
+                    sql, (select_params + [id]),
+                    binary=binary, prepare=prepare)
+
+                row = cursor.fetchone()
+
+                (result_id, result) = row
+                expected_result = expected if expected is not None else val
+
+                assert result_id == id
+                assert result == expected_result

--- a/tests/python/tests/test_jsonb_path_exists.py
+++ b/tests/python/tests/test_jsonb_path_exists.py
@@ -1,0 +1,106 @@
+import json
+import os
+import psycopg
+import random
+from itertools import product
+
+conn_params = {
+    "user": os.environ.get("CS_DATABASE__USERNAME"),
+    "password": os.environ.get("CS_DATABASE__PASSWORD"),
+    "dbname": os.environ.get("CS_DATABASE__NAME"),
+    "host": os.environ.get("CS_DATABASE__HOST"),
+    "port": 6432,
+}
+
+connection_str = psycopg.conninfo.make_conninfo(**conn_params)
+
+print("Connection to Proxy with {}".format(connection_str))
+
+# Common test data
+val = {
+    "key": "value",
+    "number": 42,
+    "array_number": [1, 2, 3],
+    "array_string": ["hello", "world"],
+    "nested": {"foo": "bar", "number": 1312},
+}
+
+
+def test_number():
+    select_jsonb("encrypted_jsonb", val, "$.number", True)
+
+
+def test_string():
+    select_jsonb("encrypted_jsonb", val, "$.nested.foo", True)
+
+
+def test_value():
+    select_jsonb("encrypted_jsonb", val, "$.nested", True)
+
+
+def test_with_unknown():
+    select_jsonb("encrypted_jsonb", val, "$.nonexistent", False)
+
+
+def test_value_with_alias():
+    select_jsonb("encrypted_jsonb", val, "$.nested", True,
+                 alias="selected")
+
+
+def select_jsonb(column, value, selector, expected, alias=None):
+    alias = "AS {}".format(alias) if alias is not None else ""
+    tests = [
+        ("jsonb_path_exists({}, '{}') {}".format(column, selector, alias), []),
+        ("jsonb_path_exists({}, %s) {}".format(column, alias), [selector]),
+    ]
+
+    for (select_fragment, params) in tests:
+        print("Testing fragment: {}, params: {}, expecting: {}".format(
+            select_fragment, params, expected))
+
+        for (binary, prepare) in product([True, None], repeat=2):
+            execute(json.dumps(value), column,
+                    select_fragment=select_fragment,
+                    select_params=params,
+                    expected=expected,
+                    binary=binary,
+                    prepare=prepare)
+
+
+def make_id():
+    return random.randrange(1, 1000000000)
+
+
+def execute(val, column, binary=None, prepare=None, expected=None,
+            select_fragment=None, select_params=[]):
+    with psycopg.connect(connection_str, autocommit=True) as conn:
+
+        with conn.cursor() as cursor:
+
+            with conn.transaction():
+                id = make_id()
+
+                print("... for column {}, with binary: {}, prepare: {}".format(
+                    column, binary, prepare))
+
+                sql = "INSERT INTO encrypted (id, {}) VALUES (%s, %s)".format(
+                    column)
+
+                cursor.execute(sql, [id, val], binary=binary, prepare=prepare)
+
+                sql = "SELECT id, {} FROM encrypted WHERE id = %s".format(
+                    select_fragment)
+                cursor.execute(
+                    sql, (select_params + [id]),
+                    binary=binary, prepare=prepare)
+
+                row = cursor.fetchone()
+
+                # If expected is None, we mean that there is no result.
+                # If expected is not None, we mean that we expect a row.
+                if expected is None:
+                    assert row == expected
+                else:
+                    (result_id, result) = row
+                    assert result_id == id
+                    assert result == expected

--- a/tests/python/tests/test_jsonb_path_query.py
+++ b/tests/python/tests/test_jsonb_path_query.py
@@ -1,0 +1,106 @@
+import json
+import os
+import psycopg
+import random
+from itertools import product
+
+conn_params = {
+    "user": os.environ.get("CS_DATABASE__USERNAME"),
+    "password": os.environ.get("CS_DATABASE__PASSWORD"),
+    "dbname": os.environ.get("CS_DATABASE__NAME"),
+    "host": os.environ.get("CS_DATABASE__HOST"),
+    "port": 6432,
+}
+
+connection_str = psycopg.conninfo.make_conninfo(**conn_params)
+
+print("Connection to Proxy with {}".format(connection_str))
+
+# Common test data
+val = {
+    "key": "value",
+    "number": 42,
+    "array_number": [1, 2, 3],
+    "array_string": ["hello", "world"],
+    "nested": {"foo": "bar", "number": 1312},
+}
+
+
+def test_number():
+    select_jsonb("encrypted_jsonb", val, "$.number", 42)
+
+
+def test_string():
+    select_jsonb("encrypted_jsonb", val, "$.nested.foo", "bar")
+
+
+def test_value():
+    select_jsonb("encrypted_jsonb", val, "$.nested", val['nested'])
+
+
+def test_with_unknown():
+    select_jsonb("encrypted_jsonb", val, "$.nonexistent", None)
+
+
+def test_value_with_alias():
+    select_jsonb("encrypted_jsonb", val, "$.nested", val['nested'],
+                 alias="selected")
+
+
+def select_jsonb(column, value, selector, expected, alias=None):
+    alias = "AS {}".format(alias) if alias is not None else ""
+    tests = [
+        ("jsonb_path_query({}, '{}') {}".format(column, selector, alias), []),
+        ("jsonb_path_query({}, %s) {}".format(column, alias), [selector]),
+    ]
+
+    for (select_fragment, params) in tests:
+        print("Testing fragment: {}, params: {}, expecting: {}".format(
+            select_fragment, params, expected))
+
+        for (binary, prepare) in product([True, None], repeat=2):
+            execute(json.dumps(value), column,
+                    select_fragment=select_fragment,
+                    select_params=params,
+                    expected=expected,
+                    binary=binary,
+                    prepare=prepare)
+
+
+def make_id():
+    return random.randrange(1, 1000000000)
+
+
+def execute(val, column, binary=None, prepare=None, expected=None,
+            select_fragment=None, select_params=[]):
+    with psycopg.connect(connection_str, autocommit=True) as conn:
+
+        with conn.cursor() as cursor:
+
+            with conn.transaction():
+                id = make_id()
+
+                print("... for column {}, with binary: {}, prepare: {}".format(
+                    column, binary, prepare))
+
+                sql = "INSERT INTO encrypted (id, {}) VALUES (%s, %s)".format(
+                    column)
+
+                cursor.execute(sql, [id, val], binary=binary, prepare=prepare)
+
+                sql = "SELECT id, {} FROM encrypted WHERE id = %s".format(
+                    select_fragment)
+                cursor.execute(
+                    sql, (select_params + [id]),
+                    binary=binary, prepare=prepare)
+
+                row = cursor.fetchone()
+
+                # If expected is None, we mean that there is no result.
+                # If expected is not None, we mean that we expect a row.
+                if expected is None:
+                    assert row == expected
+                else:
+                    (result_id, result) = row
+                    assert result_id == id
+                    assert result == expected

--- a/tests/python/tests/test_jsonb_path_query_first.py
+++ b/tests/python/tests/test_jsonb_path_query_first.py
@@ -1,0 +1,105 @@
+import json
+import os
+import psycopg
+import random
+from itertools import product
+
+conn_params = {
+    "user": os.environ.get("CS_DATABASE__USERNAME"),
+    "password": os.environ.get("CS_DATABASE__PASSWORD"),
+    "dbname": os.environ.get("CS_DATABASE__NAME"),
+    "host": os.environ.get("CS_DATABASE__HOST"),
+    "port": 6432,
+}
+
+connection_str = psycopg.conninfo.make_conninfo(**conn_params)
+
+print("Connection to Proxy with {}".format(connection_str))
+
+# Common test data
+val = {
+    "key": "value",
+    "number": 42,
+    "array_number": [3, 2, 1],
+    "array_string": ["hello", "world"],
+    "nested": {"foo": "bar", "number": 1312},
+}
+
+
+def test_array_wildcard_string():
+    select_jsonb("encrypted_jsonb", val, "$.array_string[*]", "hello")
+
+
+def test_array_wildcard_number():
+    select_jsonb("encrypted_jsonb", val, "$.array_number[*]", 3)
+
+
+def test_string():
+    select_jsonb("encrypted_jsonb", val, "$.nested.foo", "bar")
+
+
+def test_value():
+    select_jsonb("encrypted_jsonb", val, "$.nested", val['nested'])
+
+
+def test_with_unknown():
+    select_jsonb("encrypted_jsonb", val, "$.nonexistent", None)
+
+
+def test_value_with_alias():
+    select_jsonb("encrypted_jsonb", val, "$.nested", val['nested'],
+                 alias="selected")
+
+
+def select_jsonb(column, value, selector, expected, alias=None):
+    alias = "AS {}".format(alias) if alias is not None else ""
+    tests = [
+        ("jsonb_path_query_first({}, '{}') {}".format(column, selector, alias), []),
+        ("jsonb_path_query_first({}, %s) {}".format(column, alias), [selector]),
+    ]
+
+    for (select_fragment, params) in tests:
+        print("Testing fragment: {}, params: {}, expecting: {}".format(
+            select_fragment, params, expected))
+
+        for (binary, prepare) in product([True, None], repeat=2):
+            execute(json.dumps(value), column,
+                    select_fragment=select_fragment,
+                    select_params=params,
+                    expected=expected,
+                    binary=binary,
+                    prepare=prepare)
+
+
+def make_id():
+    return random.randrange(1, 1000000000)
+
+
+def execute(val, column, binary=None, prepare=None, expected=None,
+            select_fragment=None, select_params=[]):
+    with psycopg.connect(connection_str, autocommit=True) as conn:
+
+        with conn.cursor() as cursor:
+
+            with conn.transaction():
+                id = make_id()
+
+                print("... for column {}, with binary: {}, prepare: {}".format(
+                    column, binary, prepare))
+
+                sql = "INSERT INTO encrypted (id, {}) VALUES (%s, %s)".format(
+                    column)
+
+                cursor.execute(sql, [id, val], binary=binary, prepare=prepare)
+
+                sql = "SELECT id, {} FROM encrypted WHERE id = %s".format(
+                    select_fragment)
+                cursor.execute(
+                    sql, (select_params + [id]),
+                    binary=binary, prepare=prepare)
+
+                row = cursor.fetchone()
+
+                (result_id, result) = row
+                assert result_id == id
+                assert result == expected

--- a/tests/python/tests/test_jsonb_select_where_cmp.py
+++ b/tests/python/tests/test_jsonb_select_where_cmp.py
@@ -1,0 +1,257 @@
+import json
+import os
+import psycopg
+import random
+from itertools import product
+
+conn_params = {
+    "user": os.environ.get("CS_DATABASE__USERNAME"),
+    "password": os.environ.get("CS_DATABASE__PASSWORD"),
+    "dbname": os.environ.get("CS_DATABASE__NAME"),
+    "host": os.environ.get("CS_DATABASE__HOST"),
+    "port": 6432,
+}
+
+connection_str = psycopg.conninfo.make_conninfo(**conn_params)
+
+print("Connection to Proxy with {}".format(connection_str))
+
+
+def test_jsonb_gt_simple():
+    vals = make_values()
+    column = "encrypted_jsonb"
+    where_fragment_template = "{}->'{}' > %s"
+    tests = [
+        ("string", "C", vals[3:]),
+        ("number", 4, vals[4:]),
+    ]
+
+    for (field, param, expected) in tests:
+        where_fragment = where_fragment_template.format(column, field)
+        params = [json.dumps(param)]
+
+        print("Testing field: {}, param: {}, expecting: {}".format(
+            field, param, expected))
+
+        for (binary, prepare) in product([True, None], repeat=2):
+            execute(list(map(json.dumps, vals)), column,
+                    where_fragment=where_fragment,
+                    params=params,
+                    expected=expected,
+                    binary=binary,
+                    prepare=prepare)
+
+
+def test_jsonb_gt_parameterised():
+    vals = make_values()
+    column = "encrypted_jsonb"
+    where_fragment = "{}->%s > %s".format(column)
+    tests = [
+        (["string", json.dumps("C")], vals[3:]),
+        (["number", json.dumps(4)], vals[4:]),
+    ]
+
+    for (params, expected) in tests:
+
+        print("Testing params: {}, expecting: {}".format(
+            params, expected))
+
+        for (binary, prepare) in product([True, None], repeat=2):
+            execute(list(map(json.dumps, vals)), column,
+                    where_fragment=where_fragment,
+                    params=params,
+                    expected=expected,
+                    binary=binary,
+                    prepare=prepare)
+
+
+def test_jsonb_gte_simple():
+    vals = make_values()
+    column = "encrypted_jsonb"
+    where_fragment_template = "{}->'{}' >= %s"
+    tests = [
+        ("string", "C", vals[2:]),
+        ("number", 4, vals[3:]),
+    ]
+
+    for (field, param, expected) in tests:
+        where_fragment = where_fragment_template.format(column, field)
+        params = [json.dumps(param)]
+
+        print("Testing field: {}, params: {}, expecting: {}".format(
+            field, params, expected))
+
+        for (binary, prepare) in product([True, None], repeat=2):
+            execute(list(map(json.dumps, vals)), column,
+                    where_fragment=where_fragment,
+                    params=params,
+                    expected=expected,
+                    binary=binary,
+                    prepare=prepare)
+
+
+def test_jsonb_gte_parameterised():
+    vals = make_values()
+    column = "encrypted_jsonb"
+    where_fragment = "{}->%s >= %s".format(column)
+    tests = [
+        (["string", json.dumps("C")], vals[2:]),
+        (["number", json.dumps(4)], vals[3:]),
+    ]
+
+    for (params, expected) in tests:
+
+        print("Testing params: {}, expecting: {}".format(
+            params, expected))
+
+        for (binary, prepare) in product([True, None], repeat=2):
+            execute(list(map(json.dumps, vals)), column,
+                    where_fragment=where_fragment,
+                    params=params,
+                    expected=expected,
+                    binary=binary,
+                    prepare=prepare)
+
+
+def test_jsonb_lt_simple():
+    vals = make_values()
+    column = "encrypted_jsonb"
+    where_fragment_template = "{}->'{}' < %s"
+    tests = [
+        ("string", "C", vals[0:2]),
+        ("number", 4, vals[0:3]),
+    ]
+
+    for (field, param, expected) in tests:
+        where_fragment = where_fragment_template.format(column, field)
+        params = [json.dumps(param)]
+
+        print("Testing field: {}, params: {}, expecting: {}".format(
+            field, params, expected))
+
+        for (binary, prepare) in product([True, None], repeat=2):
+            execute(list(map(json.dumps, vals)), column,
+                    where_fragment=where_fragment,
+                    params=params,
+                    expected=expected,
+                    binary=binary,
+                    prepare=prepare)
+
+
+def test_jsonb_lt_parameterised():
+    vals = make_values()
+    column = "encrypted_jsonb"
+    where_fragment = "{}->%s < %s".format(column)
+    tests = [
+        (["string", json.dumps("C")], vals[0:2]),
+        (["number", json.dumps(4)], vals[0:3]),
+    ]
+
+    for (params, expected) in tests:
+
+        print("Testing params: {}, expecting: {}".format(
+            params, expected))
+
+        for (binary, prepare) in product([True, None], repeat=2):
+            execute(list(map(json.dumps, vals)), column,
+                    where_fragment=where_fragment,
+                    params=params,
+                    expected=expected,
+                    binary=binary,
+                    prepare=prepare)
+
+
+def test_jsonb_lte_simple():
+    vals = make_values()
+    column = "encrypted_jsonb"
+    where_fragment_template = "{}->'{}' <= %s"
+    tests = [
+        ("string", "C", vals[0:3]),
+        ("number", 4, vals[0:4]),
+    ]
+
+    for (field, param, expected) in tests:
+        where_fragment = where_fragment_template.format(column, field)
+        params = [json.dumps(param)]
+
+        print("Testing field: {}, params: {}, expecting: {}".format(
+            field, params, expected))
+
+        for (binary, prepare) in product([True, None], repeat=2):
+            execute(list(map(json.dumps, vals)), column,
+                    where_fragment=where_fragment,
+                    params=params,
+                    expected=expected,
+                    binary=binary,
+                    prepare=prepare)
+
+
+def test_jsonb_lte_parameterised():
+    vals = make_values()
+    column = "encrypted_jsonb"
+    where_fragment = "{}->%s <= %s".format(column)
+    tests = [
+        (["string", json.dumps("C")], vals[0:3]),
+        (["number", json.dumps(4)], vals[0:4]),
+    ]
+
+    for (params, expected) in tests:
+
+        print("Testing params: {}, expecting: {}".format(
+            params, expected))
+
+        for (binary, prepare) in product([True, None], repeat=2):
+            execute(list(map(json.dumps, vals)), column,
+                    where_fragment=where_fragment,
+                    params=params,
+                    expected=expected,
+                    binary=binary,
+                    prepare=prepare)
+
+
+def make_id():
+    return random.randrange(1, 1000000000)
+
+
+def make_values():
+    values = []
+    for n in range(1, 6):  # 1..=5
+        values.append({
+            "string": chr(ord("A") + (n - 1)),
+            "number": n,
+        })
+    return values
+
+
+def execute(vals, column, binary=None, prepare=None, expected=None,
+            where_fragment=None, params=[]):
+    with psycopg.connect(connection_str, autocommit=True) as conn:
+
+        with conn.cursor() as cursor:
+
+            with conn.transaction():
+                print("... for column {}, with binary: {}, prepare: {}".format(
+                    column, binary, prepare))
+
+                ids = []
+                for val in vals:
+                    id = make_id()
+                    ids.append(id)
+
+                    sql = "INSERT INTO encrypted (id, {}) VALUES (%s, %s)".format(
+                        column)
+                    cursor.execute(sql, [id, val], binary=binary, prepare=prepare)
+
+                sql = "SELECT encrypted_jsonb FROM encrypted WHERE id = ANY(%s) AND {}".format(
+                    where_fragment)
+                cursor.execute(
+                    sql, [ids] + params,
+                    binary=binary, prepare=prepare)
+
+                rows = list(map(
+                    lambda row_tuple: row_tuple[0], cursor.fetchall()))
+
+                rows.sort(key=lambda r: r["number"])
+                expected.sort(key=lambda r: r["number"])
+
+                assert rows == expected

--- a/tests/python/tests/test_jsonb_select_where_eq.py
+++ b/tests/python/tests/test_jsonb_select_where_eq.py
@@ -1,0 +1,144 @@
+import json
+import os
+import psycopg
+import random
+from itertools import product
+
+conn_params = {
+    "user": os.environ.get("CS_DATABASE__USERNAME"),
+    "password": os.environ.get("CS_DATABASE__PASSWORD"),
+    "dbname": os.environ.get("CS_DATABASE__NAME"),
+    "host": os.environ.get("CS_DATABASE__HOST"),
+    "port": 6432,
+}
+
+connection_str = psycopg.conninfo.make_conninfo(**conn_params)
+
+print("Connection to Proxy with {}".format(connection_str))
+
+
+def test_jsonb_eq_simple():
+    val = {"key": "value"}
+    column = "encrypted_jsonb"
+    where_fragments = [
+        "{}->'key' = %s".format(column),
+        "jsonb_path_query_first({}, 'key') = %s".format(column),
+    ]
+    tests = [
+        ("value", val),
+        ("different value", None),
+    ]
+
+    for where_fragment in where_fragments:
+        for (param, expected) in tests:
+            params = [json.dumps(param)]
+
+            print("Testing fragment: {}, params: {}, expecting: {}".format(
+                where_fragment, params, expected))
+
+            for (binary, prepare) in product([True, None], repeat=2):
+                execute(json.dumps(val), column,
+                        where_fragment=where_fragment,
+                        params=params,
+                        expected=expected,
+                        binary=binary,
+                        prepare=prepare)
+
+
+def test_jsonb_parameterised():
+    val = {
+        "key": "value",
+        "array_number": [1, 2, 3],
+        "array_string": ["hello", "world"],
+        "nested": {"foo": "bar"},
+    }
+    column = "encrypted_jsonb"
+    where_fragments = [
+        "{} -> %s = %s".format(column),
+        "jsonb_path_query_first({}, %s) = %s".format(column),
+    ]
+    tests = [
+        (["key", json.dumps("value")], val),
+        (["$.key", json.dumps("value")], val),
+        (["key", json.dumps("different value")], None),
+        (["$.nested.foo", json.dumps("bar")], val),
+        (["$.array_number[0]", json.dumps(1)], val),
+        # TODO: Test ["$.array_number", json.dumps([1, 2, 3])]
+        # TODO: Test an incorrect/missing key
+    ]
+
+    for where_fragment in where_fragments:
+        for (params, expected) in tests:
+            print("Testing fragment: {}, params: {}, expecting: {}".format(
+                where_fragment, params, expected))
+
+            for (binary, prepare) in product([True, None], repeat=2):
+                execute(json.dumps(val), column,
+                        where_fragment=where_fragment,
+                        params=params,
+                        expected=expected,
+                        binary=binary,
+                        prepare=prepare)
+
+
+def test_jsonb_eq_numeric():
+    val = {"string": "C", "number": 3}
+    column = "encrypted_jsonb"
+    where_fragment = "{}->'number' = %s".format(column)
+    tests = [
+        (3, val),
+        (5, None),
+    ]
+
+    for (param, expected) in tests:
+        params = [json.dumps(param)]
+
+        print("Testing params: {}, expecting: {}".format(
+            params, expected))
+
+        for (binary, prepare) in product([True, None], repeat=2):
+            execute(json.dumps(val), column,
+                    where_fragment=where_fragment,
+                    params=params,
+                    expected=expected,
+                    binary=binary,
+                    prepare=prepare)
+
+
+def make_id():
+    return random.randrange(1, 1000000000)
+
+
+def execute(val, column, binary=None, prepare=None, expected=None,
+            where_fragment=None, params=[]):
+    with psycopg.connect(connection_str, autocommit=True) as conn:
+
+        with conn.cursor() as cursor:
+
+            with conn.transaction():
+                id = make_id()
+
+                print("... for column {}, with binary: {}, prepare: {}".format(
+                    column, binary, prepare))
+
+                sql = "INSERT INTO encrypted (id, {}) VALUES (%s, %s)".format(
+                    column)
+
+                cursor.execute(sql, [id, val], binary=binary, prepare=prepare)
+
+                sql = "SELECT id, encrypted_jsonb FROM encrypted WHERE id = %s AND {}".format(
+                    where_fragment)
+                cursor.execute(
+                    sql, [id] + params,
+                    binary=binary, prepare=prepare)
+
+                row = cursor.fetchone()
+
+                # If expected is None, we mean that there is no result.
+                # If expected is not None, we mean that we expect a row.
+                if expected is None:
+                    assert row == expected
+                else:
+                    (result_id, result) = row
+                    assert result_id == id
+                    assert result == expected


### PR DESCRIPTION
This PR adds integration test coverage for JSONB functions and operators, roughly analogous the JSONB tests in the `cipherstash-proxy-integration` suite.

A note to reviewer(s): these tests appear a little disjointed in style, ie.

- The `test_ops_…` and `test_select_where_…` tests are closer to the existing Python tests in style, but they started getting too copy-paste-y and overwrought for my liking the more I expanded the test coverage.

- For the rest of the new tests, I switched to match the `cipherstash-proxy-integration` tests instead (1-for-1, both per file and per individual test). I haven't yet been able to go back and change the earlier tests to match the latter, pardon.


## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
