### PR TITLE
fix: error on invalid workspace_crn

### DIFF
--- a/packages/cipherstash-proxy/src/error.rs
+++ b/packages/cipherstash-proxy/src/error.rs
@@ -125,6 +125,12 @@ pub enum ConfigError {
     #[error("Invalid {name}: {value}")]
     InvalidParameter { name: String, value: String },
 
+    #[error(
+        "Invalid Workspace CRN: {crn}. CRN format is `crn:{{region}}.aws:{{workspace_id}}` For help visit {}",
+        ERROR_DOC_CONFIG_URL
+    )]
+    InvalidWorkspaceCrn { crn: String },
+
     #[error("Missing an active Encrypt configuration")]
     MissingActiveEncryptConfig,
 


### PR DESCRIPTION
crn parse error were being ignored - the variable was not set, leading to a "missing config" error message.

This change explictly handles parse errors caused by invalid `workspace_crn` and outputs an appropriate message


