### PR TITLE
refactor: ♻️ use std::mem::size_of for accurate cipher cache sizing

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -258,6 +258,55 @@ As a convenience for production deployments, with the below environment variable
 CS_DATABASE__INSTALL_AWS_RDS_CERT_BUNDLE="true"
 ```
 
+## Multitenant
+
+CipherStash Proxy supports multitenant applications by allowing clients to switch between different keysets at runtime. This enables a single Proxy instance to handle encrypted data for multiple tenants, with each tenant's data protected by separate encryption keys.
+
+### Keyset Commands
+
+#### SET CIPHERSTASH.KEYSET_ID
+
+Sets the active keyset for the current connection using a keyset UUID.
+
+**Syntax:**
+```sql
+SET CIPHERSTASH.KEYSET_ID = '<keyset-uuid>';
+```
+
+**Parameters:**
+- `keyset-uuid`: The UUID of the keyset to activate for this connection
+
+**Example:**
+```sql
+SET CIPHERSTASH.KEYSET_ID = '2cace9db-3a2a-4b46-a184-ba412b3e0730';
+```
+
+#### SET CIPHERSTASH.KEYSET_NAME
+
+Sets the active keyset for the current connection using a keyset name.
+
+**Syntax:**
+```sql
+SET CIPHERSTASH.KEYSET_NAME = '<keyset-name>';
+```
+
+**Parameters:**
+- `keyset-name`: The name of the keyset to activate for this connection
+
+**Example:**
+```sql
+SET CIPHERSTASH.KEYSET_NAME = 'tenant-1';
+```
+
+### Usage Notes
+
+- These commands must be executed before performing any encrypted operations
+- The keyset remains active for the duration of the connection
+- If a default keyset is configured in the Proxy, these commands cannot be used and will return an error
+- Each tenant should use a separate database connection with their own keyset
+- Keyset switching is connection-scoped and does not affect other connections
+
+
 
 ## Disabling encrypted mapping
 Transforming SQL statements is core to how CipherStash Proxy works.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -258,11 +258,22 @@ As a convenience for production deployments, with the below environment variable
 CS_DATABASE__INSTALL_AWS_RDS_CERT_BUNDLE="true"
 ```
 
-## Multitenant
+## Multitenant operation
 
-CipherStash Proxy supports multitenant applications by allowing clients to switch between different keysets at runtime. This enables a single Proxy instance to handle encrypted data for multiple tenants, with each tenant's data protected by separate encryption keys.
+CipherStash Proxy supports multitenant applications using ZeroKMS keysets to provide strong cryptographic separation between tenants.
 
-### Keyset Commands
+In multitenant operation, tenants are associated with a keyset, and data is protected by separate encryption keys. Data access through the proxy can be scoped to a specific keyset at runtime using the `SET CIPHERSTASH.KEYSET` SQL commands:
+  - `SET CIPHERSTASH.KEYSET_ID`
+  - `SET CIPHERSTASH.KEYSET_NAME`
+
+The `SET CIPHERSTASH.KEYSET` commands enable a proxy connection to be scoped to a keyset by `id` or `name`. Once a keyset has been set for a connection, subsequent operations are scoped to that keyset. Data can only be decrypted by the same keyset that performed the encryption.
+
+ A keyset `name` is unique to a workspace, and functions like an alias. Using a keyset `name` enables the keyset to be associated with an arbitrary identifier such as an internal `TenantId`. Use of a `name` is optional, and the actual `id`
+
+The proxy must be configured *without* a `DEFAULT_KEYSET_ID` to enable multitenant operation and the use of the `SET KEYSET` commands.
+
+
+### Keyset commands
 
 #### SET CIPHERSTASH.KEYSET_ID
 
@@ -298,14 +309,12 @@ SET CIPHERSTASH.KEYSET_NAME = '<keyset-name>';
 SET CIPHERSTASH.KEYSET_NAME = 'tenant-1';
 ```
 
-### Usage Notes
+### Usage notes
 
-- These commands must be executed before performing any encrypted operations
-- The keyset remains active for the duration of the connection
-- If a default keyset is configured in the Proxy, these commands cannot be used and will return an error
-- Each tenant should use a separate database connection with their own keyset
-- Keyset switching is connection-scoped and does not affect other connections
-
+- The `SET CIPHERSTASH.KEYSET` commands must be executed before performing any encryption operations
+- The keyset remains active for the duration of the connection, or until a subsequent `SET CIPHERSTASH.KEYSET`
+- If a default keyset is configured in the Proxy, these commands cannot be used, and will return an error
+- The active keyset is connection-scoped and does not affect other connections
 
 
 ## Disabling encrypted mapping


### PR DESCRIPTION
Replace hardcoded 3KB estimate with actual ScopedCipher struct size calculation:
- Add SCOPED_CIPHER_SIZE constant using std::mem::size_of
- Update cache weigher to use accurate size (~56 bytes vs 3KB estimate)
- Update max_capacity calculation to match weigher
- Improves cache efficiency by allowing ~50x more entries with same memory footprint

