### PR TITLE
fix: pin tests to Postgres 17

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres: &postgres
-    image: postgres:latest
+    image: postgres:17
     container_name: postgres
     environment:
       PGPORT: 5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   postgres: &postgres
     image: postgres:17
+    pull_policy: always
     container_name: postgres
     environment:
       PGPORT: 5432

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   postgres: &postgres
     image: postgres:17
+    pull_policy: always
     container_name: postgres
     command: -c 'config_file=/etc/postgresql/postgresql.conf'
     restart: always

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres: &postgres
-    image: postgres:latest
+    image: postgres:17
     container_name: postgres
     command: -c 'config_file=/etc/postgresql/postgresql.conf'
     restart: always


### PR DESCRIPTION
Previously Proxy's test harness was using images tagged `postgres:latest`, which was pointing to the latest release in the Postgres 17 series.

Postgres 18 was released in the last 24 hours, and `postgres:latest` now points to Postgres 18.

There seem to be some changes in the Postgres 18 containers, and volume mounting now [breaks](https://github.com/cipherstash/proxy/actions/runs/18117984660/job/51557338645) [consistently](https://github.com/cipherstash/proxy/actions/runs/18091500210/job/51472969879) in [CI](https://github.com/cipherstash/proxy/actions/runs/18091500241/job/51472969789?pr=328) and locally.

For now we will pin the test harness to Postgres 17, and look at supporting Postgres 18 in a subsequent PR.

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
