### PR TITLE
♻️ refactor: convert Name struct to enum and extract to own module

### DIFF
--- a/packages/cipherstash-proxy/src/postgresql/context/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/context/mod.rs
@@ -264,7 +264,7 @@ impl Context {
             } => self.get_portal_statement(name),
             Describe {
                 ref name,
-                target: Target::PreparedStatement,
+                target: Target::Statement,
             } => self.get_statement(name),
         }
     }
@@ -583,7 +583,7 @@ mod tests {
     use crate::{
         config::LogConfig,
         log,
-        postgresql::messages::{describe::Target, Name},
+        postgresql::messages::{Name, Target},
     };
     use cipherstash_client::IdentifiedBy;
     use eql_mapper::Schema;
@@ -629,7 +629,7 @@ mod tests {
 
         let describe = Describe {
             name,
-            target: Target::PreparedStatement,
+            target: Target::Statement,
         };
         context.set_describe(describe);
 

--- a/packages/cipherstash-proxy/src/postgresql/context/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/context/mod.rs
@@ -2,10 +2,7 @@ pub mod column;
 
 use super::{
     format_code::FormatCode,
-    messages::{
-        describe::{Describe, Target},
-        Name,
-    },
+    messages::{describe::Describe, Name, Target},
     Column,
 };
 use crate::{
@@ -621,7 +618,7 @@ mod tests {
 
         let mut context = Context::new(1, schema);
 
-        let name = Name("name".to_string());
+        let name = Name::from("name");
 
         context.add_statement(name.clone(), statement());
 
@@ -646,8 +643,8 @@ mod tests {
 
         let mut context = Context::new(1, schema);
 
-        let statement_name = Name("statement".to_string());
-        let portal_name = Name("portal".to_string());
+        let statement_name = Name::from("statement");
+        let portal_name = Name::from("portal");
 
         // Add statement to context
         context.add_statement(statement_name.clone(), statement());
@@ -688,8 +685,8 @@ mod tests {
         let mut context = Context::new(1, schema);
 
         // Create multiple statements
-        let statement_name_1 = Name("statement_1".to_string());
-        let statement_name_2 = Name("statement_2".to_string());
+        let statement_name_1 = Name::from("statement_1");
+        let statement_name_2 = Name::from("statement_2");
 
         // Add statements to context
         context.add_statement(statement_name_1.clone(), statement());
@@ -698,7 +695,7 @@ mod tests {
         // Replicate pipelined execution
         // Add multiple portals with the same name
         // Pointing to different statements
-        let portal_name = Name("portal".to_string());
+        let portal_name = Name::from("portal");
 
         let statement_1 = context.get_statement(&statement_name_1).unwrap();
         context.add_portal(portal_name.clone(), portal(&statement_1));
@@ -737,14 +734,14 @@ mod tests {
 
         let mut context = Context::new(1, schema);
 
-        let statement_name_1 = Name("statement_1".to_string());
+        let statement_name_1 = Name::from("statement_1");
         let portal_name_1 = Name::unnamed();
 
-        let statement_name_2 = Name("statement_2".to_string());
+        let statement_name_2 = Name::from("statement_2");
         let portal_name_2 = Name::unnamed();
 
-        let statement_name_3 = Name("statement_3".to_string());
-        let portal_name_3 = Name("portal_3".to_string());
+        let statement_name_3 = Name::from("statement_3");
+        let portal_name_3 = Name::from("portal_3");
 
         // Add statement to context
         context.add_statement(statement_name_1.clone(), statement());

--- a/packages/cipherstash-proxy/src/postgresql/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/frontend.rs
@@ -15,9 +15,10 @@ use crate::log::{CONTEXT, MAPPER, PROTOCOL};
 use crate::postgresql::context::column::Column;
 use crate::postgresql::context::Portal;
 use crate::postgresql::data::literal_from_sql;
+use crate::postgresql::messages::close::Close;
 use crate::postgresql::messages::ready_for_query::ReadyForQuery;
 use crate::postgresql::messages::terminate::Terminate;
-use crate::postgresql::messages::Name;
+use crate::postgresql::messages::{Name, Target};
 use crate::prometheus::{
     CLIENTS_BYTES_RECEIVED_TOTAL, ENCRYPTED_VALUES_TOTAL, ENCRYPTION_DURATION_SECONDS,
     ENCRYPTION_ERROR_TOTAL, ENCRYPTION_REQUESTS_TOTAL, SERVER_BYTES_SENT_TOTAL,
@@ -287,6 +288,9 @@ where
                     return Ok(());
                 }
             }
+            Code::Close => {
+                self.close_handler(&bytes).await?;
+            }
             code => {
                 debug!(target: PROTOCOL,
                     client_id = self.context.client_id,
@@ -319,6 +323,19 @@ where
         let describe = Describe::try_from(bytes)?;
         debug!(target: PROTOCOL, client_id = self.context.client_id, ?describe);
         self.context.set_describe(describe);
+        Ok(())
+    }
+
+    async fn close_handler(&mut self, bytes: &BytesMut) -> Result<(), Error> {
+        let close = Close::try_from(bytes)?;
+        debug!(target: PROTOCOL, client_id = self.context.client_id, ?close);
+        match close.target {
+            Target::Portal => self.context.close_portal(&close.name),
+            Target::Statement => {
+                self.context.close_portal(&close.name);
+                self.context.close_statement(&close.name);
+            }
+        }
         Ok(())
     }
 

--- a/packages/cipherstash-proxy/src/postgresql/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/frontend.rs
@@ -333,7 +333,7 @@ where
             Target::Portal => self.context.close_portal(&close.name),
             Target::Statement => {
                 self.context.close_portal(&close.name);
-                self.context.close_statement(&close.name);
+                // self.context.close_statement(&close.name);
             }
         }
         Ok(())

--- a/packages/cipherstash-proxy/src/postgresql/messages/bind.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/bind.rs
@@ -227,10 +227,10 @@ impl TryFrom<&BytesMut> for Bind {
         let _len = cursor.get_i32();
 
         let portal = cursor.read_string()?;
-        let portal = Name(portal);
+        let portal = Name::from(portal);
 
         let prepared_statement = cursor.read_string()?;
-        let prepared_statement = Name(prepared_statement);
+        let prepared_statement = Name::from(prepared_statement);
 
         let num_param_format_codes = cursor.get_i16();
         let mut param_format_codes = Vec::new();

--- a/packages/cipherstash-proxy/src/postgresql/messages/close.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/close.rs
@@ -52,7 +52,7 @@ impl TryFrom<&BytesMut> for Close {
         let target = cursor.get_u8();
         let target = Target::try_from(target)?;
         let name = cursor.read_string()?;
-        let name = Name(name);
+        let name = Name::from(name);
 
         Ok(Close { target, name })
     }
@@ -64,7 +64,7 @@ impl TryFrom<Close> for BytesMut {
     fn try_from(close: Close) -> Result<BytesMut, Error> {
         let mut bytes = BytesMut::new();
 
-        let name = CString::new(close.name.0.as_str())?;
+        let name = CString::new(close.name.as_str())?;
         let name = name.as_bytes_with_nul();
 
         let len = SIZE_I32 + SIZE_U8 + name.len();
@@ -122,7 +122,7 @@ mod tests {
         let close = Close::try_from(&bytes).unwrap();
 
         assert!(matches!(close.target, Target::Statement));
-        assert_eq!(close.name.0, "stmt1");
+        assert_eq!(close.name.as_str(), "stmt1");
         assert!(!close.name.is_unnamed());
     }
 
@@ -132,13 +132,13 @@ mod tests {
 
         let close = Close {
             target: Target::Portal,
-            name: Name("portal1".to_string()),
+            name: Name::from("portal1"),
         };
 
         let bytes = BytesMut::try_from(close).unwrap();
         let parsed = Close::try_from(&bytes).unwrap();
 
         assert!(matches!(parsed.target, Target::Portal));
-        assert_eq!(parsed.name.0, "portal1");
+        assert_eq!(parsed.name.as_str(), "portal1");
     }
 }

--- a/packages/cipherstash-proxy/src/postgresql/messages/close.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/close.rs
@@ -1,0 +1,144 @@
+use crate::error::{Error, ProtocolError};
+use crate::postgresql::protocol::BytesMutReadString;
+use crate::{SIZE_I32, SIZE_U8};
+
+use bytes::{Buf, BufMut, BytesMut};
+use std::convert::TryFrom;
+use std::ffi::CString;
+use std::io::Cursor;
+
+use super::target::Target;
+use super::{FrontendCode, Name};
+
+///
+/// Close b'C' (Frontend) message.
+///
+/// See: <https://www.postgresql.org/docs/current/protocol-message-formats.html>
+///
+///     Byte1('C')
+///     Identifies the message as a Close command.
+///
+///     Int32
+///     Length of message contents in bytes, including self.
+///
+///     Byte1
+///     'S' to close a prepared statement; or 'P' to close a portal.
+///
+///     String
+///     The name of the prepared statement or portal to close (an empty string selects the unnamed prepared statement or portal).
+
+#[derive(Debug, Clone)]
+pub(crate) struct Close {
+    pub target: Target,
+    pub name: Name,
+}
+
+impl TryFrom<&BytesMut> for Close {
+    type Error = Error;
+
+    fn try_from(bytes: &BytesMut) -> Result<Close, Self::Error> {
+        let mut cursor = Cursor::new(bytes);
+        let code = cursor.get_u8();
+
+        if FrontendCode::from(code) != FrontendCode::Close {
+            return Err(ProtocolError::UnexpectedMessageCode {
+                expected: FrontendCode::Close.into(),
+                received: code as char,
+            }
+            .into());
+        }
+
+        let _len = cursor.get_i32(); // read and progress cursor
+        let target = cursor.get_u8();
+        let target = Target::try_from(target)?;
+        let name = cursor.read_string()?;
+        let name = Name(name);
+
+        Ok(Close { target, name })
+    }
+}
+
+impl TryFrom<Close> for BytesMut {
+    type Error = Error;
+
+    fn try_from(close: Close) -> Result<BytesMut, Error> {
+        let mut bytes = BytesMut::new();
+
+        let name = CString::new(close.name.0.as_str())?;
+        let name = name.as_bytes_with_nul();
+
+        let len = SIZE_I32 + SIZE_U8 + name.len();
+
+        bytes.put_u8(FrontendCode::Close.into());
+        bytes.put_i32(len as i32);
+        bytes.put_u8(close.target.into());
+        bytes.put_slice(name);
+
+        Ok(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{config::LogConfig, log, postgresql::messages::Name};
+    use bytes::BytesMut;
+    use std::convert::TryFrom;
+
+    fn to_message(s: &[u8]) -> BytesMut {
+        BytesMut::from(s)
+    }
+
+    #[test]
+    pub fn test_close_statement() {
+        log::init(LogConfig::default());
+
+        // Close unnamed prepared statement: C\0\0\0\x06S\0
+        let bytes = to_message(b"C\0\0\0\x06S\0");
+        let close = Close::try_from(&bytes).unwrap();
+
+        assert!(matches!(close.target, Target::Statement));
+        assert!(close.name.is_unnamed());
+    }
+
+    #[test]
+    pub fn test_close_portal() {
+        log::init(LogConfig::default());
+
+        // Close unnamed portal: C\0\0\0\x06P\0
+        let bytes = to_message(b"C\0\0\0\x06P\0");
+        let close = Close::try_from(&bytes).unwrap();
+
+        assert!(matches!(close.target, Target::Portal));
+        assert!(close.name.is_unnamed());
+    }
+
+    #[test]
+    pub fn test_close_named_statement() {
+        log::init(LogConfig::default());
+
+        // Close named prepared statement "stmt1": C\0\0\0\x0bSstmt1\0
+        let bytes = to_message(b"C\0\0\0\x0bSstmt1\0");
+        let close = Close::try_from(&bytes).unwrap();
+
+        assert!(matches!(close.target, Target::Statement));
+        assert_eq!(close.name.0, "stmt1");
+        assert!(!close.name.is_unnamed());
+    }
+
+    #[test]
+    pub fn test_close_to_bytes() {
+        log::init(LogConfig::default());
+
+        let close = Close {
+            target: Target::Portal,
+            name: Name("portal1".to_string()),
+        };
+
+        let bytes = BytesMut::try_from(close).unwrap();
+        let parsed = Close::try_from(&bytes).unwrap();
+
+        assert!(matches!(parsed.target, Target::Portal));
+        assert_eq!(parsed.name.0, "portal1");
+    }
+}

--- a/packages/cipherstash-proxy/src/postgresql/messages/describe.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/describe.rs
@@ -33,7 +33,6 @@ pub(crate) struct Describe {
     pub name: Name,
 }
 
-
 impl TryFrom<&BytesMut> for Describe {
     type Error = Error;
 
@@ -53,7 +52,7 @@ impl TryFrom<&BytesMut> for Describe {
         let target = cursor.get_u8();
         let target = Target::try_from(target)?;
         let name = cursor.read_string()?;
-        let name = Name(name);
+        let name = Name::from(name);
 
         Ok(Describe { target, name })
     }
@@ -65,7 +64,7 @@ impl TryFrom<Describe> for BytesMut {
     fn try_from(describe: Describe) -> Result<BytesMut, Error> {
         let mut bytes = BytesMut::new();
 
-        let name = CString::new(describe.name.0.as_str())?;
+        let name = CString::new(describe.name.as_str())?;
         let name = name.as_bytes_with_nul();
 
         let len = SIZE_I32 + SIZE_U8 + name.len();
@@ -78,4 +77,3 @@ impl TryFrom<Describe> for BytesMut {
         Ok(bytes)
     }
 }
-

--- a/packages/cipherstash-proxy/src/postgresql/messages/describe.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/describe.rs
@@ -7,6 +7,7 @@ use std::convert::TryFrom;
 use std::ffi::CString;
 use std::io::Cursor;
 
+use super::target::Target;
 use super::{FrontendCode, Name};
 
 ///
@@ -32,28 +33,6 @@ pub(crate) struct Describe {
     pub name: Name,
 }
 
-///
-/// The target of the describe message.
-///
-/// Valid values are PreparedStatment or Portal
-///
-/// A Portal is a parsed statement PLUS any bound parameters
-/// Describe with `Target::Portal` returns the RowDescription describing the result set.
-/// The assuumption is that the parameters are already bound to the portal, so the Describe message is not required to include any parameter information.
-///
-/// Calls to Execute are made on a Portal (not a prepared statement) as execute requires any bound parameters
-///
-/// A PreparedStatement is the parsed statement
-/// Describe with `Target::PreparedStatement` returns a ParameterDescription followed by the RowDescription.
-///
-///
-/// See https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
-///
-#[derive(Debug, Clone)]
-pub enum Target {
-    Portal,
-    PreparedStatement,
-}
 
 impl TryFrom<&BytesMut> for Describe {
     type Error = Error;
@@ -93,21 +72,10 @@ impl TryFrom<Describe> for BytesMut {
 
         bytes.put_u8(FrontendCode::Describe.into());
         bytes.put_i32(len as i32);
-        bytes.put_u8(describe.target as u8);
+        bytes.put_u8(describe.target.into());
         bytes.put_slice(name);
 
         Ok(bytes)
     }
 }
 
-impl TryFrom<u8> for Target {
-    type Error = Error;
-
-    fn try_from(t: u8) -> Result<Target, Error> {
-        match t as char {
-            'S' => Ok(Target::PreparedStatement),
-            'P' => Ok(Target::Portal),
-            t => Err(ProtocolError::UnexpectedDescribeTarget(t).into()),
-        }
-    }
-}

--- a/packages/cipherstash-proxy/src/postgresql/messages/execute.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/execute.rs
@@ -29,7 +29,7 @@ impl TryFrom<&BytesMut> for Execute {
         let _len = cursor.get_i32(); // read and progress cursor
 
         let portal = cursor.read_string()?;
-        let portal = Name(portal);
+        let portal = Name::from(portal);
         let max_rows = cursor.get_i32();
 
         Ok(Execute { portal, max_rows })

--- a/packages/cipherstash-proxy/src/postgresql/messages/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/mod.rs
@@ -1,7 +1,10 @@
+use std::fmt;
+
 use bytes::BytesMut;
 
 pub mod authentication;
 pub mod bind;
+pub mod close;
 pub mod data_row;
 pub mod describe;
 pub mod error_response;
@@ -11,15 +14,21 @@ pub mod parse;
 pub mod query;
 pub mod ready_for_query;
 pub mod row_description;
+pub mod target;
 pub mod terminate;
+
+// Re-export commonly used types
+pub use target::Target;
 
 pub const NULL: i32 = -1;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FrontendCode {
     Bind,
+    Close,
     Describe,
     Execute,
+    Flush,
     Parse,
     PasswordMessage,
     Query,
@@ -65,8 +74,10 @@ impl From<char> for FrontendCode {
     fn from(code: char) -> Self {
         match code {
             'B' => FrontendCode::Bind,
+            'C' => FrontendCode::Close,
             'D' => FrontendCode::Describe,
             'E' => FrontendCode::Execute,
+            'H' => FrontendCode::Flush,
             'p' => FrontendCode::PasswordMessage,
             'P' => FrontendCode::Parse,
             'Q' => FrontendCode::Query,
@@ -85,8 +96,10 @@ impl From<FrontendCode> for u8 {
     fn from(code: FrontendCode) -> Self {
         match code {
             FrontendCode::Bind => b'B',
+            FrontendCode::Close => b'C',
             FrontendCode::Describe => b'D',
             FrontendCode::Execute => b'E',
+            FrontendCode::Flush => b'F',
             FrontendCode::Parse => b'P',
             FrontendCode::PasswordMessage => b'p',
             FrontendCode::Query => b'Q',
@@ -103,8 +116,10 @@ impl From<FrontendCode> for char {
     fn from(code: FrontendCode) -> Self {
         match code {
             FrontendCode::Bind => 'B',
+            FrontendCode::Close => 'C',
             FrontendCode::Describe => 'D',
             FrontendCode::Execute => 'E',
+            FrontendCode::Flush => 'F',
             FrontendCode::Parse => 'P',
             FrontendCode::PasswordMessage => 'p',
             FrontendCode::Query => 'Q',
@@ -197,6 +212,54 @@ impl From<BackendCode> for char {
             BackendCode::ReadyForQuery => 'Z',
             BackendCode::RowDescription => 'T',
             BackendCode::Unknown(c) => c,
+        }
+    }
+}
+
+impl fmt::Display for BackendCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BackendCode::Authentication => write!(f, "BackendCode::Authentication"),
+            BackendCode::BackendKeyData => write!(f, "BackendCode::BackendKeyData"),
+            BackendCode::BindComplete => write!(f, "BackendCode::BindComplete"),
+            BackendCode::CloseComplete => write!(f, "BackendCode::CloseComplete"),
+            BackendCode::CommandComplete => write!(f, "BackendCode::CommandComplete"),
+            BackendCode::CopyBothResponse => write!(f, "BackendCode::CopyBothResponse"),
+            BackendCode::CopyInResponse => write!(f, "BackendCode::CopyInResponse"),
+            BackendCode::CopyOutResponse => write!(f, "BackendCode::CopyOutResponse"),
+            BackendCode::DataRow => write!(f, "BackendCode::DataRow"),
+            BackendCode::EmptyQueryResponse => write!(f, "BackendCode::EmptyQueryResponse"),
+            BackendCode::ErrorResponse => write!(f, "BackendCode::ErrorResponse"),
+            BackendCode::NoData => write!(f, "BackendCode::NoData"),
+            BackendCode::NoticeResponse => write!(f, "BackendCode::NoticeResponse"),
+            BackendCode::NotificationResponse => write!(f, "BackendCode::NotificationResponse"),
+            BackendCode::ParameterDescription => write!(f, "BackendCode::ParameterDescription"),
+            BackendCode::ParameterStatus => write!(f, "BackendCode::ParameterStatus"),
+            BackendCode::ParseComplete => write!(f, "BackendCode::ParseComplete"),
+            BackendCode::PortalSuspended => write!(f, "BackendCode::PortalSuspended"),
+            BackendCode::ReadyForQuery => write!(f, "BackendCode::ReadyForQuery"),
+            BackendCode::RowDescription => write!(f, "BackendCode::RowDescription"),
+            BackendCode::Unknown(c) => write!(f, "BackendCode::Unknown('{}')", c),
+        }
+    }
+}
+
+impl fmt::Display for FrontendCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FrontendCode::Bind => write!(f, "FrontendCode::Bind"),
+            FrontendCode::Close => write!(f, "FrontendCode::Close"),
+            FrontendCode::Describe => write!(f, "FrontendCode::Describe"),
+            FrontendCode::Execute => write!(f, "FrontendCode::Execute"),
+            FrontendCode::Flush => write!(f, "FrontendCode::Flush"),
+            FrontendCode::Parse => write!(f, "FrontendCode::Parse"),
+            FrontendCode::PasswordMessage => write!(f, "FrontendCode::PasswordMessage"),
+            FrontendCode::Query => write!(f, "FrontendCode::Query"),
+            FrontendCode::SASLInitialResponse => write!(f, "FrontendCode::SASLInitialResponse"),
+            FrontendCode::SASLResponse => write!(f, "FrontendCode::SASLResponse"),
+            FrontendCode::Sync => write!(f, "FrontendCode::Sync"),
+            FrontendCode::Terminate => write!(f, "FrontendCode::Terminate"),
+            FrontendCode::Unknown(c) => write!(f, "FrontendCode::Unknown('{}')", c),
         }
     }
 }

--- a/packages/cipherstash-proxy/src/postgresql/messages/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/mod.rs
@@ -9,6 +9,7 @@ pub mod data_row;
 pub mod describe;
 pub mod error_response;
 pub mod execute;
+pub mod name;
 pub mod param_description;
 pub mod parse;
 pub mod query;
@@ -18,6 +19,7 @@ pub mod target;
 pub mod terminate;
 
 // Re-export commonly used types
+pub use name::Name;
 pub use target::Target;
 
 pub const NULL: i32 = -1;
@@ -261,27 +263,6 @@ impl fmt::Display for FrontendCode {
             FrontendCode::Terminate => write!(f, "FrontendCode::Terminate"),
             FrontendCode::Unknown(c) => write!(f, "FrontendCode::Unknown('{}')", c),
         }
-    }
-}
-
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
-pub struct Name(pub String);
-
-impl Name {
-    pub fn unnamed() -> Name {
-        Name("".to_string())
-    }
-
-    pub fn is_unnamed(&self) -> bool {
-        self.0.is_empty()
-    }
-}
-
-impl std::ops::Deref for Name {
-    type Target = str;
-
-    fn deref(&self) -> &str {
-        self.0.as_str()
     }
 }
 

--- a/packages/cipherstash-proxy/src/postgresql/messages/name.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/name.rs
@@ -1,0 +1,50 @@
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub enum Name {
+    Named(String),
+    Unnamed,
+}
+
+impl Name {
+    pub fn unnamed() -> Name {
+        Name::Unnamed
+    }
+
+    pub fn is_unnamed(&self) -> bool {
+        matches!(self, Name::Unnamed)
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Name::Named(s) => s,
+            Name::Unnamed => "",
+        }
+    }
+}
+
+impl std::ops::Deref for Name {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl From<String> for Name {
+    fn from(s: String) -> Self {
+        if s.is_empty() {
+            Name::Unnamed
+        } else {
+            Name::Named(s)
+        }
+    }
+}
+
+impl From<&str> for Name {
+    fn from(s: &str) -> Self {
+        if s.is_empty() {
+            Name::Unnamed
+        } else {
+            Name::Named(s.to_string())
+        }
+    }
+}

--- a/packages/cipherstash-proxy/src/postgresql/messages/parse.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/parse.rs
@@ -62,7 +62,7 @@ impl TryFrom<&BytesMut> for Parse {
 
         let _len = cursor.get_i32();
         let name = cursor.read_string()?;
-        let name = Name(name);
+        let name = Name::from(name);
 
         let statement = cursor.read_string()?;
         let num_params = cursor.get_i16();
@@ -89,7 +89,7 @@ impl TryFrom<Parse> for BytesMut {
     fn try_from(parse: Parse) -> Result<BytesMut, Error> {
         let mut bytes = BytesMut::new();
 
-        let name = CString::new(parse.name.0.as_str())?;
+        let name = CString::new(parse.name.as_str())?;
         let name = name.as_bytes_with_nul();
 
         let statement = CString::new(parse.statement)?;

--- a/packages/cipherstash-proxy/src/postgresql/messages/target.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/target.rs
@@ -1,0 +1,46 @@
+use crate::error::{Error, ProtocolError};
+use std::convert::TryFrom;
+
+///
+/// The target of describe or close messages.
+///
+/// Valid values are PreparedStatement or Portal
+///
+/// A Portal is a parsed statement PLUS any bound parameters
+/// Describe with `Target::Portal` returns the RowDescription describing the result set.
+/// The assumption is that the parameters are already bound to the portal, so the Describe message is not required to include any parameter information.
+///
+/// Calls to Execute are made on a Portal (not a prepared statement) as execute requires any bound parameters
+///
+/// A Statement is the parsed statement
+/// Describe with `Target::Statement` returns a ParameterDescription followed by the RowDescription.
+///
+///
+/// See https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
+///
+#[derive(Debug, Clone)]
+pub enum Target {
+    Portal,
+    Statement,
+}
+
+impl TryFrom<u8> for Target {
+    type Error = Error;
+
+    fn try_from(t: u8) -> Result<Target, Error> {
+        match t as char {
+            'S' => Ok(Target::Statement),
+            'P' => Ok(Target::Portal),
+            t => Err(ProtocolError::UnexpectedDescribeTarget(t).into()),
+        }
+    }
+}
+
+impl From<Target> for u8 {
+    fn from(target: Target) -> u8 {
+        match target {
+            Target::Statement => b'S',
+            Target::Portal => b'P',
+        }
+    }
+}


### PR DESCRIPTION
♻️ refactor: convert Name struct to enum and extract to own module
- Convert Name from struct to enum with Named(String) and Unnamed variants
- Extract Name type into dedicated name.rs module for better organization
- Add From<String> and From<&str> implementations for convenient construction
- Update all usage sites to use Name::from() constructor
- Update field access from .0 to .as_str() method
- Maintain backward compatibility through re-exports and Deref trait
- Improve type safety by preventing empty named statements