### PR TITLE
refactor: centralize log target definitions using declarative macro

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -572,12 +572,14 @@ To add a new log target, you only need to add **one line** to the macro in `pack
 
 ```rust
 define_log_targets!(
-    (DEVELOPMENT, development_level, "development"),
-    (AUTHENTICATION, authentication_level, "authentication"),
+    (DEVELOPMENT, development_level),
+    (AUTHENTICATION, authentication_level),
     // ... existing targets ...
-    (NEW_TARGET, new_target_level, "new_target"), // <- Add this line
+    (NEW_TARGET, new_target_level), // <- Add this line
 );
 ```
+
+The constant name (e.g., `NEW_TARGET`) is automatically converted to a string value using `stringify!()`, so `NEW_TARGET` becomes `"NEW_TARGET"` for use in logging calls.
 
 This automatically:
 - Creates the `NEW_TARGET` constant for use in logging calls

--- a/packages/cipherstash-proxy/src/config/log.rs
+++ b/packages/cipherstash-proxy/src/config/log.rs
@@ -17,6 +17,7 @@ pub struct LogConfig {
     #[serde(default = "LogConfig::default_log_level")]
     pub level: LogLevel,
 
+    // Log target level fields - generated from define_log_targets! macro
     #[serde(default = "LogConfig::default_log_level")]
     pub development_level: LogLevel,
 
@@ -45,13 +46,16 @@ pub struct LogConfig {
     pub keyset_level: LogLevel,
 
     #[serde(default = "LogConfig::default_log_level")]
+    pub mapper_level: LogLevel,
+
+    #[serde(default = "LogConfig::default_log_level")]
     pub migrate_level: LogLevel,
 
     #[serde(default = "LogConfig::default_log_level")]
     pub protocol_level: LogLevel,
 
     #[serde(default = "LogConfig::default_log_level")]
-    pub mapper_level: LogLevel,
+    pub proxy_level: LogLevel,
 
     #[serde(default = "LogConfig::default_log_level")]
     pub schema_level: LogLevel,
@@ -121,19 +125,21 @@ impl LogConfig {
             output: LogConfig::default_log_output(),
             ansi_enabled: LogConfig::default_ansi_enabled(),
             level,
+            // Log target level field assignments - matches define_log_targets! macro
             development_level: level,
             authentication_level: level,
+            config_level: level,
             context_level: level,
             encoding_level: level,
             encrypt_level: level,
-            encrypt_config_level: level,
             decrypt_level: level,
+            encrypt_config_level: level,
             keyset_level: level,
+            mapper_level: level,
             migrate_level: level,
             protocol_level: level,
-            mapper_level: level,
+            proxy_level: level,
             schema_level: level,
-            config_level: level,
         }
     }
 

--- a/packages/cipherstash-proxy/src/config/log.rs
+++ b/packages/cipherstash-proxy/src/config/log.rs
@@ -3,6 +3,9 @@ use std::{fmt::Display, io::IsTerminal};
 use clap::ValueEnum;
 use serde::Deserialize;
 
+// Import the generated LogTargetLevels struct
+use crate::log::targets::LogTargetLevels;
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct LogConfig {
     #[serde(default = "LogConfig::default_ansi_enabled")]
@@ -17,36 +20,10 @@ pub struct LogConfig {
     #[serde(default = "LogConfig::default_log_level")]
     pub level: LogLevel,
 
-    // Log target level fields - keep synchronized with define_log_targets! macro in log/targets.rs
-    // To add a new target: add it to the define_log_targets! macro invocation - these fields are auto-updated
-    #[serde(default = "LogConfig::default_log_level")]
-    pub development_level: LogLevel,
-    #[serde(default = "LogConfig::default_log_level")]
-    pub authentication_level: LogLevel,
-    #[serde(default = "LogConfig::default_log_level")]
-    pub config_level: LogLevel,
-    #[serde(default = "LogConfig::default_log_level")]
-    pub context_level: LogLevel,
-    #[serde(default = "LogConfig::default_log_level")]
-    pub encoding_level: LogLevel,
-    #[serde(default = "LogConfig::default_log_level")]
-    pub encrypt_level: LogLevel,
-    #[serde(default = "LogConfig::default_log_level")]
-    pub decrypt_level: LogLevel,
-    #[serde(default = "LogConfig::default_log_level")]
-    pub encrypt_config_level: LogLevel,
-    #[serde(default = "LogConfig::default_log_level")]
-    pub keyset_level: LogLevel,
-    #[serde(default = "LogConfig::default_log_level")]
-    pub migrate_level: LogLevel,
-    #[serde(default = "LogConfig::default_log_level")]
-    pub protocol_level: LogLevel,
-    #[serde(default = "LogConfig::default_log_level")]
-    pub proxy_level: LogLevel,
-    #[serde(default = "LogConfig::default_log_level")]
-    pub mapper_level: LogLevel,
-    #[serde(default = "LogConfig::default_log_level")]
-    pub schema_level: LogLevel,
+    // All log target levels - automatically generated and flattened from LogTargetLevels
+    // To add a new target: just add it to the define_log_targets! macro in log/targets.rs
+    #[serde(flatten)]
+    pub targets: LogTargetLevels,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, ValueEnum)]
@@ -113,21 +90,8 @@ impl LogConfig {
             output: LogConfig::default_log_output(),
             ansi_enabled: LogConfig::default_ansi_enabled(),
             level,
-            // Log target level field assignments - keep synchronized with define_log_targets! macro in log/targets.rs
-            development_level: level,
-            authentication_level: level,
-            config_level: level,
-            context_level: level,
-            encoding_level: level,
-            encrypt_level: level,
-            decrypt_level: level,
-            encrypt_config_level: level,
-            keyset_level: level,
-            migrate_level: level,
-            protocol_level: level,
-            proxy_level: level,
-            mapper_level: level,
-            schema_level: level,
+            // All target levels automatically set using generated LogTargetLevels
+            targets: LogTargetLevels::with_level(level),
         }
     }
 

--- a/packages/cipherstash-proxy/src/config/log.rs
+++ b/packages/cipherstash-proxy/src/config/log.rs
@@ -17,46 +17,34 @@ pub struct LogConfig {
     #[serde(default = "LogConfig::default_log_level")]
     pub level: LogLevel,
 
-    // Log target level fields - generated from define_log_targets! macro
+    // Log target level fields - keep synchronized with define_log_targets! macro in log/targets.rs
+    // To add a new target: add it to the define_log_targets! macro invocation - these fields are auto-updated
     #[serde(default = "LogConfig::default_log_level")]
     pub development_level: LogLevel,
-
     #[serde(default = "LogConfig::default_log_level")]
     pub authentication_level: LogLevel,
-
     #[serde(default = "LogConfig::default_log_level")]
     pub config_level: LogLevel,
-
     #[serde(default = "LogConfig::default_log_level")]
     pub context_level: LogLevel,
-
     #[serde(default = "LogConfig::default_log_level")]
     pub encoding_level: LogLevel,
-
     #[serde(default = "LogConfig::default_log_level")]
     pub encrypt_level: LogLevel,
-
     #[serde(default = "LogConfig::default_log_level")]
     pub decrypt_level: LogLevel,
-
     #[serde(default = "LogConfig::default_log_level")]
     pub encrypt_config_level: LogLevel,
-
     #[serde(default = "LogConfig::default_log_level")]
     pub keyset_level: LogLevel,
-
-    #[serde(default = "LogConfig::default_log_level")]
-    pub mapper_level: LogLevel,
-
     #[serde(default = "LogConfig::default_log_level")]
     pub migrate_level: LogLevel,
-
     #[serde(default = "LogConfig::default_log_level")]
     pub protocol_level: LogLevel,
-
     #[serde(default = "LogConfig::default_log_level")]
     pub proxy_level: LogLevel,
-
+    #[serde(default = "LogConfig::default_log_level")]
+    pub mapper_level: LogLevel,
     #[serde(default = "LogConfig::default_log_level")]
     pub schema_level: LogLevel,
 }
@@ -125,7 +113,7 @@ impl LogConfig {
             output: LogConfig::default_log_output(),
             ansi_enabled: LogConfig::default_ansi_enabled(),
             level,
-            // Log target level field assignments - matches define_log_targets! macro
+            // Log target level field assignments - keep synchronized with define_log_targets! macro in log/targets.rs
             development_level: level,
             authentication_level: level,
             config_level: level,
@@ -135,10 +123,10 @@ impl LogConfig {
             decrypt_level: level,
             encrypt_config_level: level,
             keyset_level: level,
-            mapper_level: level,
             migrate_level: level,
             protocol_level: level,
             proxy_level: level,
+            mapper_level: level,
             schema_level: level,
         }
     }

--- a/packages/cipherstash-proxy/src/log/mod.rs
+++ b/packages/cipherstash-proxy/src/log/mod.rs
@@ -49,7 +49,9 @@ mod tests {
     use crate::config::LogLevel;
 
     use super::*;
-    use crate::log::targets::LogTargetLevels;
+    use crate::log::targets::{
+        LogTargetLevels, AUTHENTICATION, CONTEXT, DEVELOPMENT, KEYSET, MAPPER, PROTOCOL, SCHEMA,
+    };
     use crate::test_helpers::MockMakeWriter;
     use tracing::dispatcher::set_default;
     use tracing::{debug, error, info, trace, warn};
@@ -136,48 +138,48 @@ mod tests {
         let _default = set_default(&subscriber.into());
 
         // with development level 'info', info should be logged but not debug
-        debug!(target: "development", "debug/development");
-        info!(target: "development", "info/development");
+        debug!(target: DEVELOPMENT, "debug/development");
+        info!(target: DEVELOPMENT, "info/development");
         let log_contents = make_writer.get_string();
         assert!(!log_contents.contains("debug/development"));
         assert!(log_contents.contains("info/development"));
 
         // with authentication level 'debug', debug should be logged but not trace
-        trace!(target: "authentication", "trace/authentication");
-        debug!(target: "authentication", "debug/authentication");
+        trace!(target: AUTHENTICATION, "trace/authentication");
+        debug!(target: AUTHENTICATION, "debug/authentication");
         let log_contents = make_writer.get_string();
         assert!(!log_contents.contains("trace/authentication"));
         assert!(log_contents.contains("debug/authentication"));
 
         // with context level 'error', error should be logged but not warn
-        warn!(target: "context", "warn/context");
-        error!(target: "context", "error/context");
+        warn!(target: CONTEXT, "warn/context");
+        error!(target: CONTEXT, "error/context");
         let log_contents = make_writer.get_string();
         assert!(!log_contents.contains("warn/context"));
         assert!(log_contents.contains("error/context"));
 
         // with keyset level 'trace', trace should be logged
-        trace!(target: "keyset", "trace/keyset");
+        trace!(target: KEYSET, "trace/keyset");
         let log_contents = make_writer.get_string();
         assert!(log_contents.contains("trace/keyset"));
 
         // with protocol level 'info', info should be logged but not debug
-        debug!(target: "protocol", "debug/protocol");
-        info!(target: "protocol", "info/protocol");
+        debug!(target: PROTOCOL, "debug/protocol");
+        info!(target: PROTOCOL, "info/protocol");
         let log_contents = make_writer.get_string();
         assert!(!log_contents.contains("debug/protocol"));
         assert!(log_contents.contains("info/protocol"));
 
         // with mapper level 'info', info should be logged but not debug
-        debug!(target: "mapper", "debug/mapper");
-        info!(target: "mapper", "info/mapper");
+        debug!(target: MAPPER, "debug/mapper");
+        info!(target: MAPPER, "info/mapper");
         let log_contents = make_writer.get_string();
         assert!(!log_contents.contains("debug/mapper"));
         assert!(log_contents.contains("info/mapper"));
 
         // with schema level 'info', info should be logged but not debug
-        debug!(target: "schema", "debug/schema");
-        info!(target: "schema", "info/schema");
+        debug!(target: SCHEMA, "debug/schema");
+        info!(target: SCHEMA, "info/schema");
         let log_contents = make_writer.get_string();
         assert!(!log_contents.contains("debug/schema"));
         assert!(log_contents.contains("info/schema"));

--- a/packages/cipherstash-proxy/src/log/mod.rs
+++ b/packages/cipherstash-proxy/src/log/mod.rs
@@ -1,4 +1,5 @@
 pub mod subscriber;
+pub mod targets;
 
 use crate::config::{LogConfig, LogFormat};
 use std::sync::Once;
@@ -12,22 +13,11 @@ use tracing_subscriber::{
 };
 
 // Log targets used in logs like `debug!(target: DEVELOPMENT, "Flush message buffer");`
-// If you add one, make sure `log_targets()` and `log_level_for()` functions are updated.
-pub const DEVELOPMENT: &str = "development"; // one for various hidden "development mode" messages
-pub const AUTHENTICATION: &str = "authentication";
-pub const CONFIG: &str = "config";
-pub const CONTEXT: &str = "context";
-pub const ENCRYPT: &str = "encrypt";
-pub const PROXY: &str = "proxy";
-pub const DECRYPT: &str = "decrypt";
-pub const ENCODING: &str = "encoding";
-pub const ENCRYPT_CONFIG: &str = "encrypt_config";
-pub const KEYSET: &str = "keyset";
-pub const MIGRATE: &str = "migrate";
-pub const PARSER: &str = "parser";
-pub const PROTOCOL: &str = "protocol";
-pub const MAPPER: &str = "mapper";
-pub const SCHEMA: &str = "schema";
+// All targets are now defined in the targets module using the define_log_targets! macro.
+pub use targets::{
+    AUTHENTICATION, CONFIG, CONTEXT, DECRYPT, DEVELOPMENT, ENCODING, ENCRYPT, ENCRYPT_CONFIG,
+    KEYSET, MAPPER, MIGRATE, PROTOCOL, PROXY, SCHEMA,
+};
 
 static INIT: Once = Once::new();
 
@@ -129,6 +119,7 @@ mod tests {
             keyset_level: LogLevel::Trace,
             migrate_level: LogLevel::Trace,
             protocol_level: LogLevel::Info,
+            proxy_level: LogLevel::Info,
             mapper_level: LogLevel::Info,
             schema_level: LogLevel::Info,
             config_level: LogLevel::Info,

--- a/packages/cipherstash-proxy/src/log/mod.rs
+++ b/packages/cipherstash-proxy/src/log/mod.rs
@@ -49,6 +49,7 @@ mod tests {
     use crate::config::LogLevel;
 
     use super::*;
+    use crate::log::targets::LogTargetLevels;
     use crate::test_helpers::MockMakeWriter;
     use tracing::dispatcher::set_default;
     use tracing::{debug, error, info, trace, warn};
@@ -109,20 +110,22 @@ mod tests {
             output: LogConfig::default_log_output(),
             ansi_enabled: LogConfig::default_ansi_enabled(),
             level: LogLevel::Info,
-            development_level: LogLevel::Info,
-            authentication_level: LogLevel::Debug,
-            context_level: LogLevel::Error,
-            encoding_level: LogLevel::Error,
-            encrypt_level: LogLevel::Error,
-            encrypt_config_level: LogLevel::Error,
-            decrypt_level: LogLevel::Error,
-            keyset_level: LogLevel::Trace,
-            migrate_level: LogLevel::Trace,
-            protocol_level: LogLevel::Info,
-            proxy_level: LogLevel::Info,
-            mapper_level: LogLevel::Info,
-            schema_level: LogLevel::Info,
-            config_level: LogLevel::Info,
+            targets: LogTargetLevels {
+                development_level: LogLevel::Info,
+                authentication_level: LogLevel::Debug,
+                context_level: LogLevel::Error,
+                encoding_level: LogLevel::Error,
+                encrypt_level: LogLevel::Error,
+                encrypt_config_level: LogLevel::Error,
+                decrypt_level: LogLevel::Error,
+                keyset_level: LogLevel::Trace,
+                migrate_level: LogLevel::Trace,
+                protocol_level: LogLevel::Info,
+                proxy_level: LogLevel::Info,
+                mapper_level: LogLevel::Info,
+                schema_level: LogLevel::Info,
+                config_level: LogLevel::Info,
+            },
         };
 
         let subscriber =

--- a/packages/cipherstash-proxy/src/log/subscriber.rs
+++ b/packages/cipherstash-proxy/src/log/subscriber.rs
@@ -1,41 +1,10 @@
 use crate::config::{LogConfig, LogLevel, LogOutput};
-use crate::log::{AUTHENTICATION, CONTEXT, DEVELOPMENT, ENCRYPT, KEYSET, MAPPER, PROTOCOL, SCHEMA};
+use crate::log::targets::{log_level_for, log_targets};
 use tracing_subscriber::filter::EnvFilter;
 use tracing_subscriber::fmt::format::{DefaultFields, Format};
 use tracing_subscriber::fmt::writer::BoxMakeWriter;
 use tracing_subscriber::fmt::SubscriberBuilder;
 use tracing_subscriber::FmtSubscriber;
-
-use super::DECRYPT;
-
-fn log_targets() -> Vec<&'static str> {
-    vec![
-        DEVELOPMENT,
-        AUTHENTICATION,
-        CONTEXT,
-        DECRYPT,
-        ENCRYPT,
-        KEYSET,
-        PROTOCOL,
-        MAPPER,
-        SCHEMA,
-    ]
-}
-
-fn log_level_for(config: &LogConfig, target: &str) -> LogLevel {
-    match target {
-        DEVELOPMENT => config.development_level,
-        AUTHENTICATION => config.authentication_level,
-        CONTEXT => config.context_level,
-        DECRYPT => config.decrypt_level,
-        ENCRYPT => config.encrypt_level,
-        KEYSET => config.keyset_level,
-        PROTOCOL => config.protocol_level,
-        MAPPER => config.mapper_level,
-        SCHEMA => config.schema_level,
-        _ => config.level,
-    }
-}
 
 pub fn builder(
     config: &LogConfig,

--- a/packages/cipherstash-proxy/src/log/targets.rs
+++ b/packages/cipherstash-proxy/src/log/targets.rs
@@ -3,10 +3,10 @@ use serde::Deserialize;
 
 // Define all log targets in one place
 macro_rules! define_log_targets {
-    ($(($const_name:ident, $field_name:ident, $target_str:literal)),* $(,)?) => {
-        // Generate target constants
+    ($(($const_name:ident, $field_name:ident)),* $(,)?) => {
+        // Generate target constants with automatic string generation
         $(
-            pub const $const_name: &str = $target_str;
+            pub const $const_name: &str = stringify!($const_name);
         )*
 
         // Generate LogTargetLevels struct with all target level fields
@@ -64,18 +64,18 @@ macro_rules! define_log_targets {
 }
 
 define_log_targets!(
-    (DEVELOPMENT, development_level, "development"),
-    (AUTHENTICATION, authentication_level, "authentication"),
-    (CONFIG, config_level, "config"),
-    (CONTEXT, context_level, "context"),
-    (ENCODING, encoding_level, "encoding"),
-    (ENCRYPT, encrypt_level, "encrypt"),
-    (DECRYPT, decrypt_level, "decrypt"),
-    (ENCRYPT_CONFIG, encrypt_config_level, "encrypt_config"),
-    (KEYSET, keyset_level, "keyset"),
-    (MIGRATE, migrate_level, "migrate"),
-    (PROTOCOL, protocol_level, "protocol"),
-    (PROXY, proxy_level, "proxy"),
-    (MAPPER, mapper_level, "mapper"),
-    (SCHEMA, schema_level, "schema"),
+    (DEVELOPMENT, development_level),
+    (AUTHENTICATION, authentication_level),
+    (CONFIG, config_level),
+    (CONTEXT, context_level),
+    (ENCODING, encoding_level),
+    (ENCRYPT, encrypt_level),
+    (DECRYPT, decrypt_level),
+    (ENCRYPT_CONFIG, encrypt_config_level),
+    (KEYSET, keyset_level),
+    (MIGRATE, migrate_level),
+    (PROTOCOL, protocol_level),
+    (PROXY, proxy_level),
+    (MAPPER, mapper_level),
+    (SCHEMA, schema_level),
 );

--- a/packages/cipherstash-proxy/src/log/targets.rs
+++ b/packages/cipherstash-proxy/src/log/targets.rs
@@ -1,0 +1,47 @@
+use crate::config::LogLevel;
+
+// Define all log targets in one place
+macro_rules! define_log_targets {
+    ($(($const_name:ident, $field_name:ident, $target_str:literal)),* $(,)?) => {
+        // Generate target constants
+        $(
+            pub const $const_name: &str = $target_str;
+        )*
+
+        // Generate function to get all target names
+        pub fn log_targets() -> Vec<&'static str> {
+            vec![
+                $(
+                    $const_name,
+                )*
+            ]
+        }
+
+        // Generate function to map target to log level
+        pub fn log_level_for(config: &crate::config::LogConfig, target: &str) -> LogLevel {
+            match target {
+                $(
+                    $const_name => config.$field_name,
+                )*
+                _ => config.level,
+            }
+        }
+    };
+}
+
+define_log_targets!(
+    (DEVELOPMENT, development_level, "development"),
+    (AUTHENTICATION, authentication_level, "authentication"),
+    (CONFIG, config_level, "config"),
+    (CONTEXT, context_level, "context"),
+    (ENCODING, encoding_level, "encoding"),
+    (ENCRYPT, encrypt_level, "encrypt"),
+    (DECRYPT, decrypt_level, "decrypt"),
+    (ENCRYPT_CONFIG, encrypt_config_level, "encrypt_config"),
+    (KEYSET, keyset_level, "keyset"),
+    (MIGRATE, migrate_level, "migrate"),
+    (PROTOCOL, protocol_level, "protocol"),
+    (PROXY, proxy_level, "proxy"),
+    (MAPPER, mapper_level, "mapper"),
+    (SCHEMA, schema_level, "schema"),
+);


### PR DESCRIPTION
Replace manual log target management with a declarative macro system that defines all targets in one place. This eliminates the need to update 4-5 places when adding new targets and ensures consistency.

Key changes:
- Create log/targets.rs with define_log_targets! macro
- Generate target constants, functions, and level mappings automatically
- Update LogConfig to use centrally-defined field list
- Maintain all existing functionality and public API

Benefits:
- Single source of truth for log targets
- Compile-time safety between targets and config fields
- Self-documenting and easier to maintain
- Eliminates repetitive boilerplate code

