### PR TITLE
deps: upgrade cipherstash-client to 0.35.0 and EQL to 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- **EQL 2.3.0**: Proxy now uses the EQL 2.3.0 release. Install EQL 2.3.0 in your database to match this release.
+- **EQL 2.3.1**: Proxy now uses the EQL 2.3.1 release. Install EQL 2.3.1 in your database to match this release.
 
 ## [2.2.0-alpha.1] - 2026-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **OPE (Order-Preserving Encryption) index**: New `ope` index type alongside the existing `ore` for range and `ORDER BY` queries on encrypted columns. Drop-in alternative to `ore` — pick one per column. See the [encrypted indexes documentation](docs/how-to/index.md) for configuration.
 
+### Changed
+
+- **EQL 2.3.0**: Proxy now uses the EQL 2.3.0 release. Install EQL 2.3.0 in your database to match this release.
+
 ## [2.2.0-alpha.1] - 2026-03-25
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "generic-array",
 ]
 
@@ -36,6 +36,21 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures 0.2.17",
+ "zeroize",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
  "zeroize",
 ]
 
@@ -193,12 +208,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
-name = "array-init"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,9 +330,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -332,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -545,6 +554,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-modes"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,15 +755,15 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
 ]
 
 [[package]]
 name = "cipherstash-client"
