### PR TITLE
♻️ refactor: extract column mapping logic into ColumnMapper module

### DIFF
--- a/packages/cipherstash-proxy/src/postgresql/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/frontend.rs
@@ -798,21 +798,15 @@ where
         typed_statement: &TypeCheckedStatement<'_>,
         param_types: Vec<i32>,
     ) -> Result<Option<Statement>, Error> {
-        let param_columns = ColumnMapper::get_param_columns(
-            typed_statement,
-            |id| self.proxy.get_column_config(id),
-            self.context.client_id,
-        )?;
-        let projection_columns = ColumnMapper::get_projection_columns(
-            typed_statement,
-            |id| self.proxy.get_column_config(id),
-            self.context.client_id,
-        )?;
-        let literal_columns = ColumnMapper::get_literal_columns(
-            typed_statement,
-            |id| self.proxy.get_column_config(id),
-            self.context.client_id,
-        )?;
+        let param_columns = ColumnMapper::get_param_columns(typed_statement, |id| {
+            self.proxy.get_column_config(id)
+        })?;
+        let projection_columns = ColumnMapper::get_projection_columns(typed_statement, |id| {
+            self.proxy.get_column_config(id)
+        })?;
+        let literal_columns = ColumnMapper::get_literal_columns(typed_statement, |id| {
+            self.proxy.get_column_config(id)
+        })?;
 
         let no_encrypted_param_columns = param_columns.iter().all(|c| c.is_none());
         let no_encrypted_projection_columns = projection_columns.iter().all(|c| c.is_none());

--- a/packages/cipherstash-proxy/src/postgresql/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/frontend.rs
@@ -1,5 +1,6 @@
 use super::context::{Context, Statement};
 use super::error_handler::PostgreSqlErrorHandler;
+use super::mapping::ColumnMapper;
 use super::messages::bind::Bind;
 use super::messages::describe::Describe;
 use super::messages::execute::Execute;
@@ -9,7 +10,6 @@ use super::messages::FrontendCode as Code;
 use super::parser::SqlParser;
 use super::protocol::{self};
 use crate::connect::Sender;
-use crate::eql::Identifier;
 use crate::error::{EncryptError, Error, MappingError};
 use crate::log::{CONTEXT, MAPPER, PROTOCOL};
 use crate::postgresql::context::column::Column;
@@ -29,10 +29,9 @@ use crate::proxy::Proxy;
 use crate::EqlEncrypted;
 use bytes::BytesMut;
 use cipherstash_client::encryption::Plaintext;
-use eql_mapper::{self, EqlMapperError, EqlTerm, TableColumn, TypeCheckedStatement};
+use eql_mapper::{self, EqlMapperError, EqlTerm, TypeCheckedStatement};
 use metrics::{counter, histogram};
 use pg_escape::quote_literal;
-use postgres_types::Type;
 use serde::Serialize;
 use sqltk::parser::ast::{self, Value};
 use sqltk::NodeKey;
@@ -799,9 +798,21 @@ where
         typed_statement: &TypeCheckedStatement<'_>,
         param_types: Vec<i32>,
     ) -> Result<Option<Statement>, Error> {
-        let param_columns = self.get_param_columns(typed_statement)?;
-        let projection_columns = self.get_projection_columns(typed_statement)?;
-        let literal_columns = self.get_literal_columns(typed_statement)?;
+        let param_columns = ColumnMapper::get_param_columns(
+            typed_statement,
+            |id| self.proxy.get_column_config(id),
+            self.context.client_id,
+        )?;
+        let projection_columns = ColumnMapper::get_projection_columns(
+            typed_statement,
+            |id| self.proxy.get_column_config(id),
+            self.context.client_id,
+        )?;
+        let literal_columns = ColumnMapper::get_literal_columns(
+            typed_statement,
+            |id| self.proxy.get_column_config(id),
+            self.context.client_id,
+        )?;
 
         let no_encrypted_param_columns = param_columns.iter().all(|c| c.is_none());
         let no_encrypted_projection_columns = projection_columns.iter().all(|c| c.is_none());
@@ -999,158 +1010,6 @@ where
                 );
                 counter!(STATEMENTS_UNMAPPABLE_TOTAL).increment(1);
                 Err(MappingError::StatementCouldNotBeTypeChecked(err.to_string()).into())
