### PR TITLE
fix(helm): PR_BYPASS specificlly pass secrets to lint job on release

### DIFF
--- a/.github/workflows/lint-test-chart.yml
+++ b/.github/workflows/lint-test-chart.yml
@@ -10,6 +10,23 @@ on:
     paths:
       - 'charts/**'
   workflow_call:
+    secrets:
+      CS_WORKSPACE_CRN:
+        required: true
+      CS_CLIENT_ID:
+        required: true
+      CS_CLIENT_KEY:
+        required: true
+      CS_CLIENT_ACCESS_KEY:
+        required: true
+      CS_CI_DATABASE_HOST:
+        required: true
+      CS_CI_DATABASE_NAME:
+        required: true
+      CS_CI_DATABASE_USER:
+        required: true
+      CS_CI_DATABASE_PASSWORD:
+        required: true
 
 jobs:
   lint-test:

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -13,6 +13,15 @@ on:
 jobs:
   lint-test:
     uses: ./.github/workflows/lint-test-chart.yml
+    secrets:
+      CS_WORKSPACE_CRN: ${{ secrets.CS_WORKSPACE_CRN }}
+      CS_CLIENT_ID: ${{ secrets.CS_CLIENT_ID }}
+      CS_CLIENT_KEY: ${{ secrets.CS_CLIENT_KEY }}
+      CS_CLIENT_ACCESS_KEY: ${{ secrets.CS_CLIENT_ACCESS_KEY }}
+      CS_CI_DATABASE_HOST: ${{ secrets.CS_CI_DATABASE_HOST }}
+      CS_CI_DATABASE_NAME: ${{ secrets.CS_CI_DATABASE_NAME }}
+      CS_CI_DATABASE_USER: ${{ secrets.CS_CI_DATABASE_USER }}
+      CS_CI_DATABASE_PASSWORD: ${{ secrets.CS_CI_DATABASE_PASSWORD }}
 
   release:
     needs: lint-test


### PR DESCRIPTION
<!-- Please provide a summary of what's being changed -->

Hot fix for passing secrets on release 

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