-version = "0.34.1-alpha.4"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3d67cc26d8422509d2c20644576124e7344a4bf14ded06c7affa8dc18aabca"
+checksum = "0257cff25a25a706af6e190e5209865aae4ddf0b36f81febee7de014b22bcc40"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -755,7 +773,6 @@ dependencies = [
  "base64",
  "base85",
  "blake3",
- "cfg-if",
  "chrono",
  "cipherstash-config",
  "cipherstash-core",
@@ -771,16 +788,12 @@ dependencies = [
  "log",
  "miette",
  "opaque-debug",
- "open 3.2.0",
  "orderable-bytes",
  "ore-rs",
  "percent-encoding",
  "rand 0.8.6",
- "recipher 0.2.2",
+ "recipher 0.2.3",
  "reqwest",
- "reqwest-middleware",
- "reqwest-retry",
- "reqwest-tracing",
  "rmp-serde",
  "rust-stemmers",
  "rust_decimal",
@@ -800,7 +813,7 @@ dependencies = [
  "url",
  "uuid",
  "vitaminc",
- "vitaminc-protected",
+ "vitaminc-protected 0.2.0-pre",
  "winnow 0.6.26",
  "zeroize",
  "zerokms-protocol",
@@ -808,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-config"
-version = "0.34.1-alpha.4"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283fa04db19f9bf2cb2f09e8c1505a15560310bc50fdc066734072c616aa8ca9"
+checksum = "d376d237e368e77de53b07bb7309812f45809299063c80b6cc3132f7d8494aed"
 dependencies = [
  "bitflags",
  "serde",
@@ -820,10 +833,11 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-core"
-version = "0.34.1-alpha.4"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bb7181053c3fc35569e0800fa7510c85ee2bffee21abbd2a7aeb498f5f0972"
+checksum = "ca84ffd8a7b2f0c8c6b04eba600738fea115f5a4ed825035a2f13aa1524085a7"
 dependencies = [
+ "getrandom 0.2.15",
  "hmac",
  "lazy_static",
  "num-bigint",
@@ -881,7 +895,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
- "vitaminc-protected",
+ "vitaminc-protected 0.1.0-pre4.2",
  "x509-parser",
 ]
 
@@ -954,15 +968,14 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cllw-ore"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d007a5be83ae12adbd17543f9631d64090d761c029d2f8f7eb8f8ddb2a87caf"
+checksum = "4f73a23cbc15404d9b314c03b16a888f798dbc681bceeb2e18674f602f9da02d"
 dependencies = [
  "blake3",
  "chrono",
  "hex",
  "orderable-bytes",
- "postgres-types",
  "rust_decimal",
  "subtle",
  "thiserror 1.0.69",
@@ -977,7 +990,7 @@ checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
 dependencies = [
  "cipher",
  "dbl",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1158,6 +1171,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,9 +1190,9 @@ dependencies = [
 
 [[package]]
 name = "cts-common"
-version = "0.34.1-alpha.4"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b26644e630f2e690194c6b61f5b613b768061750f2060cf4db73ddb8058d284"
+checksum = "ae6508011dee61bc36e16615e43cb26a8014c49ebb832e713602f3b0dc15af29"
 dependencies = [
  "arrayvec",
  "axum",
@@ -1182,6 +1204,7 @@ dependencies = [
  "diesel",
  "either",
  "fake 3.1.0",
+ "getrandom 0.4.2",
  "http",
  "miette",
  "nom 8.0.0",
@@ -1388,9 +1411,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1837,11 +1870,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1976,7 +2021,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2024,6 +2069,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2565,7 +2619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2849,16 +2903,6 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2078c0039e6a54a0c42c28faa984e115fb4c2d5bf2208f77d1961002df8576f8"
-dependencies = [
- "pathdiff",
- "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
@@ -3114,7 +3158,6 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613283563cd90e1dfc3518d548caee47e0e725455ed619881f5cf21f36de4b48"
 dependencies = [
- "array-init",
  "bytes",
  "chrono",
  "fallible-iterator",
@@ -3388,9 +3431,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -3491,13 +3534,13 @@ dependencies = [
 
 [[package]]
 name = "recipher"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b3561e1082283a4c064635b7886aa4d24db57a43ac31c55930c10797ab5cdeb"
+checksum = "9398dce78ddfce08f93e9d9a3ac64d9b0a4fed478c0a82003c6e4c90dc245125"
 dependencies = [
  "aes",
- "async-trait",
  "cmac",
+ "getrandom 0.2.15",
  "hex",
  "hex-literal",
  "opaque-debug",
@@ -3635,71 +3678,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest-middleware"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199dda04a536b532d0cc04d7979e39b1c763ea749bf91507017069c00b96056f"
-dependencies = [
- "anyhow",
- "async-trait",
- "http",
- "reqwest",
- "serde",
- "thiserror 2.0.18",
- "tower-service",
-]
-
-[[package]]
-name = "reqwest-retry"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2412db2af7d2268e7a5406be0431f37d9eb67ff390f35b395716f5f06c2eaa"
-dependencies = [
- "anyhow",
- "async-trait",
- "futures",
- "getrandom 0.2.15",
- "http",
- "hyper",
- "reqwest",
- "reqwest-middleware",
- "retry-policies",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "wasmtimer",
-]
-
-[[package]]
-name = "reqwest-tracing"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5c1a1510677d43dce9e9c0c07fc5db8772c0e5a43e4f9cef75a11affa05a578"
-dependencies = [
- "anyhow",
- "async-trait",
- "getrandom 0.2.15",
- "http",
- "matchit",
- "reqwest",
- "reqwest-middleware",
- "tracing",
-]
-
-[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
-
-[[package]]
-name = "retry-policies"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
-dependencies = [
- "rand 0.9.2",
-]
 
 [[package]]
 name = "ring"
@@ -4192,7 +4174,7 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4339,15 +4321,16 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stack-auth"
-version = "0.34.1-alpha.4"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "072e420b2bb179e7627f2e9e5ee4080d1f939c6710ecf91524d52fc87e40cbd0"
+checksum = "c823cc3d88e15478d51694ef56037400bd4ae3e1a9e046071e01d251168cc466"
 dependencies = [
  "aquamarine",
+ "base64",
  "cts-common",
  "jsonwebtoken",
  "miette",
- "open 5.3.3",
+ "open",
  "reqwest",
  "serde",
  "serde_json",
@@ -4358,16 +4341,17 @@ dependencies = [
  "url",
  "uuid",
  "vitaminc",
- "vitaminc-protected",
+ "vitaminc-protected 0.2.0-pre",
+ "web-time",
  "zeroize",
  "zerokms-protocol",
 ]
 
 [[package]]
 name = "stack-profile"
-version = "0.34.1-alpha.4"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd61bc4129d2258ec1ba89d742558308560fc0f585f9c24d478685def8efd14"
+checksum = "cfd1be30119d59260f3e932f78fbbfbe3674c151d39e7fcca24d0439e7e31ba8"
 dependencies = [
  "dirs",
  "gethostname",
@@ -4945,9 +4929,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unarray"
@@ -5018,7 +5002,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -5097,9 +5081,11 @@ checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "atomic",
  "getrandom 0.3.2",
+ "js-sys",
  "md-5",
  "serde",
  "sha1_smol",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5152,39 +5138,40 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vitaminc"
-version = "0.1.0-pre4.2"
+version = "0.2.0-pre"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c8b739a2cb1e528e77a69267728532f52d2d5ce18ae2839e26c797859fe9015"
+checksum = "ec9807fc6a29a9ab4a9cd24f103573661d7e04d48651ce8c752d32e73a686446"
 dependencies = [
  "vitaminc-aead",
  "vitaminc-encrypt",
- "vitaminc-protected",
+ "vitaminc-protected 0.2.0-pre",
  "vitaminc-random",
  "vitaminc-traits",
 ]
 
 [[package]]
 name = "vitaminc-aead"
-version = "0.1.0-pre4.2"
+version = "0.2.0-pre"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c29cef4d4b0d018c4223d366017d2a9756012acf76e25011aaca877f3c74904"
+checksum = "3933759550ab4841536e8d019fc73cd77ec2e43dcdaefa3218936534eefabb8d"
 dependencies = [
  "bytes",
  "serde",
- "vitaminc-protected",
+ "vitaminc-protected 0.2.0-pre",
  "vitaminc-random",
  "zeroize",
 ]
 
 [[package]]
 name = "vitaminc-encrypt"
-version = "0.1.0-pre4.2"
+version = "0.2.0-pre"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e3869aaf60ebb95ccbdfcf003985132325b4d1ac6f5d945ad2fbb9149afd3a"
+checksum = "2bdbcfd5e9054ce2a3f0cfac67c3e3164d65f38f3a6d593bc4d5d943e53aaf44"
 dependencies = [
+ "aes-gcm",
  "aws-lc-rs",
  "vitaminc-aead",
- "vitaminc-protected",
+ "vitaminc-protected 0.2.0-pre",
  "vitaminc-random",
  "zeroize",
 ]
@@ -5196,11 +5183,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af693c39d3cd1c818ef6267539433c6ceca87840b12d24124adbc9c8ecba1709"
 dependencies = [
  "bitvec",
- "digest",
+ "digest 0.10.7",
  "serde",
  "serde_bytes",
  "subtle",
- "vitaminc-protected-derive",
+ "vitaminc-protected-derive 0.1.0-pre4.2",
+ "zeroize",
+]
+
+[[package]]
+name = "vitaminc-protected"
+version = "0.2.0-pre"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c639c70c23871680d0cedabb2fb8cfd0ff91eb98d90dd27e9bdebf6eac1fd18"
+dependencies = [
+ "bitvec",
+ "digest 0.11.3",
+ "serde",
+ "serde_bytes",
+ "subtle",
+ "vitaminc-protected-derive 0.2.0-pre",
  "zeroize",
 ]
 
@@ -5216,23 +5218,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "vitaminc-random"
-version = "0.1.0-pre4.2"
+name = "vitaminc-protected-derive"
+version = "0.2.0-pre"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9de431cb93359d293ec7e70d05d87117a57f34bfc5bc94f040b81d4dd1afd6"
+checksum = "659afc33e7252768204f44bd9f377a120a35dc586aa3538b66a3f4cc54a88653"
 dependencies = [
- "rand 0.10.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "vitaminc-random"
+version = "0.2.0-pre"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac67bf5f90acc53c87deb5f612ad1beefd0e0e7f5452ab3443d9fa4b0e23f9c5"
+dependencies = [
+ "getrandom 0.4.2",
+ "rand 0.10.1",
  "thiserror 2.0.18",
- "vitaminc-protected",
+ "vitaminc-protected 0.2.0-pre",
  "vitaminc-random-derives",
  "zeroize",
 ]
 
 [[package]]
 name = "vitaminc-random-derives"
-version = "0.1.0-pre4.2"
+version = "0.2.0-pre"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49d33ac4682235551d25c874525c20e03d4c863b39f556391f52f7a2083bfbdf"
+checksum = "efeeb4347ca86ff167228cfbd655c7a6e8a5bd6f032330ac881d6c4c0441768b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5241,16 +5255,16 @@ dependencies = [
 
 [[package]]
 name = "vitaminc-traits"
-version = "0.1.0-pre4.2"
+version = "0.2.0-pre"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c25a9e51d24c3befddd71e907dd4ae9f21cfbaae065fb0ef5202e5d21cd198d0"
+checksum = "5aeb6ef24c094d225d00753134f082eba59ea2ba8d5d0b5ba761c038ca9375b3"
 dependencies = [
  "anyhow",
  "bytes",
  "rmp-serde",
  "serde",
  "thiserror 2.0.18",
- "vitaminc-protected",
+ "vitaminc-protected 0.2.0-pre",
  "vitaminc-random",
  "zeroize",
 ]
@@ -5429,20 +5443,6 @@ dependencies = [
  "hashbrown 0.15.2",
  "indexmap",
  "semver",
-]
-
-[[package]]
-name = "wasmtimer"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot",
- "pin-utils",
- "slab",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -5666,21 +5666,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.1",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6277,15 +6262,16 @@ dependencies = [
 
 [[package]]
 name = "zerokms-protocol"
-version = "0.12.9"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2f045e2ee975a3d448419245c4621ea8844d2a004c63a96277181dc7cf8483"
+checksum = "04a9411f442b247e7d00c6a07cfbc6d56c12d485cfaf4f7effa001bfb1615296"
 dependencies = [
  "base64",
  "cipherstash-config",
  "const-hex",
  "cts-common",
  "fake 2.10.0",
+ "getrandom 0.2.15",
  "opaque-debug",
  "rand 0.8.6",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,9 @@ debug = true
 
 [workspace.dependencies]
 sqltk = { version = "0.10.0" }
-cipherstash-client = { version = "=0.34.1-alpha.4" }
-cipherstash-config = { version = "=0.34.1-alpha.4" }
-cts-common = { version = "=0.34.1-alpha.4" }
+cipherstash-client = { version = "=0.35.0" }
+cipherstash-config = { version = "=0.35.0" }
+cts-common = { version = "=0.35.0" }
 
 thiserror = "2.0.9"
 tokio = { version = "1.44.2", features = ["full"] }

--- a/mise.local.example.toml
+++ b/mise.local.example.toml
@@ -15,7 +15,7 @@ CS_CLIENT_KEY = "client-key"
 CS_CLIENT_ID = "client-id"
 
 # The release of EQL that the proxy tests will use and releases will be built with
-CS_EQL_VERSION = "eql-2.3.0"
+CS_EQL_VERSION = "eql-2.3.1"
 
 # TLS variables are required for providing TLS to Proxy's clients.
 # CS_TLS__TYPE can be either "Path" or "Pem" (case-sensitive).

--- a/mise.local.example.toml
+++ b/mise.local.example.toml
@@ -15,7 +15,7 @@ CS_CLIENT_KEY = "client-key"
 CS_CLIENT_ID = "client-id"
 
 # The release of EQL that the proxy tests will use and releases will be built with
-CS_EQL_VERSION = "eql-2.3.0-pre.3"
+CS_EQL_VERSION = "eql-2.3.0"
 
 # TLS variables are required for providing TLS to Proxy's clients.
 # CS_TLS__TYPE can be either "Path" or "Pem" (case-sensitive).

--- a/mise.toml
+++ b/mise.toml
@@ -34,7 +34,7 @@ CS_PROXY__HOST = "host.docker.internal"
 # Misc
 DOCKER_CLI_HINTS = "false" # Please don't show us What's Next.
 
-CS_EQL_VERSION = "eql-2.3.0-pre.3"
+CS_EQL_VERSION = "eql-2.3.0"
 
 
 [tools]

--- a/mise.toml
+++ b/mise.toml
@@ -34,7 +34,7 @@ CS_PROXY__HOST = "host.docker.internal"
 # Misc
 DOCKER_CLI_HINTS = "false" # Please don't show us What's Next.
 
-CS_EQL_VERSION = "eql-2.3.0"
+CS_EQL_VERSION = "eql-2.3.1"
 
 
 [tools]

--- a/packages/cipherstash-proxy/src/error.rs
+++ b/packages/cipherstash-proxy/src/error.rs
@@ -340,9 +340,9 @@ impl From<cipherstash_client::eql::EqlError> for EncryptError {
             cipherstash_client::eql::EqlError::ColumnConfigurationMismatch { table, column } => {
                 Self::ColumnConfigurationMismatch { table, column }
             }
-            cipherstash_client::eql::EqlError::CouldNotDecryptDataForKeyset { keyset_id } => {
-                Self::CouldNotDecryptDataForKeyset { keyset_id }
-            }
+            cipherstash_client::eql::EqlError::CouldNotDecryptDataForKeyset {
+                keyset_id, ..
+            } => Self::CouldNotDecryptDataForKeyset { keyset_id },
             cipherstash_client::eql::EqlError::InvalidIndexTerm => Self::InvalidIndexTerm,
             cipherstash_client::eql::EqlError::MissingCiphertext(identifier) => {
                 Self::ColumnCouldNotBeDeserialised {

--- a/packages/cipherstash-proxy/src/lib.rs
+++ b/packages/cipherstash-proxy/src/lib.rs
@@ -16,7 +16,7 @@ pub use crate::config::{DatabaseConfig, ServerConfig, TandemConfig, TlsConfig};
 pub use crate::log::init;
 pub use crate::proxy::Proxy;
 pub use cipherstash_client::encryption::Plaintext;
-pub use cipherstash_client::eql::{EqlCiphertext, Identifier};
+pub use cipherstash_client::eql::{EqlCiphertext, EqlOutput, Identifier};
 
 use std::mem;
 

--- a/packages/cipherstash-proxy/src/postgresql/backend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/backend.rs
@@ -517,7 +517,7 @@ where
         for (col, ct) in projection_columns.iter().zip(ciphertexts) {
             match (col, ct) {
                 (Some(col), Some(ct)) => {
-                    if col.identifier != ct.identifier {
+                    if col.identifier != *ct.identifier() {
                         return Err(EncryptError::ColumnConfigurationMismatch {
                             table: col.identifier.table.to_owned(),
                             column: col.identifier.column.to_owned(),
@@ -532,8 +532,8 @@ where
                 // ciphertext with no column configuration is bad
                 (None, Some(ct)) => {
                     return Err(EncryptError::ColumnConfigurationMismatch {
-                        table: ct.identifier.table.to_owned(),
-                        column: ct.identifier.column.to_owned(),
+                        table: ct.identifier().table.to_owned(),
+                        column: ct.identifier().column.to_owned(),
                     }
                     .into());
                 }

--- a/packages/cipherstash-proxy/src/postgresql/context/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/context/mod.rs
@@ -734,7 +734,7 @@ where
         &self,
         plaintexts: Vec<Option<cipherstash_client::encryption::Plaintext>>,
         columns: &[Option<Column>],
-    ) -> Result<Vec<Option<crate::EqlCiphertext>>, Error> {
+    ) -> Result<Vec<Option<crate::EqlOutput>>, Error> {
         let keyset_id = self.keyset_identifier();
 
         self.encryption
@@ -1059,7 +1059,7 @@ mod tests {
             _keyset_id: Option<KeysetIdentifier>,
             _plaintexts: Vec<Option<cipherstash_client::encryption::Plaintext>>,
             _columns: &[Option<Column>],
-        ) -> Result<Vec<Option<crate::EqlCiphertext>>, Error> {
+        ) -> Result<Vec<Option<crate::EqlOutput>>, Error> {
             Ok(vec![])
         }
 

--- a/packages/cipherstash-proxy/src/postgresql/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/frontend.rs
@@ -27,7 +27,7 @@ use crate::prometheus::{
     STATEMENTS_PASSTHROUGH_TOTAL, STATEMENTS_UNMAPPABLE_TOTAL,
 };
 use crate::proxy::EncryptionService;
-use crate::EqlCiphertext;
+use crate::EqlOutput;
 use bytes::BytesMut;
 use cipherstash_client::encryption::Plaintext;
 use eql_mapper::{self, EqlMapperError, EqlTerm, TypeCheckedStatement};
@@ -582,13 +582,13 @@ where
     /// # Returns
     ///
     /// Vector of encrypted values corresponding to each literal, with `None` for
-    /// literals that don't require encryption and `Some(EqlCiphertext)` for encrypted values.
+    /// literals that don't require encryption and `Some(EqlOutput)` for encrypted values.
     async fn encrypt_literals(
         &mut self,
         session_id: SessionId,
         typed_statement: &TypeCheckedStatement<'_>,
         literal_columns: &Vec<Option<Column>>,
-    ) -> Result<Vec<Option<EqlCiphertext>>, Error> {
+    ) -> Result<Vec<Option<EqlOutput>>, Error> {
         let literal_values = typed_statement.literal_values();
         if literal_values.is_empty() {
             debug!(target: MAPPER,
@@ -643,7 +643,7 @@ where
     async fn transform_statement(
         &mut self,
         typed_statement: &TypeCheckedStatement<'_>,
-        encrypted_literals: &Vec<Option<EqlCiphertext>>,
+        encrypted_literals: &Vec<Option<EqlOutput>>,
     ) -> Result<Option<ast::Statement>, Error> {
         // Convert literals to ast Expr
         let mut encrypted_expressions = vec![];
@@ -1042,7 +1042,7 @@ where
         session_id: Option<SessionId>,
         bind: &Bind,
         statement: &Statement,
-    ) -> Result<Vec<Option<crate::EqlCiphertext>>, Error> {
+    ) -> Result<Vec<Option<crate::EqlOutput>>, Error> {
         let plaintexts =
             bind.to_plaintext(&statement.param_columns, &statement.postgres_param_types)?;
 

--- a/packages/cipherstash-proxy/src/postgresql/messages/bind.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/bind.rs
@@ -8,7 +8,7 @@ use crate::postgresql::protocol::BytesMutReadString;
 use crate::{SIZE_I16, SIZE_I32};
 use bytes::{Buf, BufMut, BytesMut};
 use cipherstash_client::encryption::Plaintext;
-use cipherstash_client::eql::EqlCiphertext;
+use cipherstash_client::eql::EqlOutput;
 use postgres_types::Type;
 use std::fmt::{self, Display, Formatter};
 use std::io::Cursor;
@@ -81,7 +81,7 @@ impl Bind {
         Ok(plaintexts)
     }
 
-    pub fn rewrite(&mut self, encrypted: Vec<Option<EqlCiphertext>>) -> Result<(), Error> {
+    pub fn rewrite(&mut self, encrypted: Vec<Option<EqlOutput>>) -> Result<(), Error> {
         for (idx, ct) in encrypted.iter().enumerate() {
             if let Some(ct) = ct {
                 let json = serde_json::to_value(ct)?;

--- a/packages/cipherstash-proxy/src/postgresql/messages/data_row.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/data_row.rs
@@ -239,15 +239,20 @@ impl TryFrom<&mut DataColumn> for EqlCiphertext {
 
 #[cfg(test)]
 mod tests {
-    use super::DataRow;
+    use super::{DataRow, NULL};
     use crate::Identifier;
     use crate::{
         config::{LogConfig, LogLevel},
         log,
         postgresql::{messages::data_row::DataColumn, Column},
     };
-    use bytes::BytesMut;
+    use bytes::{BufMut, BytesMut};
+    use cipherstash_client::eql::{
+        EncryptedPayload, EqlCiphertext, SteVecEntry, SteVecEntryTerm, SteVecPayload,
+        EQL_SCHEMA_VERSION,
+    };
     use cipherstash_client::schema::{ColumnConfig, ColumnType};
+    use cipherstash_client::zerokms::EncryptedRecord;
 
     fn to_message(s: &[u8]) -> BytesMut {
         BytesMut::from(s)
@@ -264,13 +269,100 @@ mod tests {
         vec![None, column_config(column)]
     }
 
+    /// A dummy `EncryptedRecord` for the `c` ciphertext field. The data_row
+    /// tests only exercise wire parsing and JSON deserialization, never
+    /// decryption, so the record does not need to be cryptographically valid.
+    fn encrypted_record() -> EncryptedRecord {
+        EncryptedRecord {
+            iv: Default::default(),
+            ciphertext: vec![1; 16],
+            tag: vec![2; 16],
+            descriptor: "encrypted/column".to_string(),
+            keyset_id: None,
+            decryption_policy: None,
+        }
+    }
+
+    /// Builds an EQL v2.3 scalar (`k = "ct"`) storage payload as a JSON string.
+    fn scalar_ciphertext_json(column: &str) -> String {
+        let ciphertext = EqlCiphertext::Encrypted(EncryptedPayload {
+            version: EQL_SCHEMA_VERSION,
+            identifier: Identifier::new("encrypted", column),
+            ciphertext: encrypted_record(),
+            hmac_256: Some("deadbeef".into()),
+            bloom_filter: None,
+            ore_block_u64_8_256: None,
+        });
+        serde_json::to_string(&ciphertext).unwrap()
+    }
+
+    /// Builds an EQL v2.3 STE-vector (`k = "sv"`) storage payload as a JSON string.
+    fn ste_vec_ciphertext_json(column: &str) -> String {
+        let ciphertext = EqlCiphertext::SteVec(SteVecPayload {
+            version: EQL_SCHEMA_VERSION,
+            identifier: Identifier::new("encrypted", column),
+            ste_vec: vec![SteVecEntry {
+                selector: "9493d6010fe7845d52149b697729c745".to_string(),
+                ciphertext: encrypted_record(),
+                is_array: None,
+                term: SteVecEntryTerm::Hmac {
+                    hmac_256: "deadbeef".into(),
+                },
+            }],
+        });
+        serde_json::to_string(&ciphertext).unwrap()
+    }
+
+    /// Frames a `DataRow` backend message from raw column payloads
+    /// (`None` for a SQL NULL column).
+    fn data_row_message(columns: &[Option<&[u8]>]) -> BytesMut {
+        let mut body = BytesMut::new();
+        body.put_i16(columns.len() as i16);
+        for column in columns {
+            match column {
+                Some(data) => {
+                    body.put_i32(data.len() as i32);
+                    body.put_slice(data);
+                }
+                None => body.put_i32(NULL),
+            }
+        }
+
+        let mut message = BytesMut::new();
+        message.put_u8(b'D');
+        message.put_i32((size_of::<i32>() + body.len()) as i32);
+        message.put_slice(&body);
+        message
+    }
+
+    /// Encodes a JSON payload as a PostgreSQL text-format composite value:
+    /// `("...")` with embedded double quotes doubled.
+    fn text_encrypted_column(json: &str) -> Vec<u8> {
+        format!("(\"{}\")", json.replace('"', "\"\"")).into_bytes()
+    }
+
+    /// Encodes a JSON payload as a PostgreSQL binary-format value: a
+    /// single-field record header followed by a `jsonb` value.
+    fn binary_encrypted_column(json: &str) -> Vec<u8> {
+        let mut bytes = BytesMut::new();
+        bytes.put_i32(1); // number of fields
+        bytes.put_i32(3802); // jsonb type OID
+        bytes.put_i32((json.len() + 1) as i32); // field length incl. jsonb version byte
+        bytes.put_u8(1); // jsonb version
+        bytes.put_slice(json.as_bytes());
+        bytes.to_vec()
+    }
+
     #[test]
     pub fn to_ciphertext_with_binary_encoding() {
         log::init(LogConfig::with_level(LogLevel::Debug));
 
         //  Binary
         // SELECT id, encrypted_text FROM encrypted WHERE id = $1
-        let bytes = to_message(b"D\0\0\nR\0\x02\0\0\0\x08w\xaam\xf8Y$\x9dI\0\0\n<\0\0\0\x01\0\0\x0e\xda\0\0\n0\x01{\"b\": null, \"c\": \"mBbLbP2ww9ymEpm_yfj>@=^)JCqtLxcewai)Ilzx#HbC2p3F;dB`XP9af|s-igMjdMWLYPqYWAB#2|%<Q?A|Izg<&Cs4$4MtatzDN{_NWZFbsdA0=?)lF+VYZewzJaCBv4Uvy=7bie\", \"i\": {\"c\": \"encrypted_text\", \"t\": \"encrypted\"}, \"m\": [71, 1624, 929, 1339, 1764, 1380, 1256, 2018, 575, 470, 1792, 1684, 205, 894, 1365, 272, 814, 1333, 1971, 1942, 1335, 404, 1204, 638, 18, 1147, 1098, 1448, 403, 234, 647, 1982, 279, 1606, 826, 113, 652, 1287, 986, 1239, 1988, 358, 1589, 1775, 1997, 633, 369, 1744, 1700, 1149, 1641, 609, 1506, 1915, 630, 1045, 141, 815, 445, 145, 1758, 1772, 1162, 1761, 1619, 1328, 901, 1090, 637, 1529, 1181, 527, 388, 2015, 1317, 1019, 1369, 1340, 176, 936, 1716, 515, 1101, 656, 1737, 1858, 1633, 1849, 512, 1347, 1389, 700, 1336, 1253, 1396, 381, 35, 586, 581, 1877, 1226, 1273, 80, 1499, 433, 1649, 573, 1150, 1572, 1533, 1077], \"o\": [\"faa1f63cb6d36094d1aa50db6c0217eb447a987071119bb127f677b6a7ee0b4fe40eed7cd84e96e8a11bbe3ea14331f3ec4c8f149ce9d2b0253b4676c86557fcec4a5f8ca4e1ee081c66bf0a3cb594c6b5739f77f62fc5e76991869c23a97f01816cde3dfc24b2ca2fbb12b50fde324f18aa51718d681772bf9caf3c059a6748cbcaf4dd1c4fa026e47f4be75ce9046de508041645c0d48cddef735db92b4495a783b2a0f54d6723c959f74aae6fab62202f0d1f2cc2336ced18df80d12b4c6b5e504d2f6e21e12e2cc8ae620b9c714b8becbed3ed8d2b4ece3f0c911eeee4cba805098becdb041966faf06546cb48037153c3285f3d53f750c7cb7b1b6a985de296d0592b0bcb71687a09cd38d53979c5399245a85f9c8c5db68d14a2c2521795b8d670700e1ff324e0f46fe5338f63074adeba5a8a7d81b2693413ed97aa827b5a16ce9fa33ff9c2870465d992e367dfca76d957cbfb1062433825b83941f40b4d47cd65522c8634f4440b058dae20ec940eecaad70f46a81599ebec6c90735a51170f5456685307e9bdb5d9b94665c6b86985dcd95125\", \"b41d89a196a35252a965ce3c330eac369ead56e9f06e2016da4d6971fe0b8d6e677e1018e7a1bd2fa0b2c1faaa12650d678352ecc81f6be879213fe78b8004b87dd7dcadec59df4dcafdb3c9aa55dcb2cc2bcf2193574b201c9a1c14764d69716f63b0c1aa30a2846696f2a1c790ca2cb26370d7e20904a8748ea98a95ee3cbb95c5f342de4e71bb080b6e5cfcb730ba4c094304c759fe520fd59fa20eb1381bf9cb07b3a952a9cd0994ba49085475b605c67df0f5fb970fe20c343bdb6e4e90037656787cfd58622aa6f77026c57b66b95390f7560ed7dc640553e6219dea4015b3484e835241090d1bae888cbf946dc114680e36119a3aa95f64fb13c88dd6e9636898d423d82964dddec5311ec94a30b71eab561988be6cd07e6b7c18df9b4f0fffcc53cec5e883830ab868ee626d7c9bf6bbf8612eb2e0b472e223a06ddf920988630809e02cacf525e7533406f08ec7b192f2d78cb9d4acda1cd8e0d35898ff15b0b6c00d5dc4fa9e45f0666319e32a54d41da63b34cd83b2ccbb70db48ab3d3a959f2e24e40b899e334b8458430376cb7e28c8e673\"], \"s\": null, \"u\": \"962d77dfaf892b596b3255c022359e54f3e8dc8b21c3d1b32ebd05555f433192\", \"v\": 1, \"sv\": null, \"ocf\": null, \"ocv\": null}");
+        let json = scalar_ciphertext_json("encrypted_text");
+        let id = 1234_i64.to_be_bytes();
+        let encrypted_text = binary_encrypted_column(&json);
+        let bytes = data_row_message(&[Some(id.as_slice()), Some(encrypted_text.as_slice())]);
         let mut data_row = DataRow::try_from(&bytes).unwrap();
 
         let column_config = column_config_with_id("encrypted_text");
@@ -284,7 +376,7 @@ mod tests {
 
         assert_eq!(
             column_config[1].as_ref().unwrap().identifier,
-            encrypted[1].as_ref().unwrap().identifier
+            *encrypted[1].as_ref().unwrap().identifier()
         );
     }
 
@@ -320,7 +412,9 @@ mod tests {
         log::init(LogConfig::with_level(LogLevel::Debug));
 
         // SELECT encrypted_jsonb FROM encrypted LIMIT 1
-        let bytes = to_message(b"D\0\0\x03\xba\0\x01\0\0\x03\xb0(\"{\"\"b\"\": null, \"\"c\"\": \"\"mBbLR(BvRN1BF^PAFs!B^`U;mA>uOUiFLgDpZXhU#s#%c4wyi&Z7`(d0IxUty-cI#Yp%o~QFF39^sRf>4*EG{zlk;}ArEQ}NQHa9@;T73aPOSTpuh\"\", \"\"i\"\": {\"\"c\"\": \"\"encrypted_jsonb\"\", \"\"t\"\": \"\"encrypted\"\"}, \"\"m\"\": null, \"\"o\"\": null, \"\"s\"\": null, \"\"u\"\": null, \"\"v\"\": 1, \"\"sv\"\": [{\"\"b\"\": \"\"8067db44a848ab32c3056a3dbe4edf16\"\", \"\"c\"\": \"\"mBbLR(BvRN1BF^PAFs!B^`U;mA>uOUiFLgDpZXhU#s#%c4wyi&Z7`(d0IxUty-cI#Yp%o~QFF39^sRf>4*EG{zlk;}ArEQ}NQHa9@;T73aPOSTpuh\"\", \"\"m\"\": null, \"\"o\"\": null, \"\"s\"\": \"\"9493d6010fe7845d52149b697729c745\"\", \"\"u\"\": null, \"\"sv\"\": null, \"\"ocf\"\": null, \"\"ocv\"\": null}, {\"\"b\"\": null, \"\"c\"\": \"\"mBbLR(BvRN1BF^PAFs!B^`U;m8QkTKr|h>Q`^NbW(CC|>SD}UM=o%mz(Fw#LQFF39^sRf>4*EG{zlk;}ArEQ}NQHa9@;T73aPOSTpuh\"\", \"\"m\"\": null, \"\"o\"\": null, \"\"s\"\": \"\"b1f0e4bb3855bc33936ef1fddf532765\"\", \"\"u\"\": null, \"\"sv\"\": null, \"\"ocf\"\": null, \"\"ocv\"\": \"\"fbc7a11fc81f2a31c904c5b05572b054824e3b5f5ece78f1b711f93175f0a4a9726157cea247e107\"\"}], \"\"ocf\"\": null, \"\"ocv\"\": null}\")");
+        let json = ste_vec_ciphertext_json("encrypted_jsonb");
+        let encrypted_jsonb = text_encrypted_column(&json);
+        let bytes = data_row_message(&[Some(encrypted_jsonb.as_slice())]);
         let mut data_row = DataRow::try_from(&bytes).unwrap();
 
         assert!(data_row.columns[0].bytes.is_some());
@@ -333,7 +427,7 @@ mod tests {
 
         assert_eq!(
             column_config[0].as_ref().unwrap().identifier,
-            encrypted[0].as_ref().unwrap().identifier
+            *encrypted[0].as_ref().unwrap().identifier()
         );
     }
 
@@ -343,7 +437,20 @@ mod tests {
 
         // SELECT * FROM encrypted WHERE id = $1;
         // Only encrypted_text is NOT NULL
-        let bytes = to_message(b"D\0\0\n\x91\0\n\0\0\0\n1297231342\xff\xff\xff\xff\0\0\nY(\"{\"\"b\"\": null, \"\"c\"\": \"\"mBbJ;S^xMu<v?;UyTSS~VfK;4C(U~uOiKbWSK*!hB3vi!C$luW$k`K6>@++(U20{lxK;qYYaDYF#30N~x;wyOUMoFOB9K!>A_9g9j@+M6V3wENqu#H8gDb9OZewzJaCBv4Uvy=7bie\"\", \"\"i\"\": {\"\"c\"\": \"\"encrypted_text\"\", \"\"t\"\": \"\"encrypted\"\"}, \"\"m\"\": [369, 381, 1758, 403, 35, 609, 1181, 1098, 1347, 1633, 1150, 815, 1997, 234, 1858, 656, 1335, 936, 1204, 630, 1764, 1328, 1649, 1396, 113, 1149, 1499, 1147, 586, 1942, 901, 1256, 1226, 1045, 637, 279, 1162, 1077, 1340, 1336, 1448, 700, 176, 1849, 1915, 1389, 71, 515, 633, 388, 1877, 1339, 1239, 638, 1365, 1380, 1273, 581, 1792, 1716, 145, 512, 814, 272, 1333, 1775, 1572, 1744, 2018, 433, 1641, 1529, 647, 1317, 652, 1606, 1737, 470, 826, 80, 929, 1700, 1619, 1253, 358, 1589, 1971, 1019, 1533, 1624, 573, 1684, 1287, 575, 1761, 527, 404, 1369, 894, 18, 1101, 986, 1772, 1090, 1506, 2015, 1988, 205, 141, 445, 1982], \"\"o\"\": [\"\"faa1f63cb6d36094d1aa50db6c0217eb447a987071119bb127f677b6a7ee0b4fe40eed7cd84e96e8a11bbe3ea14331f3ec4c8f149ce9d2b0253b4676c86557fcec4a5f8ca4e1ee081c66bf0a3cb594c6b5739f77f62fc5e76991869c23a97f01816cde3dfc24b2ca2fbb12b50fde324f18aa51718d681772bf9caf3c059a6748cbcaf4dd1c4fa02645d74699d7d265faf938c339f6cc8f57db9bd4cff8e03cae9e5d21a651b33525e86e335dff61520e8f23d7002f05fa186075a335fb7b2c740133b5a72760ccd216127d69983aa31a090a3b6ca56a48b6372cab60c979465d84dc94e5452c92517b643882fa82c22a26b4feaaa1b0ae8fcb989b10d0351fb3c9c5e56e719f820442612a67fff334438f3f5d35ff6db1b5f7a50670c7fec014f6fc19c352eb011911faf62a230e10c2d16f6c84b46cf9ee7eb1afb9c61a523891e31da2a18b445769d75c11873566dc8196d77e985423226bd1db10e4ce9eb10c2f69db7ce57d47281401617978d2bcfca23b9015b9e705615b8bf773daa87a18417f86e5338a7929fa4f10c6864af09870bfd9ddfb7848\"\", \"\"b41d89a196a35252a965ce3c330eac369ead56e9f06e2016da4d6971fe0b8d6e677e1018e7a1bd2fa0b2c1faaa12650d678352ecc81f6be879213fe78b8004b87dd7dcadec59df4dcafdb3c9aa55dcb2cc2bcf2193574b201c9a1c14764d69716f63b0c1aa30a2846696f2a1c790ca2cb26370d7e20904a8748ea98a95ee3cbb95c5f342de4e71bbf0262e84d59188ea72fe4449a16e7c73f88ed06b9cb724902a85d063c03e9b1a63dd18b9604625ca3cb8110d9c8f93e1771525c51b6ee092d554e84d61df5b557994f32191bb2b6801d9727fb707d5287e6c83d6b16763a6e66526baf80765a58d36df744be7872d2750eb28a86a519a21ee710f618c09cb2bd45f21e805ae4e11eb2987d7be31c32164d4f828fc35c389d516d0d6a54e25041985cffcb6124b4d3fa5b0ba91e19d60e3102370e9c1c768df1b427c682304a1dfdea2d3e514db22057f43d8121b8daf7c434831e5b618bbca9f4e198741927bdc168e4703fb1f703957f7b70491e06bec4adee19d29ef5e938695e1d49ef50ceef0a9c3e46bd8fe309e013e5ea0d35c5ebf3dddd97573\"\"], \"\"s\"\": null, \"\"u\"\": \"\"962d77dfaf892b596b3255c022359e54f3e8dc8b21c3d1b32ebd05555f433192\"\", \"\"v\"\": 1, \"\"sv\"\": null, \"\"ocf\"\": null, \"\"ocv\"\": null}\")\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff");
+        let json = scalar_ciphertext_json("encrypted_text");
+        let encrypted_text = text_encrypted_column(&json);
+        let bytes = data_row_message(&[
+            Some(b"1297231342".as_slice()),
+            None,
+            Some(encrypted_text.as_slice()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ]);
 
         let mut data_row = DataRow::try_from(&bytes).unwrap();
 
@@ -374,7 +481,7 @@ mod tests {
 
         assert_eq!(
             column_config[2].as_ref().unwrap().identifier,
-            encrypted[2].as_ref().unwrap().identifier
+            *encrypted[2].as_ref().unwrap().identifier()
         );
     }
 

--- a/packages/cipherstash-proxy/src/proxy/encrypt_config/manager.rs
+++ b/packages/cipherstash-proxy/src/proxy/encrypt_config/manager.rs
@@ -248,7 +248,9 @@ fn canonical_to_map(canonical: CanonicalEncryptionConfig) -> Result<EncryptConfi
 mod tests {
     use super::*;
     use cipherstash_client::eql::Identifier;
-    use cipherstash_config::column::{ArrayIndexMode, IndexType, TokenFilter, Tokenizer};
+    use cipherstash_config::column::{
+        ArrayIndexMode, IndexType, SteVecMode, TokenFilter, Tokenizer,
+    };
     use cipherstash_config::ColumnType;
     use serde_json::json;
 
@@ -518,6 +520,7 @@ mod tests {
                 prefix: "event-data".into(),
                 term_filters: vec![],
                 array_index_mode: ArrayIndexMode::ALL,
+                mode: SteVecMode::Standard,
             },
         );
     }

--- a/packages/cipherstash-proxy/src/proxy/mod.rs
+++ b/packages/cipherstash-proxy/src/proxy/mod.rs
@@ -156,7 +156,7 @@ pub trait EncryptionService: Send + Sync {
         keyset_id: Option<KeysetIdentifier>,
         plaintexts: Vec<Option<Plaintext>>,
         columns: &[Option<Column>],
-    ) -> Result<Vec<Option<crate::EqlCiphertext>>, Error>;
+    ) -> Result<Vec<Option<crate::EqlOutput>>, Error>;
 
     /// Decrypt values retrieved from the database
     async fn decrypt(

--- a/packages/cipherstash-proxy/src/proxy/zerokms/zerokms.rs
+++ b/packages/cipherstash-proxy/src/proxy/zerokms/zerokms.rs
@@ -13,7 +13,7 @@ use cipherstash_client::{
     encryption::{Plaintext, QueryOp},
     eql::{
         decrypt_eql, encrypt_eql, EqlCiphertext, EqlDecryptOpts, EqlEncryptOpts, EqlOperation,
-        PreparedPlaintext,
+        EqlOutput, PreparedPlaintext,
     },
     schema::column::IndexType,
 };
@@ -157,7 +157,7 @@ impl EncryptionService for ZeroKms {
         keyset_id: Option<KeysetIdentifier>,
         plaintexts: Vec<Option<Plaintext>>,
         columns: &[Option<Column>],
-    ) -> Result<Vec<Option<EqlCiphertext>>, Error> {
+    ) -> Result<Vec<Option<EqlOutput>>, Error> {
         debug!(target: ENCRYPT, msg="Encrypt", ?keyset_id, default_keyset_id = ?self.default_keyset_id);
 
         // A keyset is required if no default keyset has been configured
@@ -215,8 +215,9 @@ impl EncryptionService for ZeroKms {
         }
 
         // If no plaintexts to encrypt, return all None
+        // (`EqlOutput` is not `Clone`, so `vec![None; n]` cannot be used)
         if prepared_plaintexts.is_empty() {
-            return Ok(vec![None; plaintexts.len()]);
+            return Ok((0..plaintexts.len()).map(|_| None).collect());
         }
 
         // Use default opts since cipher is already initialized with the correct keyset
@@ -231,9 +232,10 @@ impl EncryptionService for ZeroKms {
         debug!(target: ENCRYPT, msg="encrypt_eql completed", count = encrypted.len(), duration_ms = encrypt_duration.as_millis());
 
         // Reconstruct the result vector with None values in the right places
-        let mut result: Vec<Option<EqlCiphertext>> = vec![None; plaintexts.len()];
-        for (idx, ciphertext) in indices.into_iter().zip(encrypted.into_iter()) {
-            result[idx] = Some(ciphertext);
+        // (`EqlOutput` is not `Clone`, so `vec![None; n]` cannot be used)
+        let mut result: Vec<Option<EqlOutput>> = (0..plaintexts.len()).map(|_| None).collect();
+        for (idx, output) in indices.into_iter().zip(encrypted.into_iter()) {
+            result[idx] = Some(output);
         }
 
         Ok(result)


### PR DESCRIPTION
Bump cipherstash-client, cipherstash-config and cts-common to 0.35.0, and CS_EQL_VERSION to the eql-2.3.0 release.

0.35.0 reworks the EQL types for the 2.3 payload format:

- `EqlCiphertext` is now a `#[serde(tag = "k")]` enum (Encrypted / SteVec) and `identifier` is a method rather than a field.
- `encrypt_eql` returns the new `EqlOutput` type (Store / Query). The encrypt path now carries `EqlOutput`; the decrypt path keeps `EqlCiphertext`. `EqlOutput` is not `Clone`, so `vec![None; n]` is replaced with iterator construction.
- `EqlError::CouldNotDecryptDataForKeyset` gained a `source` field.
- `IndexType::SteVec` gained a `mode` field.

Rewrite the data_row tests to build wire messages programmatically from the new EQL 2.3.0 types instead of hardcoded payload bytes.

<!-- Please provide a summary of what's being changed -->

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