-            }
-        }
-    }
-
-    ///
-    /// Maps typed statement projection columns to an Encrypt column configuration
-    ///
-    /// The returned `Vec` is of `Option<Column>` because the Projection columns are a mix of native and EQL types.
-    /// Only EQL colunms will have a configuration. Native types are always None.
-    ///
-    /// Preserves the ordering and semantics of the projection to reduce the complexity of positional encryption.
-    ///
-    fn get_projection_columns(
-        &self,
-        typed_statement: &eql_mapper::TypeCheckedStatement<'_>,
-    ) -> Result<Vec<Option<Column>>, Error> {
-        let mut projection_columns = vec![];
-
-        for col in typed_statement.projection.columns() {
-            let eql_mapper::ProjectionColumn { ty, .. } = col;
-            let configured_column = match &**ty {
-                eql_mapper::Type::Value(eql_mapper::Value::Eql(eql_term)) => {
-                    let TableColumn { table, column } = eql_term.table_column();
-                    let identifier: Identifier = Identifier::from((table, column));
-
-                    debug!(
-                        target: MAPPER,
-                        client_id = self.context.client_id,
-                        msg = "Configured column",
-                        column = ?identifier,
-                        ?eql_term,
-                    );
-                    self.get_column(identifier, eql_term)?
-                }
-                _ => None,
-            };
-            projection_columns.push(configured_column)
-        }
-
-        Ok(projection_columns)
-    }
-
-    ///
-    /// Maps typed statement param columns to an Encrypt column configuration
-    ///
-    /// The returned `Vec` is of `Option<Column>` because the Param columns are a mix of native and EQL types.
-    /// Only EQL colunms will have a configuration. Native types are always None.
-    ///
-    /// Preserves the ordering and semantics of the projection to reduce the complexity of positional encryption.
-    ///
-    ///
-    fn get_param_columns(
-        &self,
-        typed_statement: &eql_mapper::TypeCheckedStatement<'_>,
-    ) -> Result<Vec<Option<Column>>, Error> {
-        let mut param_columns = vec![];
-
-        for param in typed_statement.params.iter() {
-            let configured_column = match param {
-                (_, eql_mapper::Value::Eql(eql_term)) => {
-                    let TableColumn { table, column } = eql_term.table_column();
-                    let identifier = Identifier::from((table, column));
-
-                    debug!(
-                        target: MAPPER,
-                        client_id = self.context.client_id,
-                        msg = "Encrypted parameter",
-                        column = ?identifier,
-                        ?eql_term,
-                    );
-
-                    self.get_column(identifier, eql_term)?
-                }
-                _ => None,
-            };
-            param_columns.push(configured_column);
-        }
-
-        Ok(param_columns)
-    }
-
-    fn get_literal_columns(
-        &self,
-        typed_statement: &eql_mapper::TypeCheckedStatement<'_>,
-    ) -> Result<Vec<Option<Column>>, Error> {
-        let mut literal_columns = vec![];
-
-        for (eql_term, _) in typed_statement.literals.iter() {
-            let TableColumn { table, column } = eql_term.table_column();
-            let identifier = Identifier::from((table, column));
-
-            debug!(
-                target: MAPPER,
-                client_id = self.context.client_id,
-                msg = "Encrypted literal",
-                column = ?identifier,
-                ?eql_term,
-            );
-            let col = self.get_column(identifier, eql_term)?;
-            if col.is_some() {
-                literal_columns.push(col);
-            }
-        }
-
-        Ok(literal_columns)
-    }
-
-    ///
-    /// Get the column configuration for the Identifier
-    /// Returns `EncryptError::UnknownColumn` if configuration cannot be found for the Identified column
-    /// if mapping enabled, and None if mapping is disabled. It'll log a warning either way.
-    fn get_column(
-        &self,
-        identifier: Identifier,
-        eql_term: &EqlTerm,
-    ) -> Result<Option<Column>, Error> {
-        match self.proxy.get_column_config(&identifier) {
-            Some(config) => {
-                debug!(
-                    target: MAPPER,
-                    client_id = self.context.client_id,
-                    msg = "Configured column",
-                    column = ?identifier
-                );
-
-                // IndexTerm::SteVecSelector
-                let postgres_type = if matches!(eql_term, EqlTerm::JsonPath(_)) {
-                    Some(Type::JSONPATH)
-                } else {
-                    None
-                };
-
-                let eql_term = eql_term.variant();
-                Ok(Some(Column::new(
-                    identifier,
-                    config,
-                    postgres_type,
-                    eql_term,
-                )))
-            }
-            None => {
-                warn!(
-                    target: MAPPER,
-                    client_id = self.context.client_id,
-                    msg = "Configured column not found. Encryption configuration may have been deleted.",
-                    ?identifier,
-                );
-                Err(EncryptError::UnknownColumn {
-                    table: identifier.table.to_owned(),
-                    column: identifier.column.to_owned(),
-                }
-                .into())
             }
         }
     }

