### PR TITLE
feat(config): add optional database connection CLI args

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -258,6 +258,87 @@ As a convenience for production deployments, with the below environment variable
 CS_DATABASE__INSTALL_AWS_RDS_CERT_BUNDLE="true"
 ```
 
+## Command line options
+
+
+
+## Command line interface
+
+The CipherStash Proxy accepts command line arguments.
+For example, the upstream database can be specified via command line arguments.
+Useful for local dev and testing.
+
+### Usage
+
+```bash
+cipherstash-proxy [OPTIONS] [DBNAME] [COMMAND]
+```
+
+### Commands
+
+- **encrypt**  
+  Encrypt one or more columns in a table. This command requires a running and properly configured CipherStash Proxy instance.
+
+- **help**  
+  Print the help message or detailed information for the specified subcommand(s).
+
+### Arguments
+
+- **DBNAME**  
+
+  Optional name of the database to connect to. If not specified, the tool will use the environment variables or configuration file settings.
+
+  Default value: none
+
+- **-H, --db-host <DB_HOST>**
+
+  Optional database host. This value will default to the one defined in your environment or configuration file if not provided.
+
+  Default value: `127.0.0.1`
+
+- **-u, --db-user <DB_USER>**
+
+  Optional database user. This value will default to the one defined in your environment or configuration file if not provided.
+
+  Default value: `postgres`
+
+- **-p, --config-file-path <CONFIG_FILE_PATH>**
+
+  Specifies an optional path to a CipherStash Proxy configuration file.
+  If provided, the application attempts to load configuration settings from this file.
+  However, environment variables can be used instead of the file or to override any values defined within it.
+
+  Default Value: `cipherstash-proxy.toml`
+    
+  Note:
+  The application will look for "cipherstash-proxy.toml" by default if no other file path is specified.
+  
+- **-l, --log-level <LOG_LEVEL>**
+  
+  Sets an optional log level for the application, which controls the verbosity of the logging output.
+  This can be particularly useful for adjusting the level of detail in application logs
+  to suit different environments or debugging needs.
+    
+  Default Value: `info`
+    
+  Environment Variable: `CS_LOG__LEVEL`
+    
+  Possible Values: `error`, `warn`, `info`, `debug`, `trace`
+  
+- **-f, --log-format <LOG_FORMAT>**
+    
+  Specifies an optional log format for the output logs.
+  The default log format is "pretty" when the application detects that it is running in a terminal session,
+  otherwise it defaults to "structured" for non-interactive environments.
+  The setting can be overridden by the corresponding environment variable.
+    
+  Default Value: `pretty` (if running in a terminal session), otherwise `structured`
+    
+  Environment Variable: `CS_LOG__FORMAT`
+    
+  Possible Values: `pretty`, `structured`, `text`
+  
+
 ## Multitenant operation
 
 CipherStash Proxy supports multitenant applications using ZeroKMS keysets to provide strong cryptographic separation between tenants.

--- a/packages/cipherstash-proxy-integration/src/migrate/mod.rs
+++ b/packages/cipherstash-proxy-integration/src/migrate/mod.rs
@@ -42,6 +42,9 @@ mod tests {
             log_level: LogLevel::Debug,
             log_format: LogFormat::Pretty,
             command: None,
+            db_host: None,
+            db_name: None,
+            db_user: None,
         };
 
         let config = match TandemConfig::load(&args) {

--- a/packages/cipherstash-proxy/src/cli/mod.rs
+++ b/packages/cipherstash-proxy/src/cli/mod.rs
@@ -21,6 +21,21 @@ const DEFAULT_CONFIG_FILE: &str = "cipherstash-proxy.toml";
 /// CipherStash Proxy keeps your sensitive data in PostgreSQL encrypted and searchable, with no changes to SQL.
 ///
 pub struct Args {
+    /// Optional database host to connect to.
+    /// Uses env or config file if not specified.
+    #[arg(short = 'H', long)]
+    pub db_host: Option<String>,
+
+    /// Optional database name to connect to.
+    /// Uses env or config file if not specified.
+    #[arg(value_name = "DBNAME")]
+    pub db_name: Option<String>,
+
+    /// Optional database user to connect as.
+    /// Uses env or config file if not specified.
+    #[arg(short = 'u', long)]
+    pub db_user: Option<String>,
+
     /// Optional path to a CipherStash Proxy configuration file.
     ///
     /// Default is "cipherstash-proxy.toml".

--- a/packages/cipherstash-proxy/src/config/database.rs
+++ b/packages/cipherstash-proxy/src/config/database.rs
@@ -14,6 +14,8 @@ pub struct DatabaseConfig {
     pub port: u16,
 
     pub name: String,
+
+    #[serde(default = "DatabaseConfig::default_username")]
     pub username: String,
 
     #[serde(deserialize_with = "protected_string_deserializer")]
@@ -38,6 +40,10 @@ impl DatabaseConfig {
 
     pub const fn default_port() -> u16 {
         5432
+    }
+
+    pub fn default_username() -> String {
+        "postgres".to_string()
     }
 
     pub const fn default_config_reload_interval() -> u64 {

--- a/packages/cipherstash-proxy/src/config/log.rs
+++ b/packages/cipherstash-proxy/src/config/log.rs
@@ -130,30 +130,30 @@ mod tests {
         with_no_cs_vars(|| {
             temp_env::with_vars([("CS_LOG__LEVEL", Some("error"))], || {
                 let config =
-                    TandemConfig::build("tests/config/cipherstash-proxy-test.toml").unwrap();
+                    TandemConfig::build_path("tests/config/cipherstash-proxy-test.toml").unwrap();
                 assert_eq!(config.log.level, LogLevel::Error);
             });
 
             temp_env::with_vars([("CS_LOG__LEVEL", Some("WARN"))], || {
                 let config =
-                    TandemConfig::build("tests/config/cipherstash-proxy-test.toml").unwrap();
+                    TandemConfig::build_path("tests/config/cipherstash-proxy-test.toml").unwrap();
                 assert_eq!(config.log.level, LogLevel::Warn);
             });
 
             temp_env::with_vars([("CS_LOG__OUTPUT", Some("stderr"))], || {
                 let config =
-                    TandemConfig::build("tests/config/cipherstash-proxy-test.toml").unwrap();
+                    TandemConfig::build_path("tests/config/cipherstash-proxy-test.toml").unwrap();
                 assert_eq!(config.log.output, LogOutput::Stderr);
             });
 
             temp_env::with_vars([("CS_LOG__FORMAT", Some("Pretty"))], || {
                 let config =
-                    TandemConfig::build("tests/config/cipherstash-proxy-test.toml").unwrap();
+                    TandemConfig::build_path("tests/config/cipherstash-proxy-test.toml").unwrap();
                 assert_eq!(config.log.format, LogFormat::Pretty);
             });
 
             temp_env::with_vars([("CS_LOG__FORMAT", Some("dEbUG"))], || {
-                let config = TandemConfig::build("tests/config/cipherstash-proxy-test.toml");
+                let config = TandemConfig::build_path("tests/config/cipherstash-proxy-test.toml");
 
                 assert!(config.is_err());
                 assert!(matches!(config.unwrap_err(), Error::Config(_)));

--- a/packages/cipherstash-proxy/src/config/tandem.rs
+++ b/packages/cipherstash-proxy/src/config/tandem.rs
@@ -185,6 +185,11 @@ impl TandemConfig {
             env::set_var("CS_DATABASE__NAME", dbname);
         }
 
+        if let Some(db_user) = &args.db_user {
+            println!("Overriding database user from command line argument");
+            env::set_var("CS_DATABASE__USER", db_user);
+        }
+
         // Source order is important!
         let config = Config::builder()
             .add_source(config::File::with_name(&args.config_file_path).required(false))
@@ -396,7 +401,8 @@ mod tests {
                 ],
                 || {
                     let config =
-                        TandemConfig::build_path("tests/config/cipherstash-proxy-test.toml").unwrap();
+                        TandemConfig::build_path("tests/config/cipherstash-proxy-test.toml")
+                            .unwrap();
 
                     assert_eq!(config.encrypt.client_id, "CS_CLIENT_ID".to_string());
 
@@ -428,7 +434,8 @@ mod tests {
                 ],
                 || {
                     let config =
-                        TandemConfig::build_path("tests/config/cipherstash-proxy-test.toml").unwrap();
+                        TandemConfig::build_path("tests/config/cipherstash-proxy-test.toml")
+                            .unwrap();
 
                     assert_eq!(
                         &config.encrypt.client_id,
@@ -461,7 +468,8 @@ mod tests {
                 Some(Uuid::parse_str("484cd205-99e8-41ca-acfe-55a7e25a8ec2").unwrap())
             );
 
-            let config = TandemConfig::build_path("tests/config/cipherstash-proxy-bad-dataset.toml");
+            let config =
+                TandemConfig::build_path("tests/config/cipherstash-proxy-bad-dataset.toml");
 
             assert!(config.is_err());
             assert!(matches!(config.unwrap_err(), Error::Config(_)));
@@ -471,7 +479,8 @@ mod tests {
     #[test]
     fn prometheus_config() {
         with_no_cs_vars(|| {
-            let config = TandemConfig::build_path("tests/config/cipherstash-proxy-test.toml").unwrap();
+            let config =
+                TandemConfig::build_path("tests/config/cipherstash-proxy-test.toml").unwrap();
             assert!(!config.prometheus_enabled());
 
             temp_env::with_vars([("CS_PROMETHEUS__ENABLED", Some("true"))], || {
@@ -497,7 +506,8 @@ mod tests {
                 ],
                 || {
                     let config =
-                        TandemConfig::build_path("tests/config/cipherstash-proxy-test.toml").unwrap();
+                        TandemConfig::build_path("tests/config/cipherstash-proxy-test.toml")
+                            .unwrap();
                     assert!(config.prometheus_enabled());
                     assert!(config.prometheus.enabled);
                     assert_eq!(config.prometheus.port, 7777);

--- a/packages/cipherstash-proxy/src/proxy/mod.rs
+++ b/packages/cipherstash-proxy/src/proxy/mod.rs
@@ -145,7 +145,7 @@ mod tests {
     fn build_tandem_config(env: Vec<(&str, Option<&str>)>) -> TandemConfig {
         with_no_cs_vars(|| {
             temp_env::with_vars(env, || {
-                TandemConfig::build("tests/config/unknown.toml").unwrap()
+                TandemConfig::build_path("tests/config/unknown.toml").unwrap()
             })
         })
     }


### PR DESCRIPTION
Adds optional command line args to proxy for specifying the database, host and username.
If not provided, env and config is used as now.
If running in docker this has no effect but is very useful if running the binary directly.

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
