### PR TITLE
fix(eql-mapper): resolution of CTE tables

### DIFF
--- a/packages/eql-mapper/src/lib.rs
+++ b/packages/eql-mapper/src/lib.rs
@@ -810,6 +810,31 @@ mod test {
     }
 
     #[test]
+    fn cte_tables_can_be_resolved_in_subqueries() {
+        let schema = resolver(schema! {
+            tables: {
+                source_table: {
+                    id,
+                }
+
+                dest_table: {
+                    id,
+                }
+            }
+        });
+
+        let statement = parse(
+            "
+            WITH fd AS ( SELECT id FROM source_table )
+            INSERT INTO dest_table ( id )
+            SELECT id FROM fd RETURNING id
+        ",
+        );
+
+        type_check(schema, &statement).unwrap();
+    }
+
+    #[test]
     fn aggregates() {
         // init_tracing();
 


### PR DESCRIPTION
Resolutions of CTE tables would only succeed from the main statement of a `WITH` but not sub-statements of that statement.

The fix was to not create parentless scopes on entry to Statement nodes - instead create a new scope pointing to the parent scope.

<!-- Please provide a summary of what's being changed -->

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
