### PR TITLE
Send deployment notification to multitudes 

### DIFF
--- a/.github/workflows/release-aws-marketplace.yml
+++ b/.github/workflows/release-aws-marketplace.yml
@@ -105,4 +105,12 @@ jobs:
         run: |
           mise run release:aws-marketplace
 
+      - name: Notify Multitudes
+        run: |
+          curl --request POST \
+            --fail-with-body \
+            --url "https://api.developer.multitudes.co/deployments" \
+            --header "Content-Type: application/json" \
+            --header "Authorization: ${{ secrets.MULTITUDES_ACCESS_TOKEN }}" \
+            --data '{"commitSha": "${{ github.sha }}", "environmentName":"marketplace"}'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,3 +128,12 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+
+      - name: Notify Multitudes
+        run: |
+          curl --request POST \
+            --fail-with-body \
+            --url "https://api.developer.multitudes.co/deployments" \
+            --header "Content-Type: application/json" \
+            --header "Authorization: ${{ secrets.MULTITUDES_ACCESS_TOKEN }}" \
+            --data '{"commitSha": "${{ github.sha }}", "environmentName":"dockerhub"}'

--- a/packages/cipherstash-proxy-integration/src/map_ore_index_where.rs
+++ b/packages/cipherstash-proxy-integration/src/map_ore_index_where.rs
@@ -73,7 +73,14 @@ mod tests {
 
         // GT: given [1, 3], `> 1` returns [3]
         let sql = format!("SELECT {col_name} FROM encrypted WHERE {col_name} > $1");
-        test_ore_op(&client, col_name, &sql, &[&low], &[high.clone()]).await;
+        test_ore_op(
+            &client,
+            col_name,
+            &sql,
+            &[&low],
+            std::slice::from_ref(&high),
+        )
+        .await;
 
         // GT 2nd case: given [1, 3], `> 3` returns []
         let sql = format!("SELECT {col_name} FROM encrypted WHERE {col_name} > $1");
@@ -81,7 +88,14 @@ mod tests {
 
         // LT: given [1, 3], `< 3` returns [1]
         let sql = format!("SELECT {col_name} FROM encrypted WHERE {col_name} < $1");
-        test_ore_op(&client, col_name, &sql, &[&high], &[low.clone()]).await;
+        test_ore_op(
+            &client,
+            col_name,
+            &sql,
+            &[&high],
+            std::slice::from_ref(&low),
+        )
+        .await;
 
         // LT 2nd case: given [1, 3], `< 3` returns []
         let sql = format!("SELECT {col_name} FROM encrypted WHERE {col_name} < $1");
@@ -116,11 +130,18 @@ mod tests {
 
         // EQ: given [1, 3], `= 1` returns [1]
         let sql = format!("SELECT {col_name} FROM encrypted WHERE {col_name} = $1");
-        test_ore_op(&client, col_name, &sql, &[&low], &[low.clone()]).await;
+        test_ore_op(&client, col_name, &sql, &[&low], std::slice::from_ref(&low)).await;
 
         // NEQ: given [1, 3], `<> 3` returns [1]
         let sql = format!("SELECT {col_name} FROM encrypted WHERE {col_name} <> $1");
-        test_ore_op(&client, col_name, &sql, &[&high], &[low.clone()]).await;
+        test_ore_op(
+            &client,
+            col_name,
+            &sql,
+            &[&high],
+            std::slice::from_ref(&low),
+        )
+        .await;
     }
 
     /// Runs the query and checks the returned results match the expected results.

--- a/packages/cipherstash-proxy/src/config/database.rs
+++ b/packages/cipherstash-proxy/src/config/database.rs
@@ -73,7 +73,7 @@ impl DatabaseConfig {
         self.connection_timeout.map(Duration::from_millis)
     }
 
-    pub fn server_name(&self) -> Result<ServerName, Error> {
+    pub fn server_name(&self) -> Result<ServerName<'_>, Error> {
         let name = ServerName::try_from(self.host.as_str()).map_err(|_| {
             ConfigError::InvalidServerName {
                 name: self.host.to_owned(),

--- a/packages/cipherstash-proxy/src/config/server.rs
+++ b/packages/cipherstash-proxy/src/config/server.rs
@@ -65,7 +65,7 @@ impl ServerConfig {
         }
     }
 
-    pub fn server_name(&self) -> Result<ServerName, Error> {
+    pub fn server_name(&self) -> Result<ServerName<'_>, Error> {
         let name = ServerName::try_from(self.host.as_str()).map_err(|_| {
             ConfigError::InvalidServerName {
                 name: self.host.to_owned(),

--- a/packages/eql-mapper/src/inference/unifier/types.rs
+++ b/packages/eql-mapper/src/inference/unifier/types.rs
@@ -646,15 +646,3 @@ impl From<Array> for Type {
         Type::Value(Value::Array(array))
     }
 }
-
-// Statically assert that `Type` is `Send + Sync`.  If `Type` did not implement `Send` and/or `Sync` this crate would
-// fail to compile anyway but the error message is very obtuse. A failure here makes it obvious.
-const _: () = {
-    fn assert_send<T: Send>() {}
-    fn assert_sync<T: Sync>() {}
-
-    fn assert_all() {
-        assert_send::<Type>();
-        assert_sync::<Type>();
-    }
-};

--- a/packages/eql-mapper/src/type_checked_statement.rs
+++ b/packages/eql-mapper/src/type_checked_statement.rs
@@ -149,7 +149,7 @@ impl<'ast> TypeCheckedStatement<'ast> {
     fn make_transformer(
         &self,
         encrypted_literals: HashMap<NodeKey<'ast>, sqltk::parser::ast::Value>,
-    ) -> DryRunnable<impl TransformationRule<'_>> {
+    ) -> DryRunnable<'_, impl TransformationRule<'_>> {
         DryRunnable::new((
             RewriteStandardSqlFnsOnEqlTypes::new(Arc::clone(&self.node_types)),
             PreserveEffectiveAliases,


### PR DESCRIPTION
Add calls to deployment API on container release.

Call in `test.yml` is to verify that the call works, will removed before merge. 