### PR TITLE
♻️ refactor: convert Name struct to enum and extract to own module

### DIFF
--- a/packages/cipherstash-proxy/src/postgresql/messages/bind.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/bind.rs
@@ -227,10 +227,10 @@ impl TryFrom<&BytesMut> for Bind {
         let _len = cursor.get_i32();
 
         let portal = cursor.read_string()?;
-        let portal = Name(portal);
+        let portal = Name::from(portal);
 
         let prepared_statement = cursor.read_string()?;
-        let prepared_statement = Name(prepared_statement);
+        let prepared_statement = Name::from(prepared_statement);
 
         let num_param_format_codes = cursor.get_i16();
         let mut param_format_codes = Vec::new();

--- a/packages/cipherstash-proxy/src/postgresql/messages/describe.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/describe.rs
@@ -32,29 +32,6 @@ pub(crate) struct Describe {
     pub name: Name,
 }
 
-///
-/// The target of the describe message.
-///
-/// Valid values are PreparedStatment or Portal
-///
-/// A Portal is a parsed statement PLUS any bound parameters
-/// Describe with `Target::Portal` returns the RowDescription describing the result set.
-/// The assuumption is that the parameters are already bound to the portal, so the Describe message is not required to include any parameter information.
-///
-/// Calls to Execute are made on a Portal (not a prepared statement) as execute requires any bound parameters
-///
-/// A PreparedStatement is the parsed statement
-/// Describe with `Target::PreparedStatement` returns a ParameterDescription followed by the RowDescription.
-///
-///
-/// See https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
-///
-#[derive(Debug, Clone)]
-pub enum Target {
-    Portal,
-    PreparedStatement,
-}
-
 impl TryFrom<&BytesMut> for Describe {
     type Error = Error;
 
@@ -74,7 +51,7 @@ impl TryFrom<&BytesMut> for Describe {
         let target = cursor.get_u8();
         let target = Target::try_from(target)?;
         let name = cursor.read_string()?;
-        let name = Name(name);
+        let name = Name::from(name);
 
         Ok(Describe { target, name })
     }
@@ -86,7 +63,7 @@ impl TryFrom<Describe> for BytesMut {
     fn try_from(describe: Describe) -> Result<BytesMut, Error> {
         let mut bytes = BytesMut::new();
 
-        let name = CString::new(describe.name.0.as_str())?;
+        let name = CString::new(describe.name.as_str())?;
         let name = name.as_bytes_with_nul();
 
         let len = SIZE_I32 + SIZE_U8 + name.len();
@@ -97,17 +74,5 @@ impl TryFrom<Describe> for BytesMut {
         bytes.put_slice(name);
 
         Ok(bytes)
-    }
-}
-
-impl TryFrom<u8> for Target {
-    type Error = Error;
-
-    fn try_from(t: u8) -> Result<Target, Error> {
-        match t as char {
-            'S' => Ok(Target::PreparedStatement),
-            'P' => Ok(Target::Portal),
-            t => Err(ProtocolError::UnexpectedDescribeTarget(t).into()),
-        }
     }
 }

--- a/packages/cipherstash-proxy/src/postgresql/messages/execute.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/execute.rs
@@ -29,7 +29,7 @@ impl TryFrom<&BytesMut> for Execute {
         let _len = cursor.get_i32(); // read and progress cursor
 
         let portal = cursor.read_string()?;
-        let portal = Name(portal);
+        let portal = Name::from(portal);
         let max_rows = cursor.get_i32();
 
         Ok(Execute { portal, max_rows })

--- a/packages/cipherstash-proxy/src/postgresql/messages/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/mod.rs
@@ -6,12 +6,17 @@ pub mod data_row;
 pub mod describe;
 pub mod error_response;
 pub mod execute;
+pub mod name;
 pub mod param_description;
 pub mod parse;
 pub mod query;
 pub mod ready_for_query;
 pub mod row_description;
 pub mod terminate;
+
+// Re-export commonly used types
+pub use name::Name;
+pub use target::Target;
 
 pub const NULL: i32 = -1;
 

--- a/packages/cipherstash-proxy/src/postgresql/messages/name.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/name.rs
@@ -1,0 +1,50 @@
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub enum Name {
+    Named(String),
+    Unnamed,
+}
+
+impl Name {
+    pub fn unnamed() -> Name {
+        Name::Unnamed
+    }
+
+    pub fn is_unnamed(&self) -> bool {
+        matches!(self, Name::Unnamed)
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Name::Named(s) => s,
+            Name::Unnamed => "",
+        }
+    }
+}
+
+impl std::ops::Deref for Name {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl From<String> for Name {
+    fn from(s: String) -> Self {
+        if s.is_empty() {
+            Name::Unnamed
+        } else {
+            Name::Named(s)
+        }
+    }
+}
+
+impl From<&str> for Name {
+    fn from(s: &str) -> Self {
+        if s.is_empty() {
+            Name::Unnamed
+        } else {
+            Name::Named(s.to_string())
+        }
+    }
+}

--- a/packages/cipherstash-proxy/src/postgresql/messages/parse.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/parse.rs
@@ -62,7 +62,7 @@ impl TryFrom<&BytesMut> for Parse {
 
         let _len = cursor.get_i32();
         let name = cursor.read_string()?;
-        let name = Name(name);
+        let name = Name::from(name);
 
         let statement = cursor.read_string()?;
         let num_params = cursor.get_i16();
@@ -89,7 +89,7 @@ impl TryFrom<Parse> for BytesMut {
     fn try_from(parse: Parse) -> Result<BytesMut, Error> {
         let mut bytes = BytesMut::new();
 
-        let name = CString::new(parse.name.0.as_str())?;
+        let name = CString::new(parse.name.as_str())?;
         let name = name.as_bytes_with_nul();
 
         let statement = CString::new(parse.statement)?;


### PR DESCRIPTION
- Convert Name from struct to enum with Named(String) and Unnamed variants
- Extract Name type into dedicated name.rs module for better organization
- Add From<String> and From<&str> implementations for convenient construction
- Update all usage sites to use Name::from() constructor
- Update field access from .0 to .as_str() method
- Maintain backward compatibility through re-exports and Deref trait
- Improve type safety by preventing empty named statements
