### PR TITLE
refactor: split statement handling in connection Context #310

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,9 +37,3 @@ jobs:
           RUST_BACKTRACE: "1"
         run: |
           mise run --output prefix test
-
-      # Always show the Proxy logs, for debugging
-      - name: Show Proxy logs
-        if: always()
-        run: |
-          docker logs --timestamps proxy-tls

--- a/packages/cipherstash-proxy/src/postgresql/context/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/context/mod.rs
@@ -264,7 +264,7 @@ impl Context {
             } => self.get_portal_statement(name),
             Describe {
                 ref name,
-                target: Target::PreparedStatement,
+                target: Target::Statement,
             } => self.get_statement(name),
         }
     }
@@ -583,7 +583,7 @@ mod tests {
     use crate::{
         config::LogConfig,
         log,
-        postgresql::messages::{describe::Target, Name},
+        postgresql::messages::{Name, Target},
     };
     use cipherstash_client::IdentifiedBy;
     use eql_mapper::Schema;
@@ -629,7 +629,7 @@ mod tests {
 
         let describe = Describe {
             name,
-            target: Target::PreparedStatement,
+            target: Target::Statement,
         };
         context.set_describe(describe);
 

--- a/packages/cipherstash-proxy/src/postgresql/context/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/context/mod.rs
@@ -714,7 +714,7 @@ mod tests {
 
         let mut context = Context::new(1, schema);
 
-        let name = Name("name".to_string());
+        let name = Name::from("name");
 
         context.add_statement(&name, statement());
 
@@ -739,8 +739,8 @@ mod tests {
 
         let mut context = Context::new(1, schema);
 
-        let statement_name = Name("statement".to_string());
-        let portal_name = Name("portal".to_string());
+        let statement_name = Name::from("statement");
+        let portal_name = Name::from("portal");
 
         // Add statement to context
         context.add_statement(&statement_name, statement());
@@ -781,8 +781,8 @@ mod tests {
         let mut context = Context::new(1, schema);
 
         // Create multiple statements
-        let statement_name_1 = Name("statement_1".to_string());
-        let statement_name_2 = Name("statement_2".to_string());
+        let statement_name_1 = Name::from("statement_1");
+        let statement_name_2 = Name::from("statement_2");
 
         // Add statements to context
         context.add_statement(&statement_name_1, statement());
@@ -791,7 +791,7 @@ mod tests {
         // Replicate pipelined execution
         // Add multiple portals with the same name
         // Pointing to different statements
-        let portal_name = Name("portal".to_string());
+        let portal_name = Name::from("portal");
 
         let statement_1 = context.get_statement(&statement_name_1).unwrap();
         context.add_portal(portal_name.clone(), portal(&statement_1));
@@ -830,14 +830,14 @@ mod tests {
 
         let mut context = Context::new(1, schema);
 
-        let statement_name_1 = Name("statement_1".to_string());
+        let statement_name_1 = Name::from("statement_1");
         let portal_name_1 = Name::unnamed();
 
-        let statement_name_2 = Name("statement_2".to_string());
+        let statement_name_2 = Name::from("statement_2");
         let portal_name_2 = Name::unnamed();
 
-        let statement_name_3 = Name("statement_3".to_string());
-        let portal_name_3 = Name("portal_3".to_string());
+        let statement_name_3 = Name::from("statement_3");
+        let portal_name_3 = Name::from("portal_3");
 
         // Add statement to context
         context.add_statement(&statement_name_1, statement());
@@ -1178,8 +1178,8 @@ mod tests {
         assert!(retrieved5.is_none());
 
         // Test named statements (go to prepared_statements)
-        let named_name1 = Name("stmt1".to_string());
-        let named_name2 = Name("stmt2".to_string());
+        let named_name1 = Name::from("stmt1");
+        let named_name2 = Name::from("stmt2");
         let named_statement1 = statement();
         let named_statement2 = statement();
 

--- a/packages/cipherstash-proxy/src/postgresql/encryption/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/encryption/mod.rs
@@ -1,0 +1,3 @@
+pub mod service;
+
+pub use service::EncryptionService;

--- a/packages/cipherstash-proxy/src/postgresql/encryption/service.rs
+++ b/packages/cipherstash-proxy/src/postgresql/encryption/service.rs
@@ -1,0 +1,232 @@
+use crate::encrypt::Encrypt;
+use crate::error::{Error, MappingError};
+use crate::log::{CONTEXT, MAPPER};
+use crate::postgresql::context::{column::Column, KeysetIdentifier, Statement};
+use crate::postgresql::data::literal_from_sql;
+use crate::postgresql::mapping::ColumnMapper;
+use crate::postgresql::messages::bind::Bind;
+use crate::prometheus::{
+    ENCRYPTED_VALUES_TOTAL, ENCRYPTION_DURATION_SECONDS, ENCRYPTION_ERROR_TOTAL,
+    ENCRYPTION_REQUESTS_TOTAL,
+};
+use crate::EqlEncrypted;
+use cipherstash_client::encryption::Plaintext;
+use eql_mapper::{EqlTerm, TypeCheckedStatement};
+use metrics::{counter, histogram};
+use sqltk::parser::ast;
+use std::time::Instant;
+use tracing::debug;
+
+/// Encryption service for handling encrypted operations on SQL data.
+///
+/// Provides methods for encrypting parameter values, literal values, and
+/// creating encryptable statements with proper column configurations.
+pub struct EncryptionService<'a> {
+    encrypt: &'a Encrypt,
+    keyset_id: Option<KeysetIdentifier>,
+}
+
+impl<'a> EncryptionService<'a> {
+    /// Create a new EncryptionService with access to encryption configuration.
+    pub fn new(encrypt: &'a Encrypt, keyset_id: Option<KeysetIdentifier>) -> Self {
+        Self { encrypt, keyset_id }
+    }
+
+    /// Encrypt literal values from a typed SQL statement.
+    ///
+    /// # Arguments
+    ///
+    /// * `typed_statement` - Type-checked statement containing literals
+    /// * `literal_columns` - Column configurations for each literal
+    ///
+    /// # Returns
+    ///
+    /// Vector of encrypted values corresponding to each literal, with `None` for
+    /// literals that don't require encryption and `Some(EqlEncrypted)` for encrypted values.
+    pub async fn encrypt_literals(
+        &self,
+        typed_statement: &TypeCheckedStatement<'_>,
+        literal_columns: &Vec<Option<Column>>,
+    ) -> Result<Vec<Option<EqlEncrypted>>, Error> {
+        let literal_values = typed_statement.literal_values();
+        if literal_values.is_empty() {
+            debug!(target: MAPPER,
+                msg = "No literals to encrypt"
+            );
+            return Ok(vec![]);
+        }
+
+        let plaintexts = self.literals_to_plaintext(literal_values, literal_columns)?;
+
+        let start = Instant::now();
+
+        let encrypted = self
+            .encrypt
+            .encrypt(self.keyset_id.clone(), plaintexts, literal_columns)
+            .await
+            .inspect_err(|_| {
+                counter!(ENCRYPTION_ERROR_TOTAL).increment(1);
+            })?;
+
+        debug!(target: MAPPER,
+            ?literal_columns,
+            ?encrypted,
+            "Encrypted literals"
+        );
+
+        counter!(ENCRYPTION_REQUESTS_TOTAL).increment(1);
+        counter!(ENCRYPTED_VALUES_TOTAL).increment(encrypted.len() as u64);
+
+        let duration = Instant::now().duration_since(start);
+        histogram!(ENCRYPTION_DURATION_SECONDS).record(duration);
+
+        Ok(encrypted)
+    }
+
+    /// Encrypt parameter values for bind operations.
+    ///
+    /// # Arguments
+    ///
+    /// * `bind` - Bind message containing parameter values
+    /// * `statement` - Statement containing column configurations and param types
+    ///
+    /// # Returns
+    ///
+    /// Vector of encrypted parameter values with `None` for non-encrypted params.
+    ///
+    /// # Notes
+    ///
+    /// Bind holds the params.
+    /// Statement holds the column configuration and param types.
+    ///
+    /// Params are converted to plaintext using the column configuration and any `postgres_param_types` specified on Parse.
+    pub async fn encrypt_params(
+        &self,
+        bind: &Bind,
+        statement: &Statement,
+    ) -> Result<Vec<Option<crate::EqlEncrypted>>, Error> {
+        let plaintexts =
+            bind.to_plaintext(&statement.param_columns, &statement.postgres_param_types)?;
+
+        debug!(target: MAPPER, plaintexts = ?plaintexts);
+        debug!(target: CONTEXT,
+            keyset_id = ?self.keyset_id,
+        );
+
+        let start = Instant::now();
+
+        let encrypted = self
+            .encrypt
+            .encrypt(self.keyset_id.clone(), plaintexts, &statement.param_columns)
+            .await
+            .inspect_err(|_| {
+                counter!(ENCRYPTION_ERROR_TOTAL).increment(1);
+            })?;
+
+        // Avoid the iter calculation if we can
+        if self.encrypt.config.prometheus_enabled() {
+            let encrypted_count = encrypted.iter().filter(|e| e.is_some()).count() as u64;
+
+            counter!(ENCRYPTION_REQUESTS_TOTAL).increment(1);
+            counter!(ENCRYPTED_VALUES_TOTAL).increment(encrypted_count);
+
+            let duration = Instant::now().duration_since(start);
+            histogram!(ENCRYPTION_DURATION_SECONDS).record(duration);
+        }
+
+        Ok(encrypted)
+    }
+
+    /// Create an encryptable statement from a type-checked statement.
+    ///
+    /// # Arguments
+    ///
+    /// * `typed_statement` - Type-checked statement with EQL operations
+    /// * `param_types` - PostgreSQL parameter types from Parse message
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(Statement)` if the statement contains encrypted operations,
+    /// or `None` if no encryption is required.
+    ///
+    /// # Notes
+    ///
+    /// Creates a Statement from an EQL Mapper Typed Statement.
+    /// Returned Statement contains the Column configuration for any encrypted columns in params, literals and projection.
+    /// Returns `None` if the Statement is not Encryptable.
+    pub fn to_encryptable_statement(
+        &self,
+        typed_statement: &TypeCheckedStatement<'_>,
+        param_types: Vec<i32>,
+    ) -> Result<Option<Statement>, Error> {
+        let column_mapper = ColumnMapper::new(self.encrypt);
+        let param_columns = column_mapper.get_param_columns(typed_statement)?;
+        let projection_columns = column_mapper.get_projection_columns(typed_statement)?;
+        let literal_columns = column_mapper.get_literal_columns(typed_statement)?;
+
+        let no_encrypted_param_columns = param_columns.iter().all(|c| c.is_none());
+        let no_encrypted_projection_columns = projection_columns.iter().all(|c| c.is_none());
+
+        if (param_columns.is_empty() || no_encrypted_param_columns)
+            && (projection_columns.is_empty() || no_encrypted_projection_columns)
+            && !typed_statement.requires_transform()
+        {
+            return Ok(None);
+        }
+
+        debug!(target: MAPPER,
+            msg = "Encryptable Statement",
+            param_columns = ?param_columns,
+            projection_columns = ?projection_columns,
+            literal_columns = ?literal_columns,
+        );
+
+        let statement = Statement::new(
+            param_columns.to_owned(),
+            projection_columns.to_owned(),
+            literal_columns.to_owned(),
+            param_types,
+        );
+
+        Ok(Some(statement))
+    }
+
+    /// Convert SQL literal values to plaintext for encryption.
+    ///
+    /// # Arguments
+    ///
+    /// * `literals` - EQL terms and SQL values from the statement
+    /// * `literal_columns` - Column configurations for each literal
+    ///
+    /// # Returns
+    ///
+    /// Vector of plaintext values with `None` for non-encrypted literals.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MappingError::InvalidParameter` if literal conversion fails.
+    fn literals_to_plaintext(
+        &self,
+        literals: &Vec<(EqlTerm, &ast::Value)>,
+        literal_columns: &Vec<Option<Column>>,
+    ) -> Result<Vec<Option<Plaintext>>, Error> {
+        let plaintexts = literals
+            .iter()
+            .zip(literal_columns)
+            .map(|((_, val), col)| match col {
+                Some(col) => literal_from_sql(val, col.eql_term(), col.cast_type()).map_err(|err| {
+                    debug!(
+                        target: MAPPER,
+                        msg = "Could not convert literal value",
+                        value = ?val,
+                        cast_type = ?col.cast_type(),
+                        error = err.to_string()
+                    );
+                    MappingError::InvalidParameter(Box::new(col.to_owned()))
+                }),
+                None => Ok(None),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(plaintexts)
+    }
+}

--- a/packages/cipherstash-proxy/src/postgresql/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/frontend.rs
@@ -15,9 +15,10 @@ use crate::log::{CONTEXT, MAPPER, PROTOCOL};
 use crate::postgresql::context::column::Column;
 use crate::postgresql::context::Portal;
 use crate::postgresql::data::literal_from_sql;
+use crate::postgresql::messages::close::Close;
 use crate::postgresql::messages::ready_for_query::ReadyForQuery;
 use crate::postgresql::messages::terminate::Terminate;
-use crate::postgresql::messages::Name;
+use crate::postgresql::messages::{Name, Target};
 use crate::prometheus::{
     CLIENTS_BYTES_RECEIVED_TOTAL, ENCRYPTED_VALUES_TOTAL, ENCRYPTION_DURATION_SECONDS,
     ENCRYPTION_ERROR_TOTAL, ENCRYPTION_REQUESTS_TOTAL, SERVER_BYTES_SENT_TOTAL,
@@ -287,6 +288,9 @@ where
                     return Ok(());
                 }
             }
+            Code::Close => {
+                self.close_handler(&bytes).await?;
+            }
             code => {
                 debug!(target: PROTOCOL,
                     client_id = self.context.client_id,
@@ -319,6 +323,19 @@ where
         let describe = Describe::try_from(bytes)?;
         debug!(target: PROTOCOL, client_id = self.context.client_id, ?describe);
         self.context.set_describe(describe);
+        Ok(())
+    }
+
+    async fn close_handler(&mut self, bytes: &BytesMut) -> Result<(), Error> {
+        let close = Close::try_from(bytes)?;
+        debug!(target: PROTOCOL, client_id = self.context.client_id, ?close);
+        match close.target {
+            Target::Portal => self.context.close_portal(&close.name),
+            Target::Statement => {
+                self.context.close_portal(&close.name);
+                self.context.close_statement(&close.name);
+            }
+        }
         Ok(())
     }
 

--- a/packages/cipherstash-proxy/src/postgresql/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/frontend.rs
@@ -1,5 +1,6 @@
 use super::context::{Context, Statement};
 use super::error_handler::PostgreSqlErrorHandler;
+use super::mapping::ColumnMapper;
 use super::messages::bind::Bind;
 use super::messages::describe::Describe;
 use super::messages::execute::Execute;
@@ -10,11 +11,9 @@ use super::protocol::{self};
 use super::sql::SqlProcessor;
 use crate::connect::Sender;
 use crate::encrypt::Encrypt;
-use crate::eql::Identifier;
 use crate::error::{EncryptError, Error, MappingError};
 use crate::log::{CONTEXT, MAPPER, PROTOCOL};
-use crate::postgresql::context::column::Column;
-use crate::postgresql::context::Portal;
+use crate::postgresql::context::{column::Column, Portal};
 use crate::postgresql::data::literal_from_sql;
 use crate::postgresql::messages::close::Close;
 use crate::postgresql::messages::ready_for_query::ReadyForQuery;
@@ -29,10 +28,9 @@ use crate::prometheus::{
 use crate::EqlEncrypted;
 use bytes::BytesMut;
 use cipherstash_client::encryption::Plaintext;
-use eql_mapper::{self, EqlMapperError, EqlTerm, TableColumn, TypeCheckedStatement};
+use eql_mapper::{self, EqlMapperError, EqlTerm, TypeCheckedStatement};
 use metrics::{counter, histogram};
 use pg_escape::quote_literal;
-use postgres_types::Type;
 use serde::Serialize;
 use sqltk::parser::ast::{self, Value};
 use sqltk::NodeKey;
@@ -777,9 +775,10 @@ where
         typed_statement: &TypeCheckedStatement<'_>,
         param_types: Vec<i32>,
     ) -> Result<Option<Statement>, Error> {
-        let param_columns = self.get_param_columns(typed_statement)?;
-        let projection_columns = self.get_projection_columns(typed_statement)?;
-        let literal_columns = self.get_literal_columns(typed_statement)?;
+        let column_mapper = ColumnMapper::new(&self.encrypt);
+        let param_columns = column_mapper.get_param_columns(typed_statement)?;
+        let projection_columns = column_mapper.get_projection_columns(typed_statement)?;
+        let literal_columns = column_mapper.get_literal_columns(typed_statement)?;
 
         let no_encrypted_param_columns = param_columns.iter().all(|c| c.is_none());
         let no_encrypted_projection_columns = projection_columns.iter().all(|c| c.is_none());
@@ -981,157 +980,6 @@ where
         }
     }
 
-    ///
-    /// Maps typed statement projection columns to an Encrypt column configuration
-    ///
-    /// The returned `Vec` is of `Option<Column>` because the Projection columns are a mix of native and EQL types.
-    /// Only EQL colunms will have a configuration. Native types are always None.
-    ///
-    /// Preserves the ordering and semantics of the projection to reduce the complexity of positional encryption.
-    ///
-    fn get_projection_columns(
-        &self,
-        typed_statement: &eql_mapper::TypeCheckedStatement<'_>,
-    ) -> Result<Vec<Option<Column>>, Error> {
-        let mut projection_columns = vec![];
-
-        for col in typed_statement.projection.columns() {
-            let eql_mapper::ProjectionColumn { ty, .. } = col;
-            let configured_column = match &**ty {
-                eql_mapper::Type::Value(eql_mapper::Value::Eql(eql_term)) => {
-                    let TableColumn { table, column } = eql_term.table_column();
-                    let identifier: Identifier = Identifier::from((table, column));
-
-                    debug!(
-                        target: MAPPER,
-                        client_id = self.context.client_id,
-                        msg = "Configured column",
-                        column = ?identifier,
-                        ?eql_term,
-                    );
-                    self.get_column(identifier, eql_term)?
-                }
-                _ => None,
-            };
-            projection_columns.push(configured_column)
-        }
-
-        Ok(projection_columns)
-    }
-
-    ///
-    /// Maps typed statement param columns to an Encrypt column configuration
-    ///
-    /// The returned `Vec` is of `Option<Column>` because the Param columns are a mix of native and EQL types.
-    /// Only EQL colunms will have a configuration. Native types are always None.
-    ///
-    /// Preserves the ordering and semantics of the projection to reduce the complexity of positional encryption.
-    ///
-    ///
-    fn get_param_columns(
-        &self,
-        typed_statement: &eql_mapper::TypeCheckedStatement<'_>,
-    ) -> Result<Vec<Option<Column>>, Error> {
-        let mut param_columns = vec![];
-
-        for param in typed_statement.params.iter() {
-            let configured_column = match param {
-                (_, eql_mapper::Value::Eql(eql_term)) => {
-                    let TableColumn { table, column } = eql_term.table_column();
-                    let identifier = Identifier::from((table, column));
-
-                    debug!(
-                        target: MAPPER,
-                        client_id = self.context.client_id,
-                        msg = "Encrypted parameter",
-                        column = ?identifier,
-                        ?eql_term,
-                    );
-
-                    self.get_column(identifier, eql_term)?
-                }
-                _ => None,
-            };
-            param_columns.push(configured_column);
-        }
-
-        Ok(param_columns)
-    }
-
-    fn get_literal_columns(
-        &self,
-        typed_statement: &eql_mapper::TypeCheckedStatement<'_>,
-    ) -> Result<Vec<Option<Column>>, Error> {
-        let mut literal_columns = vec![];
-
-        for (eql_term, _) in typed_statement.literals.iter() {
-            let TableColumn { table, column } = eql_term.table_column();
-            let identifier = Identifier::from((table, column));
-
-            debug!(
-                target: MAPPER,
-                client_id = self.context.client_id,
-                msg = "Encrypted literal",
-                column = ?identifier,
-                ?eql_term,
-            );
-            let col = self.get_column(identifier, eql_term)?;
-            if col.is_some() {
-                literal_columns.push(col);
-            }
-        }
-
-        Ok(literal_columns)
-    }
-
-    ///
-    /// Get the column configuration for the Identifier
-    /// Returns `EncryptError::UnknownColumn` if configuration cannot be found for the Identified column
-    /// if mapping enabled, and None if mapping is disabled. It'll log a warning either way.
-    fn get_column(
-        &self,
-        identifier: Identifier,
-        eql_term: &EqlTerm,
-    ) -> Result<Option<Column>, Error> {
-        match self.encrypt.get_column_config(&identifier) {
-            Some(config) => {
-                debug!(
-                    target: MAPPER,
-                    client_id = self.context.client_id,
-                    msg = "Configured column",
-                    column = ?identifier
-                );
-
-                // IndexTerm::SteVecSelector
-                let postgres_type = if matches!(eql_term, EqlTerm::JsonPath(_)) {
-                    Some(Type::JSONPATH)
-                } else {
-                    None
-                };
-
-                let eql_term = eql_term.variant();
-                Ok(Some(Column::new(
-                    identifier,
-                    config,
-                    postgres_type,
-                    eql_term,
-                )))
-            }
-            None => {
-                warn!(
-                    target: MAPPER,
-                    client_id = self.context.client_id,
-                    msg = "Configured column not found. Encryption configuration may have been deleted.",
-                    ?identifier,
-                );
-                Err(EncryptError::UnknownColumn {
-                    table: identifier.table.to_owned(),
-                    column: identifier.column.to_owned(),
-                }
-                .into())
-            }
-        }
-    }
 
     ///
     /// Send an ReadyForQuery to the client and remove error state.

--- a/packages/cipherstash-proxy/src/postgresql/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/frontend.rs
@@ -289,7 +289,11 @@ where
                 }
             }
             Code::Close => {
-                self.close_handler(&bytes).await?;
+                debug!(target: PROTOCOL,
+                    client_id = self.context.client_id,
+                    msg = "Close",
+                    ?code,
+                );
             }
             code => {
                 debug!(target: PROTOCOL,

--- a/packages/cipherstash-proxy/src/postgresql/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/frontend.rs
@@ -722,8 +722,7 @@ where
                 counter!(STATEMENTS_ENCRYPTED_TOTAL).increment(1);
 
                 message.rewrite_param_types(&statement.param_columns);
-                self.context
-                    .add_statement(message.name.to_owned(), statement);
+                self.context.add_statement(&message.name, statement);
             }
             _ => {
                 debug!(target: MAPPER,

--- a/packages/cipherstash-proxy/src/postgresql/mapping/columns.rs
+++ b/packages/cipherstash-proxy/src/postgresql/mapping/columns.rs
@@ -1,0 +1,181 @@
+use crate::encrypt::Encrypt;
+use crate::error::{EncryptError, Error};
+use crate::eql::Identifier;
+use crate::log::MAPPER;
+use crate::postgresql::context::column::Column;
+use eql_mapper::{EqlTerm, TableColumn, TypeCheckedStatement};
+use postgres_types::Type;
+use tracing::{debug, warn};
+
+/// Column mapping service that resolves EQL column configurations.
+/// 
+/// Maps typed statement columns (projection, parameters, literals) to encryption
+/// column configurations for encrypted operations.
+pub struct ColumnMapper<'a> {
+    encrypt: &'a Encrypt,
+}
+
+impl<'a> ColumnMapper<'a> {
+    /// Create a new ColumnMapper with access to encryption configuration.
+    pub fn new(encrypt: &'a Encrypt) -> Self {
+        Self { encrypt }
+    }
+
+    /// Maps typed statement projection columns to encryption column configurations.
+    ///
+    /// The returned `Vec` contains `Option<Column>` because projection columns are a mix 
+    /// of native and EQL types. Only EQL columns will have a configuration. Native types are always None.
+    ///
+    /// Preserves the ordering and semantics of the projection to reduce the complexity of positional encryption.
+    pub fn get_projection_columns(
+        &self,
+        typed_statement: &TypeCheckedStatement<'_>,
+    ) -> Result<Vec<Option<Column>>, Error> {
+        let mut projection_columns = vec![];
+
+        for col in typed_statement.projection.columns() {
+            let eql_mapper::ProjectionColumn { ty, .. } = col;
+            let configured_column = match &**ty {
+                eql_mapper::Type::Value(eql_mapper::Value::Eql(eql_term)) => {
+                    let TableColumn { table, column } = eql_term.table_column();
+                    let identifier: Identifier = Identifier::from((table, column));
+
+                    debug!(
+                        target: MAPPER,
+                        msg = "Configured projection column",
+                        column = ?identifier,
+                        ?eql_term,
+                    );
+                    self.get_column(identifier, eql_term)?
+                }
+                _ => None,
+            };
+            projection_columns.push(configured_column)
+        }
+
+        Ok(projection_columns)
+    }
+
+    /// Maps typed statement param columns to encryption column configurations.
+    ///
+    /// The returned `Vec` contains `Option<Column>` because param columns are a mix 
+    /// of native and EQL types. Only EQL columns will have a configuration. Native types are always None.
+    ///
+    /// Preserves the ordering and semantics of the parameters to reduce the complexity of positional encryption.
+    pub fn get_param_columns(
+        &self,
+        typed_statement: &TypeCheckedStatement<'_>,
+    ) -> Result<Vec<Option<Column>>, Error> {
+        let mut param_columns = vec![];
+
+        for param in typed_statement.params.iter() {
+            let configured_column = match param {
+                (_, eql_mapper::Value::Eql(eql_term)) => {
+                    let TableColumn { table, column } = eql_term.table_column();
+                    let identifier = Identifier::from((table, column));
+
+                    debug!(
+                        target: MAPPER,
+                        msg = "Encrypted parameter column",
+                        column = ?identifier,
+                        ?eql_term,
+                    );
+
+                    self.get_column(identifier, eql_term)?
+                }
+                _ => None,
+            };
+            param_columns.push(configured_column);
+        }
+
+        Ok(param_columns)
+    }
+
+    /// Maps typed statement literal columns to encryption column configurations.
+    ///
+    /// Only returns configurations for literals that correspond to encrypted columns.
+    /// Non-encrypted literals are filtered out since they don't need processing.
+    pub fn get_literal_columns(
+        &self,
+        typed_statement: &TypeCheckedStatement<'_>,
+    ) -> Result<Vec<Option<Column>>, Error> {
+        let mut literal_columns = vec![];
+
+        for (eql_term, _) in typed_statement.literals.iter() {
+            let TableColumn { table, column } = eql_term.table_column();
+            let identifier = Identifier::from((table, column));
+
+            debug!(
+                target: MAPPER,
+                msg = "Encrypted literal column",
+                column = ?identifier,
+                ?eql_term,
+            );
+            let col = self.get_column(identifier, eql_term)?;
+            if col.is_some() {
+                literal_columns.push(col);
+            }
+        }
+
+        Ok(literal_columns)
+    }
+
+    /// Get the column configuration for the given identifier and EQL term.
+    ///
+    /// # Arguments
+    ///
+    /// * `identifier` - Table and column identifier
+    /// * `eql_term` - EQL term type information
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(Column)` if configuration exists, or an error if the column
+    /// is expected to be encrypted but no configuration is found.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EncryptError::UnknownColumn` if configuration cannot be found for 
+    /// the identified column when mapping is enabled.
+    pub fn get_column(
+        &self,
+        identifier: Identifier,
+        eql_term: &EqlTerm,
+    ) -> Result<Option<Column>, Error> {
+        match self.encrypt.get_column_config(&identifier) {
+            Some(config) => {
+                debug!(
+                    target: MAPPER,
+                    msg = "Found column configuration",
+                    column = ?identifier
+                );
+
+                // Special handling for JsonPath EQL terms
+                let postgres_type = if matches!(eql_term, EqlTerm::JsonPath(_)) {
+                    Some(Type::JSONPATH)
+                } else {
+                    None
+                };
+
+                let eql_term = eql_term.variant();
+                Ok(Some(Column::new(
+                    identifier,
+                    config,
+                    postgres_type,
+                    eql_term,
+                )))
+            }
+            None => {
+                warn!(
+                    target: MAPPER,
+                    msg = "Column configuration not found. Encryption configuration may have been deleted.",
+                    ?identifier,
+                );
+                Err(EncryptError::UnknownColumn {
+                    table: identifier.table.to_owned(),
+                    column: identifier.column.to_owned(),
+                }
+                .into())
+            }
+        }
+    }
+}

--- a/packages/cipherstash-proxy/src/postgresql/mapping/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/mapping/mod.rs
@@ -1,3 +1,5 @@
 pub mod columns;
+pub mod types;
 
 pub use columns::ColumnMapper;
+pub use types::TypeChecker;

--- a/packages/cipherstash-proxy/src/postgresql/mapping/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/mapping/mod.rs
@@ -1,0 +1,3 @@
+pub mod columns;
+
+pub use columns::ColumnMapper;

--- a/packages/cipherstash-proxy/src/postgresql/mapping/types.rs
+++ b/packages/cipherstash-proxy/src/postgresql/mapping/types.rs
@@ -1,0 +1,83 @@
+use crate::error::{Error, MappingError};
+use crate::log::MAPPER;
+use crate::prometheus::STATEMENTS_UNMAPPABLE_TOTAL;
+use eql_mapper::{self, EqlMapperError, TableResolver, TypeCheckedStatement};
+use metrics::counter;
+use sqltk::parser::ast;
+use std::sync::Arc;
+use tracing::{debug, warn};
+
+/// Type checking service for SQL statements using EQL mapper.
+///
+/// Handles analysis of SQL statements to determine type compatibility
+/// with encrypted operations and performs type inference for EQL columns.
+pub struct TypeChecker {
+    table_resolver: Arc<TableResolver>,
+}
+
+impl TypeChecker {
+    /// Create a new TypeChecker with access to schema information.
+    pub fn new(table_resolver: Arc<TableResolver>) -> Self {
+        Self { table_resolver }
+    }
+
+    /// Check if a statement requires type checking for encrypted operations.
+    ///
+    /// # Arguments
+    ///
+    /// * `statement` - AST statement to analyze
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` if the statement contains operations that require type checking.
+    pub fn requires_type_check(&self, statement: &ast::Statement) -> bool {
+        eql_mapper::requires_type_check(statement)
+    }
+
+    /// Perform type checking on a SQL statement for EQL operations.
+    ///
+    /// # Arguments
+    ///
+    /// * `statement` - AST statement to type check
+    ///
+    /// # Returns
+    ///
+    /// Returns a type-checked statement with inferred types for EQL operations,
+    /// or an error if type checking fails.
+    ///
+    /// # Errors
+    ///
+    /// - Returns `MappingError::Internal` for internal EQL mapper errors
+    /// - Returns `MappingError::StatementCouldNotBeTypeChecked` for type checking failures
+    pub fn type_check<'a>(
+        &self,
+        statement: &'a ast::Statement,
+    ) -> Result<TypeCheckedStatement<'a>, Error> {
+        match eql_mapper::type_check(self.table_resolver.clone(), statement) {
+            Ok(typed_statement) => {
+                debug!(target: MAPPER,
+                    typed_statement = ?typed_statement,
+                    "Statement type checking completed"
+                );
+
+                Ok(typed_statement)
+            }
+            Err(EqlMapperError::InternalError(str)) => {
+                warn!(
+                    msg = "Internal Error in EQL Mapper",
+                    error = str,
+                );
+                counter!(STATEMENTS_UNMAPPABLE_TOTAL).increment(1);
+                Err(MappingError::Internal(str).into())
+            }
+            Err(err) => {
+                warn!(
+                    msg = "Unmappable statement",
+                    error = err.to_string(),
+                );
+                counter!(STATEMENTS_UNMAPPABLE_TOTAL).increment(1);
+                Err(MappingError::StatementCouldNotBeTypeChecked(err.to_string()).into())
+            }
+        }
+    }
+}

--- a/packages/cipherstash-proxy/src/postgresql/messages/bind.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/bind.rs
@@ -227,10 +227,10 @@ impl TryFrom<&BytesMut> for Bind {
         let _len = cursor.get_i32();
 
         let portal = cursor.read_string()?;
-        let portal = Name(portal);
+        let portal = Name::from(portal);
 
         let prepared_statement = cursor.read_string()?;
-        let prepared_statement = Name(prepared_statement);
+        let prepared_statement = Name::from(prepared_statement);
 
         let num_param_format_codes = cursor.get_i16();
         let mut param_format_codes = Vec::new();

--- a/packages/cipherstash-proxy/src/postgresql/messages/close.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/close.rs
@@ -52,7 +52,7 @@ impl TryFrom<&BytesMut> for Close {
         let target = cursor.get_u8();
         let target = Target::try_from(target)?;
         let name = cursor.read_string()?;
-        let name = Name(name);
+        let name = Name::from(name);
 
         Ok(Close { target, name })
     }
@@ -64,7 +64,7 @@ impl TryFrom<Close> for BytesMut {
     fn try_from(close: Close) -> Result<BytesMut, Error> {
         let mut bytes = BytesMut::new();
 
-        let name = CString::new(close.name.0.as_str())?;
+        let name = CString::new(close.name.as_str())?;
         let name = name.as_bytes_with_nul();
 
         let len = SIZE_I32 + SIZE_U8 + name.len();
@@ -122,7 +122,7 @@ mod tests {
         let close = Close::try_from(&bytes).unwrap();
 
         assert!(matches!(close.target, Target::Statement));
-        assert_eq!(close.name.0, "stmt1");
+        assert_eq!(close.name.as_str(), "stmt1");
         assert!(!close.name.is_unnamed());
     }
 
@@ -132,13 +132,13 @@ mod tests {
 
         let close = Close {
             target: Target::Portal,
-            name: Name("portal1".to_string()),
+            name: Name::from("portal1"),
         };
 
         let bytes = BytesMut::try_from(close).unwrap();
         let parsed = Close::try_from(&bytes).unwrap();
 
         assert!(matches!(parsed.target, Target::Portal));
-        assert_eq!(parsed.name.0, "portal1");
+        assert_eq!(parsed.name.as_str(), "portal1");
     }
 }

--- a/packages/cipherstash-proxy/src/postgresql/messages/close.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/close.rs
@@ -1,0 +1,144 @@
+use crate::error::{Error, ProtocolError};
+use crate::postgresql::protocol::BytesMutReadString;
+use crate::{SIZE_I32, SIZE_U8};
+
+use bytes::{Buf, BufMut, BytesMut};
+use std::convert::TryFrom;
+use std::ffi::CString;
+use std::io::Cursor;
+
+use super::target::Target;
+use super::{FrontendCode, Name};
+
+///
+/// Close b'C' (Frontend) message.
+///
+/// See: <https://www.postgresql.org/docs/current/protocol-message-formats.html>
+///
+///     Byte1('C')
+///     Identifies the message as a Close command.
+///
+///     Int32
+///     Length of message contents in bytes, including self.
+///
+///     Byte1
+///     'S' to close a prepared statement; or 'P' to close a portal.
+///
+///     String
+///     The name of the prepared statement or portal to close (an empty string selects the unnamed prepared statement or portal).
+
+#[derive(Debug, Clone)]
+pub(crate) struct Close {
+    pub target: Target,
+    pub name: Name,
+}
+
+impl TryFrom<&BytesMut> for Close {
+    type Error = Error;
+
+    fn try_from(bytes: &BytesMut) -> Result<Close, Self::Error> {
+        let mut cursor = Cursor::new(bytes);
+        let code = cursor.get_u8();
+
+        if FrontendCode::from(code) != FrontendCode::Close {
+            return Err(ProtocolError::UnexpectedMessageCode {
+                expected: FrontendCode::Close.into(),
+                received: code as char,
+            }
+            .into());
+        }
+
+        let _len = cursor.get_i32(); // read and progress cursor
+        let target = cursor.get_u8();
+        let target = Target::try_from(target)?;
+        let name = cursor.read_string()?;
+        let name = Name(name);
+
+        Ok(Close { target, name })
+    }
+}
+
+impl TryFrom<Close> for BytesMut {
+    type Error = Error;
+
+    fn try_from(close: Close) -> Result<BytesMut, Error> {
+        let mut bytes = BytesMut::new();
+
+        let name = CString::new(close.name.0.as_str())?;
+        let name = name.as_bytes_with_nul();
+
+        let len = SIZE_I32 + SIZE_U8 + name.len();
+
+        bytes.put_u8(FrontendCode::Close.into());
+        bytes.put_i32(len as i32);
+        bytes.put_u8(close.target.into());
+        bytes.put_slice(name);
+
+        Ok(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{config::LogConfig, log, postgresql::messages::Name};
+    use bytes::BytesMut;
+    use std::convert::TryFrom;
+
+    fn to_message(s: &[u8]) -> BytesMut {
+        BytesMut::from(s)
+    }
+
+    #[test]
+    pub fn test_close_statement() {
+        log::init(LogConfig::default());
+
+        // Close unnamed prepared statement: C\0\0\0\x06S\0
+        let bytes = to_message(b"C\0\0\0\x06S\0");
+        let close = Close::try_from(&bytes).unwrap();
+
+        assert!(matches!(close.target, Target::Statement));
+        assert!(close.name.is_unnamed());
+    }
+
+    #[test]
+    pub fn test_close_portal() {
+        log::init(LogConfig::default());
+
+        // Close unnamed portal: C\0\0\0\x06P\0
+        let bytes = to_message(b"C\0\0\0\x06P\0");
+        let close = Close::try_from(&bytes).unwrap();
+
+        assert!(matches!(close.target, Target::Portal));
+        assert!(close.name.is_unnamed());
+    }
+
+    #[test]
+    pub fn test_close_named_statement() {
+        log::init(LogConfig::default());
+
+        // Close named prepared statement "stmt1": C\0\0\0\x0bSstmt1\0
+        let bytes = to_message(b"C\0\0\0\x0bSstmt1\0");
+        let close = Close::try_from(&bytes).unwrap();
+
+        assert!(matches!(close.target, Target::Statement));
+        assert_eq!(close.name.0, "stmt1");
+        assert!(!close.name.is_unnamed());
+    }
+
+    #[test]
+    pub fn test_close_to_bytes() {
+        log::init(LogConfig::default());
+
+        let close = Close {
+            target: Target::Portal,
+            name: Name("portal1".to_string()),
+        };
+
+        let bytes = BytesMut::try_from(close).unwrap();
+        let parsed = Close::try_from(&bytes).unwrap();
+
+        assert!(matches!(parsed.target, Target::Portal));
+        assert_eq!(parsed.name.0, "portal1");
+    }
+}

--- a/packages/cipherstash-proxy/src/postgresql/messages/describe.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/describe.rs
@@ -33,7 +33,6 @@ pub(crate) struct Describe {
     pub name: Name,
 }
 
-
 impl TryFrom<&BytesMut> for Describe {
     type Error = Error;
 
@@ -53,7 +52,7 @@ impl TryFrom<&BytesMut> for Describe {
         let target = cursor.get_u8();
         let target = Target::try_from(target)?;
         let name = cursor.read_string()?;
-        let name = Name(name);
+        let name = Name::from(name);
 
         Ok(Describe { target, name })
     }
@@ -65,7 +64,7 @@ impl TryFrom<Describe> for BytesMut {
     fn try_from(describe: Describe) -> Result<BytesMut, Error> {
         let mut bytes = BytesMut::new();
 
-        let name = CString::new(describe.name.0.as_str())?;
+        let name = CString::new(describe.name.as_str())?;
         let name = name.as_bytes_with_nul();
 
         let len = SIZE_I32 + SIZE_U8 + name.len();
@@ -78,4 +77,3 @@ impl TryFrom<Describe> for BytesMut {
         Ok(bytes)
     }
 }
-

--- a/packages/cipherstash-proxy/src/postgresql/messages/describe.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/describe.rs
@@ -7,6 +7,7 @@ use std::convert::TryFrom;
 use std::ffi::CString;
 use std::io::Cursor;
 
+use super::target::Target;
 use super::{FrontendCode, Name};
 
 ///
@@ -32,28 +33,6 @@ pub(crate) struct Describe {
     pub name: Name,
 }
 
-///
-/// The target of the describe message.
-///
-/// Valid values are PreparedStatment or Portal
-///
-/// A Portal is a parsed statement PLUS any bound parameters
-/// Describe with `Target::Portal` returns the RowDescription describing the result set.
-/// The assuumption is that the parameters are already bound to the portal, so the Describe message is not required to include any parameter information.
-///
-/// Calls to Execute are made on a Portal (not a prepared statement) as execute requires any bound parameters
-///
-/// A PreparedStatement is the parsed statement
-/// Describe with `Target::PreparedStatement` returns a ParameterDescription followed by the RowDescription.
-///
-///
-/// See https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
-///
-#[derive(Debug, Clone)]
-pub enum Target {
-    Portal,
-    PreparedStatement,
-}
 
 impl TryFrom<&BytesMut> for Describe {
     type Error = Error;
@@ -93,21 +72,10 @@ impl TryFrom<Describe> for BytesMut {
 
         bytes.put_u8(FrontendCode::Describe.into());
         bytes.put_i32(len as i32);
-        bytes.put_u8(describe.target as u8);
+        bytes.put_u8(describe.target.into());
         bytes.put_slice(name);
 
         Ok(bytes)
     }
 }
 
-impl TryFrom<u8> for Target {
-    type Error = Error;
-
-    fn try_from(t: u8) -> Result<Target, Error> {
-        match t as char {
-            'S' => Ok(Target::PreparedStatement),
-            'P' => Ok(Target::Portal),
-            t => Err(ProtocolError::UnexpectedDescribeTarget(t).into()),
-        }
-    }
-}

--- a/packages/cipherstash-proxy/src/postgresql/messages/execute.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/execute.rs
@@ -29,7 +29,7 @@ impl TryFrom<&BytesMut> for Execute {
         let _len = cursor.get_i32(); // read and progress cursor
 
         let portal = cursor.read_string()?;
-        let portal = Name(portal);
+        let portal = Name::from(portal);
         let max_rows = cursor.get_i32();
 
         Ok(Execute { portal, max_rows })

--- a/packages/cipherstash-proxy/src/postgresql/messages/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/mod.rs
@@ -1,7 +1,10 @@
+use std::fmt;
+
 use bytes::BytesMut;
 
 pub mod authentication;
 pub mod bind;
+pub mod close;
 pub mod data_row;
 pub mod describe;
 pub mod error_response;
@@ -11,15 +14,21 @@ pub mod parse;
 pub mod query;
 pub mod ready_for_query;
 pub mod row_description;
+pub mod target;
 pub mod terminate;
+
+// Re-export commonly used types
+pub use target::Target;
 
 pub const NULL: i32 = -1;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FrontendCode {
     Bind,
+    Close,
     Describe,
     Execute,
+    Flush,
     Parse,
     PasswordMessage,
     Query,
@@ -65,8 +74,10 @@ impl From<char> for FrontendCode {
     fn from(code: char) -> Self {
         match code {
             'B' => FrontendCode::Bind,
+            'C' => FrontendCode::Close,
             'D' => FrontendCode::Describe,
             'E' => FrontendCode::Execute,
+            'H' => FrontendCode::Flush,
             'p' => FrontendCode::PasswordMessage,
             'P' => FrontendCode::Parse,
             'Q' => FrontendCode::Query,
@@ -85,8 +96,10 @@ impl From<FrontendCode> for u8 {
     fn from(code: FrontendCode) -> Self {
         match code {
             FrontendCode::Bind => b'B',
+            FrontendCode::Close => b'C',
             FrontendCode::Describe => b'D',
             FrontendCode::Execute => b'E',
+            FrontendCode::Flush => b'F',
             FrontendCode::Parse => b'P',
             FrontendCode::PasswordMessage => b'p',
             FrontendCode::Query => b'Q',
@@ -103,8 +116,10 @@ impl From<FrontendCode> for char {
     fn from(code: FrontendCode) -> Self {
         match code {
             FrontendCode::Bind => 'B',
+            FrontendCode::Close => 'C',
             FrontendCode::Describe => 'D',
             FrontendCode::Execute => 'E',
+            FrontendCode::Flush => 'F',
             FrontendCode::Parse => 'P',
             FrontendCode::PasswordMessage => 'p',
             FrontendCode::Query => 'Q',
@@ -197,6 +212,54 @@ impl From<BackendCode> for char {
             BackendCode::ReadyForQuery => 'Z',
             BackendCode::RowDescription => 'T',
             BackendCode::Unknown(c) => c,
+        }
+    }
+}
+
+impl fmt::Display for BackendCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BackendCode::Authentication => write!(f, "BackendCode::Authentication"),
+            BackendCode::BackendKeyData => write!(f, "BackendCode::BackendKeyData"),
+            BackendCode::BindComplete => write!(f, "BackendCode::BindComplete"),
+            BackendCode::CloseComplete => write!(f, "BackendCode::CloseComplete"),
+            BackendCode::CommandComplete => write!(f, "BackendCode::CommandComplete"),
+            BackendCode::CopyBothResponse => write!(f, "BackendCode::CopyBothResponse"),
+            BackendCode::CopyInResponse => write!(f, "BackendCode::CopyInResponse"),
+            BackendCode::CopyOutResponse => write!(f, "BackendCode::CopyOutResponse"),
+            BackendCode::DataRow => write!(f, "BackendCode::DataRow"),
+            BackendCode::EmptyQueryResponse => write!(f, "BackendCode::EmptyQueryResponse"),
+            BackendCode::ErrorResponse => write!(f, "BackendCode::ErrorResponse"),
+            BackendCode::NoData => write!(f, "BackendCode::NoData"),
+            BackendCode::NoticeResponse => write!(f, "BackendCode::NoticeResponse"),
+            BackendCode::NotificationResponse => write!(f, "BackendCode::NotificationResponse"),
+            BackendCode::ParameterDescription => write!(f, "BackendCode::ParameterDescription"),
+            BackendCode::ParameterStatus => write!(f, "BackendCode::ParameterStatus"),
+            BackendCode::ParseComplete => write!(f, "BackendCode::ParseComplete"),
+            BackendCode::PortalSuspended => write!(f, "BackendCode::PortalSuspended"),
+            BackendCode::ReadyForQuery => write!(f, "BackendCode::ReadyForQuery"),
+            BackendCode::RowDescription => write!(f, "BackendCode::RowDescription"),
+            BackendCode::Unknown(c) => write!(f, "BackendCode::Unknown('{}')", c),
+        }
+    }
+}
+
+impl fmt::Display for FrontendCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FrontendCode::Bind => write!(f, "FrontendCode::Bind"),
+            FrontendCode::Close => write!(f, "FrontendCode::Close"),
+            FrontendCode::Describe => write!(f, "FrontendCode::Describe"),
+            FrontendCode::Execute => write!(f, "FrontendCode::Execute"),
+            FrontendCode::Flush => write!(f, "FrontendCode::Flush"),
+            FrontendCode::Parse => write!(f, "FrontendCode::Parse"),
+            FrontendCode::PasswordMessage => write!(f, "FrontendCode::PasswordMessage"),
+            FrontendCode::Query => write!(f, "FrontendCode::Query"),
+            FrontendCode::SASLInitialResponse => write!(f, "FrontendCode::SASLInitialResponse"),
+            FrontendCode::SASLResponse => write!(f, "FrontendCode::SASLResponse"),
+            FrontendCode::Sync => write!(f, "FrontendCode::Sync"),
+            FrontendCode::Terminate => write!(f, "FrontendCode::Terminate"),
+            FrontendCode::Unknown(c) => write!(f, "FrontendCode::Unknown('{}')", c),
         }
     }
 }

--- a/packages/cipherstash-proxy/src/postgresql/messages/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/mod.rs
@@ -9,6 +9,7 @@ pub mod data_row;
 pub mod describe;
 pub mod error_response;
 pub mod execute;
+pub mod name;
 pub mod param_description;
 pub mod parse;
 pub mod query;
@@ -18,6 +19,7 @@ pub mod target;
 pub mod terminate;
 
 // Re-export commonly used types
+pub use name::Name;
 pub use target::Target;
 
 pub const NULL: i32 = -1;
@@ -261,27 +263,6 @@ impl fmt::Display for FrontendCode {
             FrontendCode::Terminate => write!(f, "FrontendCode::Terminate"),
             FrontendCode::Unknown(c) => write!(f, "FrontendCode::Unknown('{}')", c),
         }
-    }
-}
-
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
-pub struct Name(pub String);
-
-impl Name {
-    pub fn unnamed() -> Name {
-        Name("".to_string())
-    }
-
-    pub fn is_unnamed(&self) -> bool {
-        self.0.is_empty()
-    }
-}
-
-impl std::ops::Deref for Name {
-    type Target = str;
-
-    fn deref(&self) -> &str {
-        self.0.as_str()
     }
 }
 

--- a/packages/cipherstash-proxy/src/postgresql/messages/name.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/name.rs
@@ -1,0 +1,50 @@
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub enum Name {
+    Named(String),
+    Unnamed,
+}
+
+impl Name {
+    pub fn unnamed() -> Name {
+        Name::Unnamed
+    }
+
+    pub fn is_unnamed(&self) -> bool {
+        matches!(self, Name::Unnamed)
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Name::Named(s) => s,
+            Name::Unnamed => "",
+        }
+    }
+}
+
+impl std::ops::Deref for Name {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl From<String> for Name {
+    fn from(s: String) -> Self {
+        if s.is_empty() {
+            Name::Unnamed
+        } else {
+            Name::Named(s)
+        }
+    }
+}
+
+impl From<&str> for Name {
+    fn from(s: &str) -> Self {
+        if s.is_empty() {
+            Name::Unnamed
+        } else {
+            Name::Named(s.to_string())
+        }
+    }
+}

--- a/packages/cipherstash-proxy/src/postgresql/messages/parse.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/parse.rs
@@ -62,7 +62,7 @@ impl TryFrom<&BytesMut> for Parse {
 
         let _len = cursor.get_i32();
         let name = cursor.read_string()?;
-        let name = Name(name);
+        let name = Name::from(name);
 
         let statement = cursor.read_string()?;
         let num_params = cursor.get_i16();
@@ -89,7 +89,7 @@ impl TryFrom<Parse> for BytesMut {
     fn try_from(parse: Parse) -> Result<BytesMut, Error> {
         let mut bytes = BytesMut::new();
 
-        let name = CString::new(parse.name.0.as_str())?;
+        let name = CString::new(parse.name.as_str())?;
         let name = name.as_bytes_with_nul();
 
         let statement = CString::new(parse.statement)?;

--- a/packages/cipherstash-proxy/src/postgresql/messages/target.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/target.rs
@@ -1,0 +1,46 @@
+use crate::error::{Error, ProtocolError};
+use std::convert::TryFrom;
+
+///
+/// The target of describe or close messages.
+///
+/// Valid values are PreparedStatement or Portal
+///
+/// A Portal is a parsed statement PLUS any bound parameters
+/// Describe with `Target::Portal` returns the RowDescription describing the result set.
+/// The assumption is that the parameters are already bound to the portal, so the Describe message is not required to include any parameter information.
+///
+/// Calls to Execute are made on a Portal (not a prepared statement) as execute requires any bound parameters
+///
+/// A Statement is the parsed statement
+/// Describe with `Target::Statement` returns a ParameterDescription followed by the RowDescription.
+///
+///
+/// See https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
+///
+#[derive(Debug, Clone)]
+pub enum Target {
+    Portal,
+    Statement,
+}
+
+impl TryFrom<u8> for Target {
+    type Error = Error;
+
+    fn try_from(t: u8) -> Result<Target, Error> {
+        match t as char {
+            'S' => Ok(Target::Statement),
+            'P' => Ok(Target::Portal),
+            t => Err(ProtocolError::UnexpectedDescribeTarget(t).into()),
+        }
+    }
+}
+
+impl From<Target> for u8 {
+    fn from(target: Target) -> u8 {
+        match target {
+            Target::Statement => b'S',
+            Target::Portal => b'P',
+        }
+    }
+}

--- a/packages/cipherstash-proxy/src/postgresql/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/mod.rs
@@ -5,6 +5,7 @@ mod error_handler;
 mod format_code;
 mod frontend;
 mod handler;
+mod mapping;
 mod message_buffer;
 mod messages;
 mod protocol;

--- a/packages/cipherstash-proxy/src/postgresql/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/mod.rs
@@ -1,6 +1,7 @@
 mod backend;
 mod context;
 mod data;
+mod encryption;
 mod error_handler;
 mod format_code;
 mod frontend;

--- a/packages/cipherstash-proxy/src/postgresql/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/mod.rs
@@ -8,6 +8,7 @@ mod handler;
 mod message_buffer;
 mod messages;
 mod protocol;
+mod sql;
 mod startup;
 
 pub use context::column::Column;

--- a/packages/cipherstash-proxy/src/postgresql/sql/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/sql/mod.rs
@@ -1,0 +1,3 @@
+pub mod processor;
+
+pub use processor::SqlProcessor;

--- a/packages/cipherstash-proxy/src/postgresql/sql/processor.rs
+++ b/packages/cipherstash-proxy/src/postgresql/sql/processor.rs
@@ -1,0 +1,142 @@
+use crate::error::{EncryptError, Error};
+use crate::postgresql::context::{Context, KeysetIdentifier};
+use crate::prometheus::STATEMENTS_TOTAL;
+use eql_mapper::{self, TableResolver};
+use metrics::counter;
+use sqltk::parser::ast;
+use sqltk::parser::dialect::PostgreSqlDialect;
+use sqltk::parser::parser::Parser;
+use std::sync::Arc;
+use tracing::{debug, info};
+
+const DIALECT: PostgreSqlDialect = PostgreSqlDialect {};
+
+/// SQL processing service that handles parsing, validation, and analysis of SQL statements.
+pub struct SqlProcessor;
+
+impl SqlProcessor {
+    /// Parse a single SQL statement string into an AST.
+    ///
+    /// # Arguments
+    ///
+    /// * `statement` - SQL statement string to parse
+    ///
+    /// # Returns
+    ///
+    /// Returns the parsed AST statement or an error if parsing fails.
+    pub fn parse_statement(statement: &str) -> Result<ast::Statement, Error> {
+        let statement = Parser::new(&DIALECT)
+            .try_with_sql(statement)?
+            .parse_statement()?;
+
+        debug!(
+            target: "mapper",
+            statement = %statement,
+            "Parsed SQL statement"
+        );
+
+        counter!(STATEMENTS_TOTAL).increment(1);
+
+        Ok(statement)
+    }
+
+    /// Parse a SQL string potentially containing multiple statements into parsed ASTs.
+    ///
+    /// # Arguments
+    ///
+    /// * `statements` - SQL string containing one or more statements separated by semicolons
+    ///
+    /// # Returns
+    ///
+    /// Returns a vector of parsed AST statements or an error if parsing fails.
+    pub fn parse_statements(statements: &str) -> Result<Vec<ast::Statement>, Error> {
+        let statements = Parser::new(&DIALECT)
+            .try_with_sql(statements)?
+            .parse_statements()?;
+
+        debug!(
+            target: "mapper",
+            statements = ?statements,
+            count = statements.len(),
+            "Parsed multiple SQL statements"
+        );
+
+        counter!(STATEMENTS_TOTAL).increment(statements.len() as u64);
+
+        Ok(statements)
+    }
+
+    /// Check if a statement contains DDL that would change the schema.
+    ///
+    /// # Arguments
+    ///
+    /// * `table_resolver` - Schema resolver for DDL detection
+    /// * `statement` - AST statement to check
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` if the statement contains DDL that changes schema, `false` otherwise.
+    pub fn check_for_schema_change(
+        table_resolver: Arc<TableResolver>,
+        statement: &ast::Statement,
+    ) -> bool {
+        let schema_changed = eql_mapper::collect_ddl(table_resolver, statement);
+
+        if schema_changed {
+            debug!(
+                target: "mapper",
+                msg = "Schema change detected in statement"
+            );
+        }
+
+        schema_changed
+    }
+
+    /// Handle `SET CIPHERSTASH KEYSET_*` statements.
+    ///
+    /// # Arguments
+    ///
+    /// * `statement` - AST statement to check for keyset commands
+    /// * `context` - Session context for storing keyset information
+    /// * `default_keyset_configured` - Whether a default keyset is configured
+    ///
+    /// # Returns
+    ///
+    /// Returns the keyset identifier if a SET command was processed, or an error
+    /// if the command is invalid or conflicts with configuration.
+    ///
+    /// # Errors
+    ///
+    /// - Returns `EncryptError::UnexpectedSetKeyset` if called when a default keyset is configured
+    /// - Returns parse errors if the keyset ID cannot be parsed as a valid UUID
+    pub fn handle_set_keyset(
+        statement: &ast::Statement,
+        context: &mut Context,
+        default_keyset_configured: bool,
+    ) -> Result<Option<KeysetIdentifier>, Error> {
+        if let Some(keyset_identifier) = context.maybe_set_keyset(statement)? {
+            debug!(
+                keyset_identifier = ?keyset_identifier,
+                "Processing SET CIPHERSTASH.KEYSET command"
+            );
+
+            if default_keyset_configured {
+                debug!(
+                    target: "mapper",
+                    keyset_identifier = ?keyset_identifier,
+                    msg = "SET KEYSET command conflicts with configured default keyset"
+                );
+                return Err(EncryptError::UnexpectedSetKeyset.into());
+            }
+
+            info!(
+                msg = "SET CIPHERSTASH.KEYSET",
+                keyset_identifier = keyset_identifier.to_string()
+            );
+
+            return Ok(Some(keyset_identifier));
+        }
+
+        Ok(None)
+    }
+}


### PR DESCRIPTION
♻️ refactor: separate unnamed and named statement storage in context
- Split statement storage into queue for unnamed statements and HashMap for prepared statements
- Add dedicated methods for managing unnamed vs named statements
- Update Context to route statements based on name type (unnamed vs named)
- Add comprehensive test coverage for both statement types
- Fix code formatting issues in describe.rs


♻️ refactor: convert Name struct to enum and extract to own module
- Convert Name from struct to enum with Named(String) and Unnamed variants
- Extract Name type into dedicated name.rs module for better organization
- Add From<String> and From<&str> implementations for convenient construction
- Update all usage sites to use Name::from() constructor
- Update field access from .0 to .as_str() method
- Maintain backward compatibility through re-exports and Deref trait
- Improve type safety by preventing empty named statements