--- a/packages/cipherstash-proxy/src/postgresql/mapping.rs
+++ b/packages/cipherstash-proxy/src/postgresql/mapping.rs
@@ -19,7 +19,6 @@ impl ColumnMapper {
     pub fn get_projection_columns(
         typed_statement: &TypeCheckedStatement<'_>,
         get_column_config: impl Fn(&Identifier) -> Option<ColumnConfig>,
-        client_id: i32,
     ) -> Result<Vec<Option<Column>>, Error> {
         let mut projection_columns = vec![];
 
@@ -36,7 +35,7 @@ impl ColumnMapper {
                         column = ?identifier,
                         ?eql_term,
                     );
-                    Self::get_column(identifier, eql_term, &get_column_config, client_id)?
+                    Self::get_column(identifier, eql_term, &get_column_config)?
                 }
                 _ => None,
             };
@@ -55,7 +54,6 @@ impl ColumnMapper {
     pub fn get_param_columns(
         typed_statement: &TypeCheckedStatement<'_>,
         get_column_config: impl Fn(&Identifier) -> Option<ColumnConfig>,
-        client_id: i32,
     ) -> Result<Vec<Option<Column>>, Error> {
         let mut param_columns = vec![];
 
@@ -72,7 +70,7 @@ impl ColumnMapper {
                         ?eql_term,
                     );
 
-                    Self::get_column(identifier, eql_term, &get_column_config, client_id)?
+                    Self::get_column(identifier, eql_term, &get_column_config)?
                 }
                 _ => None,
             };
