### PR TITLE
chore: PR_BYPASS upgrade eql to 2.1.8

### DIFF
--- a/mise.local.example.toml
+++ b/mise.local.example.toml
@@ -15,7 +15,7 @@ CS_CLIENT_KEY = "client-key"
 CS_CLIENT_ID = "client-id"
 
 # The release of EQL that the proxy tests will use and releases will be built with
-CS_EQL_VERSION="eql-2.1.6"
+CS_EQL_VERSION = "eql-2.1.8"
 
 # TLS variables are required for providing TLS to Proxy's clients.
 # CS_TLS__TYPE can be either "Path" or "Pem" (case-sensitive).

--- a/mise.toml
+++ b/mise.toml
@@ -31,7 +31,7 @@ CS_PROXY__HOST = "proxy"
 # Misc
 DOCKER_CLI_HINTS = "false" # Please don't show us What's Next.
 
-CS_EQL_VERSION = "eql-2.1.6"
+CS_EQL_VERSION = "eql-2.1.8"
 
 
 [tools]


### PR DESCRIPTION
<!-- Please provide a summary of what's being changed -->

Upgrade Proxy to use EQL 2.1.8.

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
