### PR TITLE
Add SET command for run-time configuration of keyset_id

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,9 @@ jobs:
           # The tests/docker-compose.yml config passes the ENV vars into the container
           CS_CLIENT_ACCESS_KEY: ${{ secrets.CS_CLIENT_ACCESS_KEY }}
           CS_DEFAULT_KEYSET_ID: ${{ secrets.CS_DEFAULT_KEYSET_ID }}
+          CS_TENANT_KEYSET_ID_1: ${{ secrets.CS_TENANT_KEYSET_ID_1 }}
+          CS_TENANT_KEYSET_ID_2: ${{ secrets.CS_TENANT_KEYSET_ID_2 }}
+          CS_TENANT_KEYSET_ID_3: ${{ secrets.CS_TENANT_KEYSET_ID_3 }}
           CS_CLIENT_ID: ${{ secrets.CS_CLIENT_ID }}
           CS_CLIENT_KEY: ${{ secrets.CS_CLIENT_KEY }}
           CS_WORKSPACE_CRN: "crn:ap-southeast-2.aws:${{ secrets.CS_WORKSPACE_ID }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-client"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3985602dbc15e633da566c1fba9c974c1644255396c525e68441f19f4539d6d"
+checksum = "d83afae8d39f37d0d309589bda0570cfbd7d0488919465dbaeeb5df87fd6dadc"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ debug = true
 
 [workspace.dependencies]
 sqltk = { version = "0.10.0" }
-cipherstash-client = "0.25.0"
+cipherstash-client = "0.26.0"
 cts-common = { version = "0.3.0" }
 thiserror = "2.0.9"
 tokio = { version = "1.44.2", features = ["full"] }

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -329,10 +329,9 @@ If the `keyset_id` of the record does not match the current `keyset_id` the data
 
 ### How to Fix
 