@@ -85,7 +83,6 @@ impl ColumnMapper {
     pub fn get_literal_columns(
         typed_statement: &TypeCheckedStatement<'_>,
         get_column_config: impl Fn(&Identifier) -> Option<ColumnConfig>,
-        client_id: i32,
     ) -> Result<Vec<Option<Column>>, Error> {
         let mut literal_columns = vec![];
 
@@ -99,7 +96,7 @@ impl ColumnMapper {
                 column = ?identifier,
                 ?eql_term,
             );
-            let col = Self::get_column(identifier, eql_term, &get_column_config, client_id)?;
+            let col = Self::get_column(identifier, eql_term, &get_column_config)?;
             if col.is_some() {
                 literal_columns.push(col);
             }
@@ -115,13 +112,11 @@ impl ColumnMapper {
         identifier: Identifier,
         eql_term: &EqlTerm,
         get_column_config: impl Fn(&Identifier) -> Option<ColumnConfig>,
-        client_id: i32,
     ) -> Result<Option<Column>, Error> {
         match get_column_config(&identifier) {
             Some(config) => {
                 debug!(
                     target: MAPPER,
-                    client_id,
                     msg = "Configured column",
                     column = ?identifier
                 );
@@ -144,7 +139,6 @@ impl ColumnMapper {
             None => {
                 warn!(
                     target: MAPPER,
-                    client_id,
                     msg = "Configured column not found. Encryption configuration may have been deleted.",
                     ?identifier,
                 );

--- a/packages/cipherstash-proxy/src/postgresql/mapping.rs
+++ b/packages/cipherstash-proxy/src/postgresql/mapping.rs
@@ -1,0 +1,159 @@
+use crate::eql::Identifier;
+use crate::error::{EncryptError, Error};
+use crate::log::MAPPER;
+use crate::postgresql::context::column::Column;
+use cipherstash_client::schema::ColumnConfig;
+use eql_mapper::{EqlTerm, TableColumn, TypeCheckedStatement};
+use postgres_types::Type;
+use tracing::{debug, warn};
+
+pub struct ColumnMapper;
+
+impl ColumnMapper {
+    /// Maps typed statement projection columns to an Encrypt column configuration
+    ///
+    /// The returned `Vec` is of `Option<Column>` because the Projection columns are a mix of native and EQL types.
+    /// Only EQL colunms will have a configuration. Native types are always None.
+    ///
+    /// Preserves the ordering and semantics of the projection to reduce the complexity of positional encryption.
+    pub fn get_projection_columns(
+        typed_statement: &TypeCheckedStatement<'_>,
+        get_column_config: impl Fn(&Identifier) -> Option<ColumnConfig>,
+        client_id: i32,
+    ) -> Result<Vec<Option<Column>>, Error> {
+        let mut projection_columns = vec![];
+
+        for col in typed_statement.projection.columns() {
+            let eql_mapper::ProjectionColumn { ty, .. } = col;
+            let configured_column = match &**ty {
+                eql_mapper::Type::Value(eql_mapper::Value::Eql(eql_term)) => {
+                    let TableColumn { table, column } = eql_term.table_column();
+                    let identifier: Identifier = Identifier::from((table, column));
+
+                    debug!(
+                        target: MAPPER,
+                        msg = "Configured column",
+                        column = ?identifier,
+                        ?eql_term,
+                    );
+                    Self::get_column(identifier, eql_term, &get_column_config, client_id)?
+                }
+                _ => None,
+            };
+            projection_columns.push(configured_column)
+        }
+
+        Ok(projection_columns)
+    }
+
+    /// Maps typed statement param columns to an Encrypt column configuration
+    ///
+    /// The returned `Vec` is of `Option<Column>` because the Param columns are a mix of native and EQL types.
+    /// Only EQL colunms will have a configuration. Native types are always None.
+    ///
+    /// Preserves the ordering and semantics of the projection to reduce the complexity of positional encryption.
+    pub fn get_param_columns(
+        typed_statement: &TypeCheckedStatement<'_>,
+        get_column_config: impl Fn(&Identifier) -> Option<ColumnConfig>,
+        client_id: i32,
+    ) -> Result<Vec<Option<Column>>, Error> {
+        let mut param_columns = vec![];
+
+        for param in typed_statement.params.iter() {
+            let configured_column = match param {
+                (_, eql_mapper::Value::Eql(eql_term)) => {
+                    let TableColumn { table, column } = eql_term.table_column();
+                    let identifier = Identifier::from((table, column));
+
+                    debug!(
+                        target: MAPPER,
+                        msg = "Encrypted parameter",
+                        column = ?identifier,
+                        ?eql_term,
+                    );
+
+                    Self::get_column(identifier, eql_term, &get_column_config, client_id)?
+                }
+                _ => None,
+            };
+            param_columns.push(configured_column);
+        }
+
+        Ok(param_columns)
+    }
+
+    pub fn get_literal_columns(
+        typed_statement: &TypeCheckedStatement<'_>,
+        get_column_config: impl Fn(&Identifier) -> Option<ColumnConfig>,
+        client_id: i32,
+    ) -> Result<Vec<Option<Column>>, Error> {
+        let mut literal_columns = vec![];
+
+        for (eql_term, _) in typed_statement.literals.iter() {
+            let TableColumn { table, column } = eql_term.table_column();
+            let identifier = Identifier::from((table, column));
+
+            debug!(
+                target: MAPPER,
+                msg = "Encrypted literal",
+                column = ?identifier,
+                ?eql_term,
+            );
+            let col = Self::get_column(identifier, eql_term, &get_column_config, client_id)?;
+            if col.is_some() {
+                literal_columns.push(col);
+            }
+        }
+
+        Ok(literal_columns)
+    }
+
+    /// Get the column configuration for the Identifier
+    /// Returns `EncryptError::UnknownColumn` if configuration cannot be found for the Identified column
+    /// if mapping enabled, and None if mapping is disabled. It'll log a warning either way.
+    pub fn get_column(
+        identifier: Identifier,
+        eql_term: &EqlTerm,
+        get_column_config: impl Fn(&Identifier) -> Option<ColumnConfig>,
+        client_id: i32,
+    ) -> Result<Option<Column>, Error> {
+        match get_column_config(&identifier) {
+            Some(config) => {
+                debug!(
+                    target: MAPPER,
+                    client_id,
+                    msg = "Configured column",
+                    column = ?identifier
+                );
+
+                // IndexTerm::SteVecSelector
+                let postgres_type = if matches!(eql_term, EqlTerm::JsonPath(_)) {
+                    Some(Type::JSONPATH)
+                } else {
+                    None
+                };
+
+                let eql_term = eql_term.variant();
+                Ok(Some(Column::new(
+                    identifier,
+                    config,
+                    postgres_type,
+                    eql_term,
+                )))
+            }
+            None => {
+                warn!(
+                    target: MAPPER,
+                    client_id,
+                    msg = "Configured column not found. Encryption configuration may have been deleted.",
+                    ?identifier,
+                );
+                Err(EncryptError::UnknownColumn {
+                    table: identifier.table.to_owned(),
+                    column: identifier.column.to_owned(),
+                }
+                .into())
+            }
+        }
+    }
+}

--- a/packages/cipherstash-proxy/src/postgresql/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/mod.rs
@@ -5,6 +5,7 @@ mod error_handler;
 mod format_code;
 mod frontend;
 mod handler;
+mod mapping;
 mod message_buffer;
 mod messages;
 mod parser;

--- a/packages/cipherstash-proxy/src/postgresql/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/mod.rs
@@ -5,7 +5,7 @@ mod error_handler;
 mod format_code;
 mod frontend;
 mod handler;
-mod mapping;
+mod statement_analyzer;
 mod message_buffer;
 mod messages;
 mod parser;

--- a/packages/cipherstash-proxy/src/postgresql/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/mod.rs
@@ -5,12 +5,12 @@ mod error_handler;
 mod format_code;
 mod frontend;
 mod handler;
-mod statement_analyzer;
 mod message_buffer;
 mod messages;
 mod parser;
 mod protocol;
 mod startup;
+mod statement_analyzer;
 
 pub use context::column::Column;
 pub use context::KeysetIdentifier;

--- a/packages/cipherstash-proxy/src/postgresql/statement_analyzer.rs
+++ b/packages/cipherstash-proxy/src/postgresql/statement_analyzer.rs
@@ -4,8 +4,8 @@ use crate::log::MAPPER;
 use crate::postgresql::context::column::Column;
 use crate::prometheus::STATEMENTS_UNMAPPABLE_TOTAL;
 use cipherstash_client::schema::ColumnConfig;
-use eql_mapper::{EqlMapperError, EqlTerm, TableColumn, TypeCheckedStatement};
 use eql_mapper::TableResolver;
+use eql_mapper::{EqlMapperError, EqlTerm, TableColumn, TypeCheckedStatement};
 use metrics::counter;
 use postgres_types::Type;
 use sqltk::parser::ast;
@@ -75,7 +75,10 @@ impl<'a> StatementAnalyzer<'a> {
         self.typed_statement.literal_values()
     }
 
-    pub fn transform(&self, encrypted_nodes: std::collections::HashMap<sqltk::NodeKey, sqltk::parser::ast::Value>) -> Result<sqltk::parser::ast::Statement, eql_mapper::EqlMapperError> {
+    pub fn transform(
+        &self,
+        encrypted_nodes: std::collections::HashMap<sqltk::NodeKey, sqltk::parser::ast::Value>,
+    ) -> Result<sqltk::parser::ast::Statement, eql_mapper::EqlMapperError> {
         self.typed_statement.transform(encrypted_nodes)
     }
 


### PR DESCRIPTION
Move column configuration mapping functions from Frontend to new ColumnMapper module to reduce cognitive load and improve code organization.

- Create packages/cipherstash-proxy/src/postgresql/mapping.rs with ColumnMapper struct
- Move get_projection_columns, get_param_columns, get_literal_columns, and get_column functions
- Update interface to use static methods with dependency injection pattern
- Clean up unused imports in frontend.rs (Identifier, TableColumn, Type)
- Preserve all functionality including logging and error handling

