### PR TITLE
♻️ refactor: extract SQL parsing logic into dedicated Parser module

### DIFF
--- a/packages/cipherstash-proxy/src/postgresql/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/mod.rs
@@ -7,6 +7,7 @@ mod frontend;
 mod handler;
 mod message_buffer;
 mod messages;
+mod parser;
 mod protocol;
 mod startup;
 

--- a/packages/cipherstash-proxy/src/postgresql/parser.rs
+++ b/packages/cipherstash-proxy/src/postgresql/parser.rs
@@ -1,0 +1,34 @@
+use crate::error::Error;
+use crate::prometheus::STATEMENTS_TOTAL;
+use metrics::counter;
+use sqltk::parser::ast;
+use sqltk::parser::dialect::PostgreSqlDialect;
+use sqltk::parser::parser::Parser;
+
+const DIALECT: PostgreSqlDialect = PostgreSqlDialect {};
+
+pub struct SqlParser;
+
+impl SqlParser {
+    /// Parse a SQL statement string into an SqlParser AST
+    pub fn parse_statement(statement: &str) -> Result<ast::Statement, Error> {
+        let statement = Parser::new(&DIALECT)
+            .try_with_sql(statement)?
+            .parse_statement()?;
+
+        counter!(STATEMENTS_TOTAL).increment(1);
+
+        Ok(statement)
+    }
+
+    /// Parse a SQL String potentially containing multiple statements into parsed SqlParser AST
+    pub fn parse_statements(statement: &str) -> Result<Vec<ast::Statement>, Error> {
+        let statement = Parser::new(&DIALECT)
+            .try_with_sql(statement)?
+            .parse_statements()?;
+
+        counter!(STATEMENTS_TOTAL).increment(statement.len() as u64);
+
+        Ok(statement)
+    }
+}


### PR DESCRIPTION
Move parse_statement and parse_statements functions from Frontend to new SqlParser module to reduce cognitive load and improve code organization.

- Create packages/cipherstash-proxy/src/postgresql/parser.rs with SqlParser struct
- Move parsing functions with metrics tracking intact
- Update frontend.rs to use SqlParser::parse_statement and SqlParser::parse_statements
- Clean up unused imports and constants in frontend.rs