-1. Check that the `keyset_id` in the configuration matches the encrypted records.
-2. If using the `SET CIPHERSTASH.KEYSET_ID` statement, check that this `keyset_id`matches the encrypted records.
-is a valid UUID.
-3. Check that the configured `client` has been granted access to to the `keyset_id`.
+1. Check that the `keyset_id` in the configuration matches the `keyset_id` of the encrypted records.
+2. If using the `SET CIPHERSTASH.KEYSET_ID` statement, check that this `keyset_id` matches the `keyset_id` of the encrypted records.
+3. Check that the configured `client` has been granted access to the `keyset_id`.
 
 
 <!-- ---------------------------------------------------------------------------------------------------- -->

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -15,8 +15,9 @@
 
 - Encrypt errors:
   - [Column could not be encrypted](#encrypt-column-could-not-be-encrypted)
-  - [KeysetId could not be set](#encrypt-keyset-id-could-not-be-set)
   - [Column could not be encrypted](#encrypt-column-could-not-be-encrypted)
+  - [Could not decrypt data for keyset](#encrypt-encrypt-could-not-decrypt-data-for-keyset)
+  - [KeysetId could not be set](#encrypt-keyset-id-could-not-be-set)
   - [Plaintext could not be encoded](#encrypt-plaintext-could-not-be-encoded)
   - [Unknown column](#encrypt-unknown-column)
   - [Unknown table](#encrypt-unknown-table)
@@ -274,6 +275,7 @@ The most likely cause is network access to the ZeroKMS service.
 
 
 
+
 <!-- ---------------------------------------------------------------------------------------------------- -->
 
 
@@ -288,24 +290,52 @@ A keyset_id could not be set using the `SET CIPHERSTASH.KEYSET_ID` command.
 A keyset_id could not be set using `SET CIPHERSTASH.KEYSET_ID`
 ```
 
-
 ### How to Fix
 
 1. Check the syntax of the `SET CIPHERSTASH.KEYSET_ID` command. The `keyset_id` value should be in single quotes.
 2. Check that the provided `keyset_id` is a valid UUID.
+2. Check that the value is being set as a literal. The PostgreSQL `SET` statement does not support parameterised querying.
 
 
 ```
    SET [ SESSION ] CIPHERSTASH.KEYSET_ID { TO | = } '{keyset_id}'
 ```
 
+<!-- ---------------------------------------------------------------------------------------------------- -->
 
 
+## Could not decrypt data for keyset <a id='encrypt-could-not-decrypt-data-for-keyset'></a>
 
+The data belonging to the active `keyset_id` could not be decrypted.
+
+
+### Error message
+
+```
+Could not decrypt data for keyset '{keyset_id}'
+```
+
+### Notes
+
+This error is caused because the active `keyset_id` does not match the `keyset_id` of the data being decrypted.
+
+Each encrypted record belong to a `keyset` with a unique identifier (the `keyset_id`).
+
+The proxy encrypts data in the currently active `keyset`.
+
+A single default keyset can be defined in the proxy configuration or the `SET CIPHERSTASH.KEYSET_ID` statement can be used to dynamically set the active `keyset` at runtime.
+
+If the `keyset_id` of the record does not match the current `keyset_id` the data cannot be decrypted.
+
+### How to Fix
+
+1. Check that the `keyset_id` in the configuration matches the encrypted records.
+2. If using the `SET CIPHERSTASH.KEYSET_ID` statement, check that this `keyset_id`matches the encrypted records.
+is a valid UUID.
+3. Check that the configured `client` has been granted access to to the `keyset_id`.
 
 
 <!-- ---------------------------------------------------------------------------------------------------- -->
-
 
 
 ## Plaintext could not be encoded <a id='encrypt-plaintext-could-not-be-encoded'></a>
@@ -344,7 +374,9 @@ For example:
 2. Check that the configuration has not changed.
 3. Check [EQL](https://github.com/cipherstash/encrypt-query-language).
 
+
 <!-- ---------------------------------------------------------------------------------------------------- -->
+
 
 ## Unknown Column <a id='encrypt-unknown-column'></a>
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -292,6 +292,7 @@ A keyset_id could not be set using `SET CIPHERSTASH.KEYSET_ID`
 ### How to Fix
 
 1. Check the syntax of the `SET CIPHERSTASH.KEYSET_ID` command. The `keyset_id` value should be in single quotes.
+2. Check that the provided `keyset_id` is a valid UUID.
 
 
 ```

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -15,6 +15,8 @@
 
 - Encrypt errors:
   - [Column could not be encrypted](#encrypt-column-could-not-be-encrypted)
+  - [KeysetId could not be set](#encrypt-keyset-id-could-not-be-set)
+  - [Column could not be encrypted](#encrypt-column-could-not-be-encrypted)
   - [Plaintext could not be encoded](#encrypt-plaintext-could-not-be-encoded)
   - [Unknown column](#encrypt-unknown-column)
   - [Unknown table](#encrypt-unknown-table)
@@ -269,6 +271,35 @@ The most likely cause is network access to the ZeroKMS service.
 <!-- TODO: Link to ZeroKMS Doc -->
 3. Check that the encrypted configuration `cast` matches the expected type.
 <!-- TODO: Link to config -->
+
+
+
+<!-- ---------------------------------------------------------------------------------------------------- -->
+
+
+## KeysetId could not be set <a id='encrypt-keyset-id-could-not-be-set'></a>
+
+A keyset_id could not be set using the `SET CIPHERSTASH.KEYSET_ID` command.
+
+
+### Error message
+
+```
+A keyset_id could not be set using `SET CIPHERSTASH.KEYSET_ID`
+```
+
+
+### How to Fix
+
+1. Check the syntax of the `SET CIPHERSTASH.KEYSET_ID` command. The `keyset_id` value should be in single quotes.
+
+
+```
+   SET [ SESSION ] CIPHERSTASH.KEYSET_ID { TO | = } '{keyset_id}'
+```
+
+
+
 
 
 

--- a/packages/cipherstash-proxy-integration/src/common.rs
+++ b/packages/cipherstash-proxy-integration/src/common.rs
@@ -7,7 +7,7 @@ use rustls::{
 };
 use serde_json::Value;
 use std::sync::{Arc, Once};
-use tokio_postgres::{types::ToSql, Client, NoTls, SimpleQueryMessage};
+use tokio_postgres::{types::ToSql, Client, NoTls, Row, SimpleQueryMessage};
 use tracing_subscriber::{filter::Directive, EnvFilter, FmtSubscriber};
 
 pub const PROXY: u16 = 6432;
@@ -184,6 +184,12 @@ pub async fn query_with_client<T: for<'a> tokio_postgres::types::FromSql<'a> + S
     client: &Client,
 ) -> Vec<T> {
     let rows = client.query(sql, &[]).await.unwrap();
+    rows.iter().map(|row| row.get(0)).collect::<Vec<T>>()
+}
+
+pub fn rows_to_vec<T: for<'a> tokio_postgres::types::FromSql<'a> + Send + Sync>(
+    rows: &Vec<Row>,
+) -> Vec<T> {
     rows.iter().map(|row| row.get(0)).collect::<Vec<T>>()
 }
 

--- a/packages/cipherstash-proxy-integration/src/common.rs
+++ b/packages/cipherstash-proxy-integration/src/common.rs
@@ -188,7 +188,7 @@ pub async fn query_with_client<T: for<'a> tokio_postgres::types::FromSql<'a> + S
 }
 
 pub fn rows_to_vec<T: for<'a> tokio_postgres::types::FromSql<'a> + Send + Sync>(
-    rows: &Vec<Row>,
+    rows: &[Row],
 ) -> Vec<T> {
     rows.iter().map(|row| row.get(0)).collect::<Vec<T>>()
 }

--- a/packages/cipherstash-proxy-integration/src/lib.rs
+++ b/packages/cipherstash-proxy-integration/src/lib.rs
@@ -17,6 +17,7 @@ mod passthrough;
 mod pipeline;
 mod schema_change;
 mod select;
+mod set_keyset_id;
 mod simple_protocol;
 mod support;
 mod update;

--- a/packages/cipherstash-proxy-integration/src/map_ore_index_where.rs
+++ b/packages/cipherstash-proxy-integration/src/map_ore_index_where.rs
@@ -73,7 +73,15 @@ mod tests {
 
         // GT: given [1, 3], `> 1` returns [3]
         let sql = format!("SELECT {col_name} FROM encrypted WHERE {col_name} > $1");
-        test_ore_op(&client, col_name, &sql, &[&low], &[high.clone()]).await;
+
+        test_ore_op(
+            &client,
+            col_name,
+            &sql,
+            &[&low],
+            std::slice::from_ref(&high),
+        )
+        .await;
 
         // GT 2nd case: given [1, 3], `> 3` returns []
         let sql = format!("SELECT {col_name} FROM encrypted WHERE {col_name} > $1");
@@ -81,7 +89,14 @@ mod tests {
 
         // LT: given [1, 3], `< 3` returns [1]
         let sql = format!("SELECT {col_name} FROM encrypted WHERE {col_name} < $1");
-        test_ore_op(&client, col_name, &sql, &[&high], &[low.clone()]).await;
+        test_ore_op(
+            &client,
+            col_name,
+            &sql,
+            &[&high],
+            std::slice::from_ref(&low),
+        )
+        .await;
 
         // LT 2nd case: given [1, 3], `< 3` returns []
         let sql = format!("SELECT {col_name} FROM encrypted WHERE {col_name} < $1");
@@ -116,11 +131,18 @@ mod tests {
 
         // EQ: given [1, 3], `= 1` returns [1]
         let sql = format!("SELECT {col_name} FROM encrypted WHERE {col_name} = $1");
-        test_ore_op(&client, col_name, &sql, &[&low], &[low.clone()]).await;
+        test_ore_op(&client, col_name, &sql, &[&low], std::slice::from_ref(&low)).await;
 
         // NEQ: given [1, 3], `<> 3` returns [1]
         let sql = format!("SELECT {col_name} FROM encrypted WHERE {col_name} <> $1");
-        test_ore_op(&client, col_name, &sql, &[&high], &[low.clone()]).await;
+        test_ore_op(
+            &client,
+            col_name,
+            &sql,
+            &[&high],
+            std::slice::from_ref(&low),
+        )
+        .await;
     }
 
     /// Runs the query and checks the returned results match the expected results.

--- a/packages/cipherstash-proxy-integration/src/set_keyset_id.rs
+++ b/packages/cipherstash-proxy-integration/src/set_keyset_id.rs
@@ -30,12 +30,13 @@ mod tests {
         let insert_sql = "INSERT INTO encrypted (id, encrypted_int4) VALUES ($1, $2)";
         let select_sql = "SELECT encrypted_int4 FROM encrypted WHERE id = $1";
 
-        // // INSERT with DEFAULT keyset
+        //  --------
+        // INSERT with DEFAULT keyset
         let default_id = random_id();
         let default_encrypted_val = 1;
         execute_query(insert_sql, &[&default_id, &default_encrypted_val]).await;
 
-        // KEYSET_ID IS SCOPRED TO A CONNECTION
+        // KEYSET_ID IS SCOPED TO A CONNECTION
         // The same client/connection is used for tests
         let client = connect_with_tls(PROXY).await;
 
@@ -45,14 +46,14 @@ mod tests {
         let expected = vec![default_encrypted_val];
         assert_eq!(expected, actual);
 
-        // Test setting keyset_id with single quotes
+        //  --------
+        // INSERT and SELECT as TENANT 1
+
+        // SET tenant 1
         let sql = format!("SET CIPHERSTASH.KEYSET_ID = '{tenant_keyset_id_1}'");
         let result = client.query(&sql, &[]).await;
         assert!(result.is_ok(), "Setting keyset_id should succeed");
 
-        //  --
-
-        // INSERT and SELECT as TENANT 1
         let tenant_1_id = random_id();
         let encrypted_val = 2;
 
@@ -67,16 +68,18 @@ mod tests {
         let expected = vec![encrypted_val];
         assert_eq!(expected, actual);
 
-        // As TENANT 1 SELECT the data created with the DEFAULT keyset
+        //  --------
+        // SELECT data creted with DEFAULT as TENANT 1
         let result = client.query(select_sql, &[&default_id]).await;
         assert!(result.is_err());
 
-        // Use the DEFAULT keyset
+        //  --------
+        // SELECT as DEFAULT
+
         let sql = format!("SET CIPHERSTASH.KEYSET_ID = '{default_keyset_id}'");
         let result = client.query(&sql, &[]).await;
         assert!(result.is_ok(), "Setting keyset_id should succeed");
 
-        // Record can now be decrypted
         let rows = client.query(select_sql, &[&default_id]).await.unwrap();
         let actual = rows_to_vec::<i32>(&rows);
         let expected = vec![default_encrypted_val];
@@ -92,11 +95,15 @@ mod tests {
 
         clear().await;
 
+        let tenant_keyset_id_1 = std::env::var("CS_TENANT_KEYSET_ID_1")
+            .map(|s| Uuid::parse_str(&s).unwrap())
+            .unwrap();
+
         let client = connect_with_tls(PROXY).await;
 
         // Test setting keyset_id with simple query
-        let sql = "SET CIPHERSTASH.KEYSET_ID = 'simple-query-keyset-789'";
-        let result = client.simple_query(sql).await;
+        let sql = format!("SET CIPHERSTASH.KEYSET_ID = '{tenant_keyset_id_1}'");
+        let result = client.simple_query(&sql).await;
         assert!(
             result.is_ok(),
             "Setting keyset_id with simple query should succeed"
@@ -126,10 +133,22 @@ mod tests {
 
         clear().await;
 
+        let default_keyset_id = std::env::var("CS_DEFAULT_KEYSET_ID")
+            .map(|s| Uuid::parse_str(&s).unwrap())
+            .unwrap();
+
+        let tenant_keyset_id_1 = std::env::var("CS_TENANT_KEYSET_ID_1")
+            .map(|s| Uuid::parse_str(&s).unwrap())
+            .unwrap();
+
+        let tenant_keyset_id_2 = std::env::var("CS_TENANT_KEYSET_ID_2")
+            .map(|s| Uuid::parse_str(&s).unwrap())
+            .unwrap();
+
         // Client 1 sets a keyset_id
         let client1 = connect_with_tls(PROXY).await;
-        let sql = "SET CIPHERSTASH.KEYSET_ID = 'client1-keyset'";
-        let result = client1.query(sql, &[]).await;
+        let sql = format!("SET CIPHERSTASH.KEYSET_ID = '{tenant_keyset_id_1}'");
+        let result = client1.query(&sql, &[]).await;
         assert!(result.is_ok(), "Client 1 should be able to set keyset_id");
 
         // Client 2 should not be affected by client 1's keyset_id setting
@@ -151,24 +170,35 @@ mod tests {
         let result2 = client2.query(insert_sql, &[&id2, &text2]).await;
         assert!(result2.is_ok(), "Client 2 insert should succeed");
 
+        //  --------
         // Client 2 can now set its own keyset_id
-        let sql = "SET CIPHERSTASH.KEYSET_ID = 'client2-keyset'";
-        let result = client2.query(sql, &[]).await;
-        assert!(
-            result.is_ok(),
-            "Client 2 should be able to set its own keyset_id"
-        );
+        let sql = format!("SET CIPHERSTASH.KEYSET_ID = '{tenant_keyset_id_2}'");
+        let result = client2.query(&sql, &[]).await;
+        assert!(result.is_ok(),);
 
-        // Both clients should still be able to query their data
-        let select_sql = "SELECT encrypted_text FROM encrypted WHERE id = $1";
+        //  --------
+        // SELECT with Client 1
+        let sql = format!("SELECT encrypted_text FROM encrypted WHERE id = {id1}");
+        let rows = query_with_client::<String>(&sql, &client1).await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0], text1);
 
-        let rows1 = query_with_client::<String>(select_sql, &client1).await;
-        assert_eq!(rows1.len(), 1);
-        assert_eq!(rows1[0], text1);
+        // // SELECT with Client 2 (which is now TENANT 2) is an error
+        let sql = format!("SELECT encrypted_text FROM encrypted WHERE id = {id2}");
+        let result = client2.query(&sql, &[]).await;
+        assert!(result.is_err(),);
 
-        let rows2 = query_with_client::<String>(select_sql, &client2).await;
-        assert_eq!(rows2.len(), 1);
-        assert_eq!(rows2[0], text2);
+        //  --------
+        // Client 2 sets DEFAULT
+        let sql = format!("SET CIPHERSTASH.KEYSET_ID = '{default_keyset_id}'");
+        let result = client2.query(&sql, &[]).await;
+        assert!(result.is_ok(),);
+
+        // SELECT with Client 2 (which is now TENANT 2) is an error
+        let sql = format!("SELECT encrypted_text FROM encrypted WHERE id = {id2}");
+        let rows = query_with_client::<String>(&sql, &client2).await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0], text2);
     }
 
     ///
@@ -182,40 +212,30 @@ mod tests {
 
         let client = connect_with_tls(PROXY).await;
 
+        let tenant_keyset_id_1 = std::env::var("CS_TENANT_KEYSET_ID_1")
+            .map(|s| Uuid::parse_str(&s).unwrap())
+            .unwrap();
+
         // Test different string literal formats
         let test_cases = vec![
-            ("'single-quoted'", "single-quoted"),
-            ("\"double-quoted\"", "double-quoted"),
-            ("'keyset-with-dashes-123'", "keyset-with-dashes-123"),
-            (
-                "'keyset_with_underscores_456'",
-                "keyset_with_underscores_456",
-            ),
-            ("'UPPERCASE-KEYSET'", "UPPERCASE-KEYSET"),
-            ("'lowercase-keyset'", "lowercase-keyset"),
-            ("'Mixed-Case-Keyset'", "Mixed-Case-Keyset"),
+            format!("'{tenant_keyset_id_1}'"), // single quote
+            format!("'{}'", tenant_keyset_id_1.to_string().to_lowercase()), // remove dashes from uuid
+            format!("'{}'", tenant_keyset_id_1.to_string().to_uppercase()), // remove dashes from uuid
+            format!("'{}'", tenant_keyset_id_1.to_string().replace("-", "")), // remove dashes from uuid
         ];
 
-        for (quoted_value, _expected_value) in test_cases {
-            let sql = format!("SET CIPHERSTASH.KEYSET_ID = {}", quoted_value);
+        for value in test_cases {
+            let sql = format!("SET CIPHERSTASH.KEYSET_ID = {}", value);
             let result = client.query(&sql, &[]).await;
-            assert!(
-                result.is_ok(),
-                "Setting keyset_id with {} should succeed",
-                quoted_value
-            );
+            assert!(result.is_ok());
 
             // Test that operations still work after each keyset_id change
             let id = random_id();
-            let text = format!("test data for {}", quoted_value);
+            let text = format!("test data for {}", value);
 
             let insert_sql = "INSERT INTO encrypted (id, encrypted_text) VALUES ($1, $2)";
             let result = client.query(insert_sql, &[&id, &text]).await;
-            assert!(
-                result.is_ok(),
-                "Insert should work after setting keyset_id to {}",
-                quoted_value
-            );
+            assert!(result.is_ok(),);
         }
     }
 
@@ -230,26 +250,26 @@ mod tests {
 
         let client = connect_with_tls(PROXY).await;
 
+        let tenant_keyset_id_1 = std::env::var("CS_TENANT_KEYSET_ID_1")
+            .map(|s| Uuid::parse_str(&s).unwrap())
+            .unwrap();
+
         // Test cases that should potentially fail or be handled gracefully
         let invalid_cases = vec![
-            "SET CIPHERSTASH.KEYSET_ID = unquoted-value", // unquoted string
-            "SET CIPHERSTASH.KEYSET_ID = 123",            // numeric value
-            "SET CIPHERSTASH.KEYSET_ID = NULL",           // null value
+            format!("SET CIPHERSTASH.KEYSET_ID = {tenant_keyset_id_1}"), // unquoted string
+            format!("SET CIPHERSTASH.KEYSET_ID = \"{tenant_keyset_id_1}\""), // double quoted string
+            format!("SET CIPHERSTASH.KEYSET_ID = 123"),                  // numeric value
+            format!("SET CIPHERSTASH.KEYSET_ID = NULL"),                 // null value
         ];
 
         for invalid_sql in invalid_cases {
-            let result = client.query(invalid_sql, &[]).await;
-            // The proxy should either handle these gracefully or return appropriate errors
-            // We don't assert failure here as the behavior may vary based on implementation
-            println!("Result for '{}': {:?}", invalid_sql, result);
+            let result = client.query(&invalid_sql, &[]).await;
+            assert!(result.is_err(),);
         }
 
         // Ensure that after invalid attempts, a valid keyset_id can still be set
-        let sql = "SET CIPHERSTASH.KEYSET_ID = 'recovery-keyset'";
-        let result = client.query(sql, &[]).await;
-        assert!(
-            result.is_ok(),
-            "Should be able to set valid keyset_id after invalid attempts"
-        );
+        let sql = format!("SET CIPHERSTASH.KEYSET_ID = '{tenant_keyset_id_1}'");
+        let result = client.query(&sql, &[]).await;
+        assert!(result.is_ok(),);
     }
 }

--- a/packages/cipherstash-proxy-integration/src/set_keyset_id.rs
+++ b/packages/cipherstash-proxy-integration/src/set_keyset_id.rs
@@ -1,11 +1,9 @@
 #[cfg(test)]
 mod tests {
     use crate::common::{
-        clear, connect_with_tls, execute_query, query_by, query_with_client, random_id,
-        rows_to_vec, trace, PROXY,
+        clear, connect_with_tls, execute_query, query_with_client, random_id, rows_to_vec, trace,
+        PROXY,
     };
-    use serde_json::Value;
-    use tracing::{error, info};
     use uuid::Uuid;
 
     ///
@@ -25,7 +23,7 @@ mod tests {
             .map(|s| Uuid::parse_str(&s).unwrap())
             .unwrap();
 
-        let tenant_keyset_id_2 = std::env::var("CS_TENANT_KEYSET_ID_2")
+        let _tenant_keyset_id_2 = std::env::var("CS_TENANT_KEYSET_ID_2")
             .map(|s| Uuid::parse_str(&s).unwrap())
             .unwrap();
 
@@ -35,7 +33,7 @@ mod tests {
         // // INSERT with DEFAULT keyset
         let default_id = random_id();
         let default_encrypted_val = 1;
-        execute_query(&insert_sql, &[&default_id, &encrypted_val]).await;
+        execute_query(insert_sql, &[&default_id, &default_encrypted_val]).await;
 
         // KEYSET_ID IS SCOPRED TO A CONNECTION
         // The same client/connection is used for tests
@@ -45,6 +43,7 @@ mod tests {
         let rows = client.query(select_sql, &[&default_id]).await.unwrap();
         let actual = rows_to_vec::<i32>(&rows);
         let expected = vec![default_encrypted_val];
+        assert_eq!(expected, actual);
 
         // Test setting keyset_id with single quotes
         let sql = format!("SET CIPHERSTASH.KEYSET_ID = '{tenant_keyset_id_1}'");
@@ -73,7 +72,7 @@ mod tests {
         assert!(result.is_err());
 
         // Use the DEFAULT keyset
-        let sql = format!("SET CIPHERSTASH.KEYSET_ID = '{default_keyset_Id}'");
+        let sql = format!("SET CIPHERSTASH.KEYSET_ID = '{default_keyset_id}'");
         let result = client.query(&sql, &[]).await;
         assert!(result.is_ok(), "Setting keyset_id should succeed");
 
@@ -81,6 +80,7 @@ mod tests {
         let rows = client.query(select_sql, &[&default_id]).await.unwrap();
         let actual = rows_to_vec::<i32>(&rows);
         let expected = vec![default_encrypted_val];
+        assert_eq!(expected, actual);
     }
 
     ///

--- a/packages/cipherstash-proxy-integration/src/set_keyset_id.rs
+++ b/packages/cipherstash-proxy-integration/src/set_keyset_id.rs
@@ -1,0 +1,255 @@
+#[cfg(test)]
+mod tests {
+    use crate::common::{
+        clear, connect_with_tls, execute_query, query_by, query_with_client, random_id,
+        rows_to_vec, trace, PROXY,
+    };
+    use serde_json::Value;
+    use tracing::{error, info};
+    use uuid::Uuid;
+
+    ///
+    /// Tests that the `SET CIPHERSTASH.KEYSET_ID = 'keyset_id'` command is handled correctly
+    /// Test both extended and simple query protocols
+    ///
+    #[tokio::test]
+    async fn set_keyset_id_with_extended_query() {
+        trace();
+        clear().await;
+
+        let default_keyset_id = std::env::var("CS_DEFAULT_KEYSET_ID")
+            .map(|s| Uuid::parse_str(&s).unwrap())
+            .unwrap();
+
+        let tenant_keyset_id_1 = std::env::var("CS_TENANT_KEYSET_ID_1")
+            .map(|s| Uuid::parse_str(&s).unwrap())
+            .unwrap();
+
+        let tenant_keyset_id_2 = std::env::var("CS_TENANT_KEYSET_ID_2")
+            .map(|s| Uuid::parse_str(&s).unwrap())
+            .unwrap();
+
+        let insert_sql = "INSERT INTO encrypted (id, encrypted_int4) VALUES ($1, $2)";
+        let select_sql = "SELECT encrypted_int4 FROM encrypted WHERE id = $1";
+
+        // // INSERT with DEFAULT keyset
+        let default_id = random_id();
+        let default_encrypted_val = 1;
+        execute_query(&insert_sql, &[&default_id, &encrypted_val]).await;
+
+        // KEYSET_ID IS SCOPRED TO A CONNECTION
+        // The same client/connection is used for tests
+        let client = connect_with_tls(PROXY).await;
+
+        // SELECT with DEFAULT keyset
+        let rows = client.query(select_sql, &[&default_id]).await.unwrap();
+        let actual = rows_to_vec::<i32>(&rows);
+        let expected = vec![default_encrypted_val];
+
+        // Test setting keyset_id with single quotes
+        let sql = format!("SET CIPHERSTASH.KEYSET_ID = '{tenant_keyset_id_1}'");
+        let result = client.query(&sql, &[]).await;
+        assert!(result.is_ok(), "Setting keyset_id should succeed");
+
+        //  --
+
+        // INSERT and SELECT as TENANT 1
+        let tenant_1_id = random_id();
+        let encrypted_val = 2;
+
+        client
+            .query(insert_sql, &[&tenant_1_id, &encrypted_val])
+            .await
+            .unwrap();
+
+        let rows = client.query(select_sql, &[&tenant_1_id]).await.unwrap();
+        let actual = rows_to_vec::<i32>(&rows);
+
+        let expected = vec![encrypted_val];
+        assert_eq!(expected, actual);
+
+        // As TENANT 1 SELECT the data created with the DEFAULT keyset
+        let result = client.query(select_sql, &[&default_id]).await;
+        assert!(result.is_err());
+
+        // Use the DEFAULT keyset
+        let sql = format!("SET CIPHERSTASH.KEYSET_ID = '{default_keyset_Id}'");
+        let result = client.query(&sql, &[]).await;
+        assert!(result.is_ok(), "Setting keyset_id should succeed");
+
+        // Record can now be decrypted
+        let rows = client.query(select_sql, &[&default_id]).await.unwrap();
+        let actual = rows_to_vec::<i32>(&rows);
+        let expected = vec![default_encrypted_val];
+    }
+
+    ///
+    /// Tests that the `SET CIPHERSTASH.KEYSET_ID = 'keyset_id'` command works with simple queries
+    ///
+    #[tokio::test]
+    async fn set_keyset_id_with_simple_query() {
+        trace();
+
+        clear().await;
+
+        let client = connect_with_tls(PROXY).await;
+
+        // Test setting keyset_id with simple query
+        let sql = "SET CIPHERSTASH.KEYSET_ID = 'simple-query-keyset-789'";
+        let result = client.simple_query(sql).await;
+        assert!(
+            result.is_ok(),
+            "Setting keyset_id with simple query should succeed"
+        );
+
+        // Test that regular operations still work
+        let id = random_id();
+        let encrypted_text = "simple query test".to_string();
+
+        let insert_sql = format!(
+            "INSERT INTO encrypted (id, encrypted_text) VALUES ({}, '{}')",
+            id, encrypted_text
+        );
+        let result = client.simple_query(&insert_sql).await;
+        assert!(
+            result.is_ok(),
+            "Simple insert should work after setting keyset_id"
+        );
+    }
+
+    ///
+    /// Tests that keyset_id setting is bound to the specific client connection
+    ///
+    #[tokio::test]
+    async fn set_keyset_id_bound_to_client() {
+        trace();
+
+        clear().await;
+
+        // Client 1 sets a keyset_id
+        let client1 = connect_with_tls(PROXY).await;
+        let sql = "SET CIPHERSTASH.KEYSET_ID = 'client1-keyset'";
+        let result = client1.query(sql, &[]).await;
+        assert!(result.is_ok(), "Client 1 should be able to set keyset_id");
+
+        // Client 2 should not be affected by client 1's keyset_id setting
+        let client2 = connect_with_tls(PROXY).await;
+
+        // Both clients should be able to perform operations independently
+        let id1 = random_id();
+        let id2 = random_id();
+        let text1 = "client1 data".to_string();
+        let text2 = "client2 data".to_string();
+
+        let insert_sql = "INSERT INTO encrypted (id, encrypted_text) VALUES ($1, $2)";
+
+        // Client 1 insert (has keyset_id set)
+        let result1 = client1.query(insert_sql, &[&id1, &text1]).await;
+        assert!(result1.is_ok(), "Client 1 insert should succeed");
+
+        // Client 2 insert (no keyset_id set)
+        let result2 = client2.query(insert_sql, &[&id2, &text2]).await;
+        assert!(result2.is_ok(), "Client 2 insert should succeed");
+
+        // Client 2 can now set its own keyset_id
+        let sql = "SET CIPHERSTASH.KEYSET_ID = 'client2-keyset'";
+        let result = client2.query(sql, &[]).await;
+        assert!(
+            result.is_ok(),
+            "Client 2 should be able to set its own keyset_id"
+        );
+
+        // Both clients should still be able to query their data
+        let select_sql = "SELECT encrypted_text FROM encrypted WHERE id = $1";
+
+        let rows1 = query_with_client::<String>(select_sql, &client1).await;
+        assert_eq!(rows1.len(), 1);
+        assert_eq!(rows1[0], text1);
+
+        let rows2 = query_with_client::<String>(select_sql, &client2).await;
+        assert_eq!(rows2.len(), 1);
+        assert_eq!(rows2[0], text2);
+    }
+
+    ///
+    /// Tests various string literal formats for keyset_id values
+    ///
+    #[tokio::test]
+    async fn set_keyset_id_string_formats() {
+        trace();
+
+        clear().await;
+
+        let client = connect_with_tls(PROXY).await;
+
+        // Test different string literal formats
+        let test_cases = vec![
+            ("'single-quoted'", "single-quoted"),
+            ("\"double-quoted\"", "double-quoted"),
+            ("'keyset-with-dashes-123'", "keyset-with-dashes-123"),
+            (
+                "'keyset_with_underscores_456'",
+                "keyset_with_underscores_456",
+            ),
+            ("'UPPERCASE-KEYSET'", "UPPERCASE-KEYSET"),
+            ("'lowercase-keyset'", "lowercase-keyset"),
+            ("'Mixed-Case-Keyset'", "Mixed-Case-Keyset"),
+        ];
+
+        for (quoted_value, _expected_value) in test_cases {
+            let sql = format!("SET CIPHERSTASH.KEYSET_ID = {}", quoted_value);
+            let result = client.query(&sql, &[]).await;
+            assert!(
+                result.is_ok(),
+                "Setting keyset_id with {} should succeed",
+                quoted_value
+            );
+
+            // Test that operations still work after each keyset_id change
+            let id = random_id();
+            let text = format!("test data for {}", quoted_value);
+
+            let insert_sql = "INSERT INTO encrypted (id, encrypted_text) VALUES ($1, $2)";
+            let result = client.query(insert_sql, &[&id, &text]).await;
+            assert!(
+                result.is_ok(),
+                "Insert should work after setting keyset_id to {}",
+                quoted_value
+            );
+        }
+    }
+
+    ///
+    /// Tests error handling for invalid keyset_id syntax
+    ///
+    #[tokio::test]
+    async fn set_keyset_id_invalid_syntax() {
+        trace();
+
+        clear().await;
+
+        let client = connect_with_tls(PROXY).await;
+
+        // Test cases that should potentially fail or be handled gracefully
+        let invalid_cases = vec![
+            "SET CIPHERSTASH.KEYSET_ID = unquoted-value", // unquoted string
+            "SET CIPHERSTASH.KEYSET_ID = 123",            // numeric value
+            "SET CIPHERSTASH.KEYSET_ID = NULL",           // null value
+        ];
+
+        for invalid_sql in invalid_cases {
+            let result = client.query(invalid_sql, &[]).await;
+            // The proxy should either handle these gracefully or return appropriate errors
+            // We don't assert failure here as the behavior may vary based on implementation
+            println!("Result for '{}': {:?}", invalid_sql, result);
+        }
+
+        // Ensure that after invalid attempts, a valid keyset_id can still be set
+        let sql = "SET CIPHERSTASH.KEYSET_ID = 'recovery-keyset'";
+        let result = client.query(sql, &[]).await;
+        assert!(
+            result.is_ok(),
+            "Should be able to set valid keyset_id after invalid attempts"
+        );
+    }
+}

--- a/packages/cipherstash-proxy/src/config/database.rs
+++ b/packages/cipherstash-proxy/src/config/database.rs
@@ -73,7 +73,7 @@ impl DatabaseConfig {
         self.connection_timeout.map(Duration::from_millis)
     }
 
-    pub fn server_name(&self) -> Result<ServerName, Error> {
+    pub fn server_name(&self) -> Result<ServerName<'_>, Error> {
         let name = ServerName::try_from(self.host.as_str()).map_err(|_| {
             ConfigError::InvalidServerName {
                 name: self.host.to_owned(),

--- a/packages/cipherstash-proxy/src/error.rs
+++ b/packages/cipherstash-proxy/src/error.rs
@@ -227,6 +227,12 @@ pub enum EncryptError {
     #[error("Column configuration for column '{column}' in table '{table}' does not match the encrypted column. For help visit {}#encrypt-column-config-mismatch", ERROR_DOC_BASE_URL)]
     ColumnConfigurationMismatch { table: String, column: String },
 
+    #[error(
+        "Could not decrypt data for keyset '{keyset_id}'. For help visit {}#encrypt-could-not-decrypt-data-for-keyset",
+        ERROR_DOC_BASE_URL
+    )]
+    CouldNotDecryptDataForKeyset { keyset_id: String },
+
     #[error("InvalidIndexTerm")]
     InvalidIndexTerm,
 

--- a/packages/cipherstash-proxy/src/error.rs
+++ b/packages/cipherstash-proxy/src/error.rs
@@ -228,7 +228,7 @@ pub enum EncryptError {
     ColumnConfigurationMismatch { table: String, column: String },
 
     #[error(
-        "Could not decrypt data for keyset '{keyset_id}'. For help visit {}#encrypt-could-not-decrypt-data-for-keyset",
+        "Could not decrypt data using keyset '{keyset_id}'. For help visit {}#encrypt-could-not-decrypt-data-for-keyset",
         ERROR_DOC_BASE_URL
     )]
     CouldNotDecryptDataForKeyset { keyset_id: String },

--- a/packages/cipherstash-proxy/src/error.rs
+++ b/packages/cipherstash-proxy/src/error.rs
@@ -230,6 +230,12 @@ pub enum EncryptError {
     #[error("InvalidIndexTerm")]
     InvalidIndexTerm,
 
+    #[error(
+        "A keyset_id could not be set using `SET CIPHERSTASH.KEYSET_ID`. For help visit {}#encrypt-keyset-id-could-not-be-set",
+        ERROR_DOC_BASE_URL
+    )]
+    KeysetIdCouldNotBeSet,
+
     /// This should in practice be unreachable
     #[error("Missing encrypt configuration for column type `{plaintext_type}`. For help visit {}#encrypt-missing-encrypt-configuration", ERROR_DOC_BASE_URL)]
     MissingEncryptConfiguration { plaintext_type: String },

--- a/packages/cipherstash-proxy/src/postgresql/backend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/backend.rs
@@ -23,16 +23,65 @@ use bytes::BytesMut;
 use metrics::{counter, histogram};
 use std::time::Instant;
 use tokio::io::AsyncRead;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
+/// The PostgreSQL proxy backend that handles server-to-client message processing.
+///
+/// The Backend intercepts messages from PostgreSQL servers, identifies encrypted data
+/// in query results, performs batch decryption, and forwards decrypted results back to
+/// PostgreSQL clients. It implements efficient batching strategies to minimize decryption
+/// overhead and maintains proper PostgreSQL wire protocol semantics.
+///
+/// # Message Flow
+///
+/// ```text
+/// Server -> Backend -> Client
+///    |         |         |
+///    |   [Intercept]     |
+///    |   [Buffer Rows]   |
+///    |   [Batch Decrypt] |
+///    |   [Format Data]   |
+///    |         |         |
+///    +----> [Forward] ---+
+/// ```
+///
+/// # Key Responsibilities
+///
+/// - **Result Decryption**: Decrypt encrypted column values in query results
+/// - **Batch Processing**: Buffer DataRow messages for efficient batch decryption
+/// - **Format Conversion**: Convert decrypted data to appropriate PostgreSQL wire formats
+/// - **Protocol Compliance**: Maintain PostgreSQL message ordering and semantics
+/// - **Error Handling**: Process and log PostgreSQL error responses
+/// - **Metadata Management**: Handle ParameterDescription and RowDescription messages
+///
+/// # Buffering Strategy
+///
+/// DataRow messages containing encrypted data are buffered to enable batch decryption:
+/// - Buffer fills up to a configurable capacity
+/// - Flush occurs on buffer full, session end, or non-DataRow message
+/// - Batching reduces encryption API round-trips and improves performance
+///
+/// # Message Types Handled
+///
+/// - `DataRow`: Query result rows (buffered for batch decryption)
+/// - `CommandComplete`: Indicates end of query execution (triggers flush)
+/// - `ErrorResponse`: PostgreSQL error messages (logged and forwarded)
+/// - `RowDescription`: Result column metadata (modified for encrypted columns)
+/// - `ParameterDescription`: Parameter metadata (modified for encrypted parameters)
+/// - `ReadyForQuery`: Session ready state (triggers schema reload if needed)
 pub struct Backend<R>
 where
     R: AsyncRead + Unpin,
 {
+    /// Sender for outgoing messages to client
     client_sender: Sender,
+    /// Reader for incoming messages from server
     server_reader: R,
+    /// Encryption service for column decryption
     encrypt: Encrypt,
+    /// Session context with portal and statement metadata
     context: Context,
+    /// Buffer for batching DataRow messages before decryption
     buffer: MessageBuffer,
 }
 
@@ -40,6 +89,14 @@ impl<R> Backend<R>
 where
     R: AsyncRead + Unpin,
 {
+    /// Creates a new Backend instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `client_sender` - Channel sender for sending messages to the client
+    /// * `server_reader` - Stream for reading messages from the PostgreSQL server
+    /// * `encrypt` - Encryption service for handling column decryption
+    /// * `context` - Session context shared with the frontend
     pub fn new(
         client_sender: Sender,
         server_reader: R,
@@ -56,28 +113,46 @@ where
         }
     }
 
+    /// Main message processing loop for handling server messages.
     ///
-    /// An Execute phase is always terminated by the appearance of exactly one of these messages:
-    ///     CommandComplete
-    ///     EmptyQueryResponse
-    ///     ErrorResponse
-    ///     PortalSuspended
+    /// Reads messages from the PostgreSQL server, processes them based on message type,
+    /// performs decryption for encrypted result data, and forwards messages to the client.
     ///
-    /// Describe Flow
-    ///     Describe => [D1, D2]
-    ///         Get -> D1
-    ///         Handle ParameterDescription and/or RowDescription
-    ///         Complete
-    ///     Describe => [D2]
+    /// # PostgreSQL Protocol Phases
     ///
-    /// Execute Flow
-    ///     Execute [E1, E2]
-    ///        Get -> E1
-    ///        Handle DataRow
-    ///               DataRow
+    /// ## Execute Phase
+    /// Execute operations produce a stream of DataRow messages followed by exactly one of:
+    /// - `CommandComplete` - Successful completion
+    /// - `EmptyQueryResponse` - Empty query completed
+    /// - `ErrorResponse` - Error occurred
+    /// - `PortalSuspended` - Portal execution suspended (LIMIT reached)
     ///
+    /// ## Describe Phase
+    /// Describe operations return metadata about statements or portals:
+    /// - `ParameterDescription` - Parameter metadata (for statements)
+    /// - `RowDescription` - Result column metadata
+    /// - `NoData` - No result columns
     ///
+    /// # Message Processing Flow
     ///
+    /// 1. **Read Message**: Read and parse PostgreSQL wire protocol message
+    /// 2. **Check Passthrough**: Skip processing if encryption is disabled
+    /// 3. **Handle by Type**: Route to appropriate handler based on message code
+    /// 4. **Buffer Management**: Buffer DataRows, flush on completion/errors
+    /// 5. **Forward**: Send processed message to PostgreSQL client
+    ///
+    /// # Buffering Behavior
+    ///
+    /// DataRow messages are buffered for batch decryption to improve performance.
+    /// The buffer is automatically flushed when:
+    /// - Buffer reaches capacity
+    /// - Execute phase completes (CommandComplete, ErrorResponse, etc.)
+    /// - Non-DataRow message is encountered
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` on successful message processing, or an `Error` if a fatal
+    /// error occurs that should terminate the connection.
     pub async fn rewrite(&mut self) -> Result<(), Error> {
         let connection_timeout = self.encrypt.config.database.connection_timeout();
 
@@ -99,6 +174,9 @@ where
             self.write_with_flush(bytes).await?;
             return Ok(());
         }
+
+        let keyset_id = self.context.keyset_id();
+        warn!(?self.context.client_id, ?keyset_id);
 
         match code.into() {
             BackendCode::DataRow => {
@@ -178,12 +256,42 @@ where
         Ok(())
     }
 
+    /// Handles PostgreSQL ErrorResponse messages from the server.
     ///
-    /// Handle error response messages
-    /// The Frontend triggers an exception in the database for some errors
-    /// These errors are filtered here
-    /// Other Error Responses are logged and passed through
+    /// ErrorResponse messages indicate that an error occurred during SQL execution.
+    /// This handler logs the errors for debugging and monitoring purposes, then
+    /// forwards them to the client unchanged to maintain PostgreSQL compatibility.
     ///
+    /// # Error Types
+    ///
+    /// PostgreSQL can return various types of errors:
+    /// - **Syntax Errors**: Malformed SQL statements
+    /// - **Permission Errors**: Access denied to tables/columns
+    /// - **Constraint Violations**: Primary key, foreign key, etc.
+    /// - **Data Errors**: Type mismatches, invalid values
+    /// - **System Errors**: Connection issues, resource exhaustion
+    ///
+    /// # Proxy Error Integration
+    ///
+    /// Some errors may originate from proxy operations:
+    /// - Encryption/decryption failures propagated as database exceptions
+    /// - Schema validation errors from EQL mapping
+    /// - Key retrieval errors from the encryption service
+    ///
+    /// These proxy-generated errors are formatted as PostgreSQL-compatible
+    /// error responses by the frontend, so they appear as normal database
+    /// errors to maintain client compatibility.
+    ///
+    /// # Logging and Monitoring
+    ///
+    /// All errors are logged at ERROR level for debugging and recorded in
+    /// monitoring systems. This helps track both application-level issues
+    /// and proxy-specific problems.
+    ///
+    /// # Returns
+    ///
+    /// Always returns `Some(bytes)` containing the original error response
+    /// to forward to the client unchanged.
     fn error_response_handler(&mut self, bytes: &BytesMut) -> Result<Option<BytesMut>, Error> {
         let error_response = ErrorResponse::try_from(bytes)?;
         error!(msg = "PostgreSQL Error", error = ?error_response);
@@ -230,11 +338,45 @@ where
         Ok(())
     }
 
+    /// Flushes all buffered DataRow messages by performing batch decryption.
     ///
-    /// Flush all buffered DataRow messages
+    /// This is the core decryption logic that processes buffered DataRow messages,
+    /// extracts encrypted column values, performs batch decryption, and sends the
+    /// decrypted results back to the client in the proper PostgreSQL wire format.
     ///
-    /// Decrypts any configured column values and writes the decrypted values to the client
+    /// # Process Overview
     ///
+    /// 1. **Portal Validation**: Check if current portal requires decryption
+    /// 2. **Data Extraction**: Extract encrypted values from buffered DataRows
+    /// 3. **Batch Decryption**: Send all encrypted values to decryption service
+    /// 4. **Format Conversion**: Convert decrypted plaintext to PostgreSQL wire format
+    /// 5. **Result Assembly**: Reconstruct DataRows with decrypted values
+    /// 6. **Client Delivery**: Send decrypted DataRows to client
+    ///
+    /// # Portal-Based Processing
+    ///
+    /// Decryption behavior is determined by the portal associated with the current execution:
+    /// - **Encrypted Portal**: Contains column metadata for decryption
+    /// - **Passthrough Portal**: No decryption needed, should not have buffered data
+    ///
+    /// # Batch Decryption Benefits
+    ///
+    /// - **Performance**: Single API call for multiple encrypted values
+    /// - **Efficiency**: Reduces network round-trips to encryption service
+    /// - **Consistency**: All values decrypted with same keyset ID
+    ///
+    /// # Format Code Handling
+    ///
+    /// Result columns can be formatted as text or binary based on format codes
+    /// specified in the original Bind message. Decrypted values are properly
+    /// encoded according to these format specifications.
+    ///
+    /// # Error Handling
+    ///
+    /// Decryption errors (including key retrieval failures) are converted to
+    /// appropriate error responses and recorded in metrics. The error mapping
+    /// implemented in the encryption service ensures proper keyset ID context
+    /// is preserved in error messages.
     async fn flush(&mut self) -> Result<(), Error> {
         if self.buffer.is_empty() {
             debug!(target: MAPPER, client_id = self.context.client_id, msg = "Empty buffer");
@@ -282,6 +424,7 @@ where
         self.check_column_config(projection_columns, &ciphertexts)?;
 
         let keyset_id = self.context.keyset_id();
+        warn!(?keyset_id);
 
         // Decrypt CipherText -> Plaintext
         let plaintexts = self
@@ -433,10 +576,40 @@ where
         }
     }
 
+    /// Handles PostgreSQL DataRow messages containing query result data.
     ///
-    /// Handle DataRow messages
-    /// If there is no associated Portal, the row does not require decryption and can be passed through
+    /// DataRow messages contain the actual row data returned by SELECT queries.
+    /// This handler determines whether rows contain encrypted data that needs
+    /// decryption, and either buffers them for batch processing or passes them
+    /// through unchanged.
     ///
+    /// # Processing Decision
+    ///
+    /// The handler examines the portal associated with the current execution:
+    /// - **Encrypted Portal**: Rows may contain encrypted data, buffer for decryption
+    /// - **Passthrough Portal**: Rows contain no encrypted data, forward immediately
+    /// - **No Portal**: No execution context, forward immediately
+    ///
+    /// # Buffering Strategy
+    ///
+    /// Encrypted rows are added to an internal buffer rather than being processed
+    /// immediately. This enables:
+    /// - Batch decryption of multiple encrypted values
+    /// - Improved performance through reduced API calls
+    /// - Better error handling for decryption operations
+    ///
+    /// The buffer is automatically flushed when it reaches capacity or when
+    /// the query execution completes.
+    ///
+    /// # Return Value
+    ///
+    /// Returns `Ok(true)` if the row was buffered (caller should not forward),
+    /// or `Ok(false)` if the row should be forwarded unchanged by the caller.
+    ///
+    /// # Metrics
+    ///
+    /// Records metrics for both encrypted and passthrough row processing to
+    /// track proxy performance and encryption usage patterns.
     async fn data_row_handler(&mut self, bytes: &BytesMut) -> Result<bool, Error> {
         counter!(ROWS_TOTAL).increment(1);
         match self.context.get_portal_from_execute().as_deref() {

--- a/packages/cipherstash-proxy/src/postgresql/backend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/backend.rs
@@ -281,10 +281,16 @@ where
 
         self.check_column_config(projection_columns, &ciphertexts)?;
 
+        let keyset_id = self.context.keyset_id();
+
         // Decrypt CipherText -> Plaintext
-        let plaintexts = self.encrypt.decrypt(ciphertexts).await.inspect_err(|_| {
-            counter!(DECRYPTION_ERROR_TOTAL).increment(1);
-        })?;
+        let plaintexts = self
+            .encrypt
+            .decrypt(keyset_id, ciphertexts)
+            .await
+            .inspect_err(|_| {
+                counter!(DECRYPTION_ERROR_TOTAL).increment(1);
+            })?;
 
         // Avoid the iter calculation if we can
         if self.encrypt.config.prometheus_enabled() {

--- a/packages/cipherstash-proxy/src/postgresql/context/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/context/mod.rs
@@ -21,7 +21,7 @@ use std::{
     sync::{Arc, LazyLock, RwLock},
     time::{Duration, Instant},
 };
-use tracing::{debug, error};
+use tracing::debug;
 use uuid::Uuid;
 
 type DescribeQueue = Queue<Describe>;

--- a/packages/cipherstash-proxy/src/postgresql/context/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/context/mod.rs
@@ -360,7 +360,7 @@ impl Context {
                 })) = values.first()
                 {
                     let keyset_id =
-                        Uuid::parse_str(&value).map_err(|_| EncryptError::KeysetIdCouldNotBeSet)?;
+                        Uuid::parse_str(value).map_err(|_| EncryptError::KeysetIdCouldNotBeSet)?;
 
                     self.keyset_id = Some(keyset_id.to_owned());
                     return Ok(Some(keyset_id.to_owned()));

--- a/packages/cipherstash-proxy/src/postgresql/error_handler.rs
+++ b/packages/cipherstash-proxy/src/postgresql/error_handler.rs
@@ -1,0 +1,86 @@
+/// Shared error handling functionality for PostgreSQL protocol components.
+///
+/// This trait provides consistent error handling between frontend and backend
+/// components, ensuring that all errors are properly converted to PostgreSQL
+/// ErrorResponse messages and sent to clients in a protocol-compliant manner.
+use crate::{
+    connect::Sender,
+    error::{EncryptError, Error},
+    postgresql::messages::error_response::ErrorResponse,
+};
+use bytes::BytesMut;
+use tracing::debug;
+
+/// Trait for components that can send PostgreSQL error responses to clients.
+///
+/// This trait abstracts the common error handling patterns used by both
+/// frontend and backend components, providing consistent error conversion
+/// and client communication.
+pub trait PostgreSqlErrorHandler {
+    /// Get the client sender for this component
+    fn client_sender(&mut self) -> &mut Sender;
+
+    /// Get the client ID for logging purposes
+    fn client_id(&self) -> i32;
+
+    /// Convert various error types into appropriate PostgreSQL ErrorResponse messages.
+    ///
+    /// # Error Type Mapping
+    ///
+    /// - `MappingError` -> InvalidSqlStatement error
+    /// - `EncryptError::UnknownColumn` -> Unknown column error
+    /// - `EncryptError::CouldNotRetrieveKey` -> Key retrieval error
+    /// - All others -> System error
+    ///
+    /// # Arguments
+    ///
+    /// * `err` - The error to be converted to a PostgreSQL ErrorResponse
+    fn error_to_response(&self, err: Error) -> ErrorResponse {
+        match err {
+            Error::Mapping(err) => ErrorResponse::invalid_sql_statement(err.to_string()),
+            Error::Encrypt(EncryptError::UnknownColumn {
+                ref table,
+                ref column,
+            }) => ErrorResponse::unknown_column(err.to_string(), table, column),
+            Error::Encrypt(EncryptError::CouldNotDecryptDataForKeyset { .. }) => {
+                ErrorResponse::system_error(err.to_string())
+            }
+            _ => ErrorResponse::system_error(err.to_string()),
+        }
+    }
+
+    /// Send an ErrorResponse message to the client.
+    ///
+    /// Converts the ErrorResponse to PostgreSQL wire format and sends it
+    /// to the client via the component's sender channel.
+    ///
+    /// # Arguments
+    ///
+    /// * `error_response` - The ErrorResponse to send to the client
+    fn send_error_response(&mut self, error_response: ErrorResponse) -> Result<(), Error> {
+        let message = BytesMut::try_from(error_response)?;
+
+        debug!(
+            target: "PROTOCOL",
+            client_id = self.client_id(),
+            msg = "send_error_response",
+            ?message,
+        );
+
+        self.client_sender().send(message)?;
+        Ok(())
+    }
+
+    /// Handle an error by converting it to a PostgreSQL ErrorResponse and sending to client.
+    ///
+    /// This is the main error handling entry point that combines error conversion
+    /// and client communication.
+    ///
+    /// # Arguments
+    ///
+    /// * `err` - The error to handle
+    fn handle_error(&mut self, err: Error) -> Result<(), Error> {
+        let error_response = self.error_to_response(err);
+        self.send_error_response(error_response)
+    }
+}

--- a/packages/cipherstash-proxy/src/postgresql/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/frontend.rs
@@ -277,7 +277,10 @@ where
             if let Some(mapping_disabled) =
                 self.context.maybe_set_unsafe_disable_mapping(&statement)
             {
-                warn!("SET CIPHERSTASH.DISABLE_MAPPING" = mapping_disabled);
+                warn!(
+                    msg = "SET CIPHERSTASH.DISABLE_MAPPING = {mapping_disabled}",
+                    mapping_disabled
+                );
             }
 
             if self.context.unsafe_disable_mapping() {
@@ -285,6 +288,10 @@ where
                 counter!(STATEMENTS_PASSTHROUGH_MAPPING_DISABLED_TOTAL).increment(1);
                 counter!(STATEMENTS_PASSTHROUGH_TOTAL).increment(1);
                 continue;
+            }
+
+            if let Some(keyset_id) = self.context.maybe_set_keyset_id(&statement)? {
+                warn!(msg = "SET CIPHERSTASH.KEYSET_ID = {keyset_id}", keyset_id);
             }
 
             self.check_for_schema_change(&statement);
@@ -501,7 +508,10 @@ where
         let statement = self.parse_statement(&message.statement)?;
 
         if let Some(mapping_disabled) = self.context.maybe_set_unsafe_disable_mapping(&statement) {
-            warn!("SET CIPHERSTASH.DISABLE_MAPPING" = mapping_disabled);
+            warn!(
+                msg = "SET CIPHERSTASH.DISABLE_MAPPING = {mapping_disabled}",
+                mapping_disabled
+            );
         }
 
         if self.context.unsafe_disable_mapping() {
@@ -509,6 +519,10 @@ where
             counter!(STATEMENTS_PASSTHROUGH_MAPPING_DISABLED_TOTAL).increment(1);
             counter!(STATEMENTS_PASSTHROUGH_TOTAL).increment(1);
             return Ok(None);
+        }
+
+        if let Some(keyset_id) = self.context.maybe_set_keyset_id(&statement)? {
+            warn!(msg = "SET CIPHERSTASH.KEYSET_ID = {keyset_id}", keyset_id);
         }
 
         self.check_for_schema_change(&statement);

--- a/packages/cipherstash-proxy/src/postgresql/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/mod.rs
@@ -1,6 +1,7 @@
 mod backend;
 mod context;
 mod data;
+mod error_handler;
 mod format_code;
 mod frontend;
 mod handler;

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -68,6 +68,7 @@ services:
       - CS_LOG__LEVEL=${CS_LOG__LEVEL:-debug}
       - CS_LOG__PROTOCOL_LEVEL=${CS_LOG__PROTOCOL_LEVEL:-debug}
       - CS_LOG__MAPPER_LEVEL=${CS_LOG__MAPPER_LEVEL:-debug}
+      - CS_LOG__CONTEXT_LEVEL=${CS_LOG__CONTEXT_LEVEL:-debug}
     networks:
       - postgres
     deploy:
@@ -103,7 +104,11 @@ services:
       - CS_SERVER__REQUIRE_TLS=true
       - CS_PROMETHEUS__ENABLED=${CS_PROMETHEUS__ENABLED:-true}
       - CS_WORKSPACE_CRN=${CS_WORKSPACE_CRN}
-
+      - CS_LOG__FORMAT=${CS_LOG__FORMAT:-pretty}
+      - CS_LOG__LEVEL=${CS_LOG__LEVEL:-debug}
+      - CS_LOG__PROTOCOL_LEVEL=${CS_LOG__PROTOCOL_LEVEL:-debug}
+      - CS_LOG__MAPPER_LEVEL=${CS_LOG__MAPPER_LEVEL:-debug}
+      - CS_LOG__CONTEXT_LEVEL=${CS_LOG__CONTEXT_LEVEL:-debug}
     volumes:
       - ./tls/server.cert:/etc/cipherstash-proxy/server.cert
       - ./tls/server.key:/etc/cipherstash-proxy/server.key


### PR DESCRIPTION
The Proxy should expose a `SET` command that enables run-time configuration of a `keyset_id`: 

```
SET CIPHERSTASH.KEYSET_ID = 'EXAMPLE-UUID-4b38-9571-e0cf47802677'
```

- [x] Parse set command
- [x] Parse keyset as UUID if defined  
- [x] Set keyset_id if defined
- [x] Error if set command but value cannot be parsed 
- [x] Update error docs with syntax details 
- [x] Extract zerokms initalisation 
- [x] Enable cipher initalisation to accept keyset_id 
- [x] Pass keyset_id when encrypting or decrypting
- [x] Handle decrypt errors
- [x] Refactor to extract error handling from frontend into common module
- [x] Update backend to send decrypt errors as pg errors



