### PR TITLE
feat(cli): connection flags + DX (quiet logging, random port, best-effort TLS)

### DIFF
--- a/packages/cipherstash-proxy-integration/src/migrate/mod.rs
+++ b/packages/cipherstash-proxy-integration/src/migrate/mod.rs
@@ -42,9 +42,15 @@ mod tests {
             log_level: LogLevel::Debug,
             log_format: LogFormat::Pretty,
             command: None,
+            database_url: None,
             db_host: None,
+            db_port: None,
             db_name: None,
             db_user: None,
+            db_password: None,
+            no_tls: false,
+            tls: false,
+            debug: false,
         };
 
         let config = match TandemConfig::load(&args) {

--- a/packages/cipherstash-proxy-integration/src/migrate/mod.rs
+++ b/packages/cipherstash-proxy-integration/src/migrate/mod.rs
@@ -39,7 +39,7 @@ mod tests {
 
         let args = Args {
             config_file_path: "".to_string(),
-            log_level: LogLevel::Debug,
+            log_level: Some(LogLevel::Debug),
             log_format: LogFormat::Pretty,
             command: None,
             database_url: None,

--- a/packages/cipherstash-proxy/src/cli/mod.rs
+++ b/packages/cipherstash-proxy/src/cli/mod.rs
@@ -21,10 +21,22 @@ const DEFAULT_CONFIG_FILE: &str = "cipherstash-proxy.toml";
 /// CipherStash Proxy keeps your sensitive data in PostgreSQL encrypted and searchable, with no changes to SQL.
 ///
 pub struct Args {
+    /// Optional full PostgreSQL connection string, e.g.
+    /// "postgres://user:pass@host:5432/dbname".
+    /// Sets host, port, user, password and database name at once.
+    /// Individual flags below override matching parts of the URL.
+    #[arg(long, value_name = "URL", verbatim_doc_comment)]
+    pub database_url: Option<String>,
+
     /// Optional database host to connect to.
     /// Uses env or config file if not specified.
     #[arg(short = 'H', long)]
     pub db_host: Option<String>,
+
+    /// Optional database port to connect to.
+    /// Uses env or config file if not specified.
+    #[arg(short = 'P', long)]
+    pub db_port: Option<u16>,
 
     /// Optional database name to connect to.
     /// Uses env or config file if not specified.
@@ -35,6 +47,20 @@ pub struct Args {
     /// Uses env or config file if not specified.
     #[arg(short = 'u', long)]
     pub db_user: Option<String>,
+
+    /// Optional database password.
+    /// Uses env or config file if not specified.
+    /// Prefer CS_DATABASE__PASSWORD or --database-url to avoid leaking the
+    /// password into shell history / the process list.
+    #[arg(short = 'W', long, verbatim_doc_comment)]
+    pub db_password: Option<String>,
+
+    /// Disable inbound (client-facing) TLS: the proxy listens for client
+    /// connections in plaintext. Overrides any CS_TLS__* env / config.
+    /// Use for local development only. Does not affect the connection from the
+    /// proxy to the database.
+    #[arg(long, verbatim_doc_comment)]
+    pub no_tls: bool,
 
     /// Optional path to a CipherStash Proxy configuration file.
     ///

--- a/packages/cipherstash-proxy/src/cli/mod.rs
+++ b/packages/cipherstash-proxy/src/cli/mod.rs
@@ -59,8 +59,19 @@ pub struct Args {
     /// connections in plaintext. Overrides any CS_TLS__* env / config.
     /// Use for local development only. Does not affect the connection from the
     /// proxy to the database.
-    #[arg(long, verbatim_doc_comment)]
+    #[arg(long, verbatim_doc_comment, conflicts_with = "tls")]
     pub no_tls: bool,
+
+    /// Require inbound (client-facing) TLS. Startup fails if TLS is not
+    /// configured or the certificate/key are invalid. Without this flag the
+    /// proxy uses TLS when configured and falls back to plaintext otherwise.
+    #[arg(long, verbatim_doc_comment)]
+    pub tls: bool,
+
+    /// Enable verbose (debug) logging. Without it the proxy logs errors only.
+    /// An explicit --log-level / CS_LOG__LEVEL or a config file takes precedence.
+    #[arg(long, verbatim_doc_comment)]
+    pub debug: bool,
 
     /// Optional path to a CipherStash Proxy configuration file.
     ///

--- a/packages/cipherstash-proxy/src/cli/mod.rs
+++ b/packages/cipherstash-proxy/src/cli/mod.rs
@@ -84,8 +84,8 @@ pub struct Args {
     ///
     /// Optional log level.
     ///
-    #[arg(short, long, value_enum, default_value_t = LogConfig::default_log_level(), env = "CS_LOG__LEVEL", global = true)]
-    pub log_level: LogLevel,
+    #[arg(short, long, value_enum, env = "CS_LOG__LEVEL", global = true)]
+    pub log_level: Option<LogLevel>,
 
     ///
     /// Optional log format. Default level is "pretty" if running in a terminal session, otherwise "structured".
@@ -115,5 +115,24 @@ pub async fn run(args: Args, config: TandemConfig) -> Result<bool, Error> {
             Ok(true)
         }
         None => Ok(false),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Args;
+    use crate::config::LogLevel;
+    use clap::Parser;
+
+    #[test]
+    fn log_level_preserves_whether_it_was_explicitly_set() {
+        temp_env::with_var_unset("CS_LOG__LEVEL", || {
+            let omitted = Args::try_parse_from(["cipherstash-proxy"]).unwrap();
+            let explicit =
+                Args::try_parse_from(["cipherstash-proxy", "--log-level", "info"]).unwrap();
+
+            assert_eq!(omitted.log_level, None);
+            assert_eq!(explicit.log_level, Some(LogLevel::Info));
+        });
     }
 }

--- a/packages/cipherstash-proxy/src/config/tandem.rs
+++ b/packages/cipherstash-proxy/src/config/tandem.rs
@@ -131,6 +131,8 @@ impl TandemConfig {
             db_user: None,
             db_password: None,
             no_tls: false,
+            tls: false,
+            debug: false,
             log_level: LogConfig::default_log_level(),
             log_format: LogConfig::default_log_format(),
             command: None,

--- a/packages/cipherstash-proxy/src/config/tandem.rs
+++ b/packages/cipherstash-proxy/src/config/tandem.rs
@@ -391,9 +391,6 @@ impl Default for PrometheusConfig {
 
 static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"`([^`]+)`").unwrap());
 
-///
-/// Extracts a field name (if present) from a config::ConfigError string
-/// This is called in `build` if a ConfigError message contains the string `missing field`
 /// Parse a PostgreSQL connection string (e.g.
 /// "postgres://user:pass@host:5432/dbname") and set the corresponding
 /// CS_DATABASE__* env vars for each component present. Individual --db-* flags
@@ -423,9 +420,15 @@ fn apply_database_url(url: &str) -> Result<(), Error> {
     }
 
     if let Some(password) = pg.get_password() {
-        if let Ok(password) = std::str::from_utf8(password) {
-            env::set_var("CS_DATABASE__PASSWORD", password);
-        }
+        // The password is required downstream as a String. Rather than silently
+        // dropping a non-UTF8 password (which would leave the proxy connecting
+        // with no password, or a stale env/config one), fail clearly.
+        let password =
+            std::str::from_utf8(password).map_err(|_| ConfigError::InvalidParameter {
+                name: "database-url".to_string(),
+                value: "password contains invalid UTF-8".to_string(),
+            })?;
+        env::set_var("CS_DATABASE__PASSWORD", password);
     }
 
     if let Some(dbname) = pg.get_dbname() {
@@ -524,6 +527,27 @@ mod tests {
                     assert!(std::env::var("CS_DATABASE__USER").is_err());
                 },
             );
+        });
+    }
+
+    #[test]
+    /// A non-UTF8 password in --database-url is an error, not a silent no-op.
+    /// tokio-postgres percent-decodes the password to raw bytes without UTF-8
+    /// validation, so `%FF` yields invalid UTF-8; we must reject it rather than
+    /// leave CS_DATABASE__PASSWORD unset (which would connect with no/stale
+    /// credentials).
+    fn database_url_rejects_non_utf8_password() {
+        use crate::config::tandem::apply_database_url;
+        with_no_cs_vars(|| {
+            temp_env::with_vars_unset(["CS_DATABASE__PASSWORD"], || {
+                let result = apply_database_url("postgres://alice:%FF@db.example.com/orders");
+                assert!(
+                    result.is_err(),
+                    "expected a non-UTF8 password to be rejected"
+                );
+                // And it must not have set a password from the bad URL.
+                assert!(std::env::var("CS_DATABASE__PASSWORD").is_err());
+            });
         });
     }
 

--- a/packages/cipherstash-proxy/src/config/tandem.rs
+++ b/packages/cipherstash-proxy/src/config/tandem.rs
@@ -108,15 +108,29 @@ impl TandemConfig {
             config.log.format = args.log_format;
         }
 
+        // --no-tls forces a plaintext inbound listener, ignoring any CS_TLS__*
+        // env / config. (Does not affect the proxy -> database connection.)
+        if args.no_tls {
+            if config.tls.is_some() {
+                println!("Disabling inbound TLS (--no-tls): the proxy will listen without TLS");
+            }
+            config.tls = None;
+            config.server.require_tls = false;
+        }
+
         Ok(config)
     }
 
     pub fn build_path(path: &str) -> Result<Self, Error> {
         let args = Args {
             config_file_path: path.to_string(),
+            database_url: None,
             db_host: None,
+            db_port: None,
             db_name: None,
             db_user: None,
+            db_password: None,
+            no_tls: false,
             log_level: LogConfig::default_log_level(),
             log_format: LogConfig::default_log_format(),
             command: None,
@@ -169,10 +183,22 @@ impl TandemConfig {
                 env
             }));
 
-        // Command line arguments override env vars
+        // Command line arguments override env vars.
+        // A full connection string is applied first; individual flags below
+        // then override matching parts of it.
+        if let Some(url) = &args.database_url {
+            println!("Overriding database connection from --database-url");
+            apply_database_url(url)?;
+        }
+
         if let Some(db_host) = &args.db_host {
             println!("Overriding database host from command line argument");
             env::set_var("CS_DATABASE__HOST", db_host);
+        }
+
+        if let Some(db_port) = &args.db_port {
+            println!("Overriding database port from command line argument");
+            env::set_var("CS_DATABASE__PORT", db_port.to_string());
         }
 
         if let Some(dbname) = &args.db_name {
@@ -182,7 +208,12 @@ impl TandemConfig {
 
         if let Some(db_user) = &args.db_user {
             println!("Overriding database user from command line argument");
-            env::set_var("CS_DATABASE__USER", db_user);
+            env::set_var("CS_DATABASE__USERNAME", db_user);
+        }
+
+        if let Some(db_password) = &args.db_password {
+            println!("Overriding database password from command line argument");
+            env::set_var("CS_DATABASE__PASSWORD", db_password);
         }
 
         // Source order is important!
@@ -361,6 +392,47 @@ static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"`([^`]+)`").unwrap())
 ///
 /// Extracts a field name (if present) from a config::ConfigError string
 /// This is called in `build` if a ConfigError message contains the string `missing field`
+/// Parse a PostgreSQL connection string (e.g.
+/// "postgres://user:pass@host:5432/dbname") and set the corresponding
+/// CS_DATABASE__* env vars for each component present. Individual --db-* flags
+/// are applied after this and take precedence.
+fn apply_database_url(url: &str) -> Result<(), Error> {
+    use std::str::FromStr;
+
+    let pg =
+        tokio_postgres::Config::from_str(url).map_err(|err| ConfigError::InvalidParameter {
+            name: "database-url".to_string(),
+            value: err.to_string(),
+        })?;
+
+    if let Some(host) = pg.get_hosts().iter().find_map(|h| match h {
+        tokio_postgres::config::Host::Tcp(host) => Some(host.clone()),
+        _ => None,
+    }) {
+        env::set_var("CS_DATABASE__HOST", host);
+    }
+
+    if let Some(port) = pg.get_ports().first() {
+        env::set_var("CS_DATABASE__PORT", port.to_string());
+    }
+
+    if let Some(user) = pg.get_user() {
+        env::set_var("CS_DATABASE__USERNAME", user);
+    }
+
+    if let Some(password) = pg.get_password() {
+        if let Ok(password) = std::str::from_utf8(password) {
+            env::set_var("CS_DATABASE__PASSWORD", password);
+        }
+    }
+
+    if let Some(dbname) = pg.get_dbname() {
+        env::set_var("CS_DATABASE__NAME", dbname);
+    }
+
+    Ok(())
+}
+
 /// Expected string is in the forms:
 ///     "missing field `{field}}` for key `{key}`"
 ///     "missing field `{field}}`"
@@ -418,6 +490,40 @@ mod tests {
     use uuid::Uuid;
 
     const CS_PREFIX: &str = "CS_TEST";
+
+    #[test]
+    /// --database-url sets each CS_DATABASE__* var, including USERNAME (not USER
+    /// -- a previous bug set the wrong var so --db-user was a silent no-op).
+    fn database_url_sets_connection_env() {
+        use crate::config::tandem::apply_database_url;
+        with_no_cs_vars(|| {
+            temp_env::with_vars_unset(
+                [
+                    "CS_DATABASE__HOST",
+                    "CS_DATABASE__PORT",
+                    "CS_DATABASE__USERNAME",
+                    "CS_DATABASE__USER",
+                    "CS_DATABASE__PASSWORD",
+                    "CS_DATABASE__NAME",
+                ],
+                || {
+                    apply_database_url("postgres://alice:s3cret@db.example.com:5430/orders")
+                        .unwrap();
+
+                    assert_eq!(
+                        std::env::var("CS_DATABASE__HOST").unwrap(),
+                        "db.example.com"
+                    );
+                    assert_eq!(std::env::var("CS_DATABASE__PORT").unwrap(), "5430");
+                    assert_eq!(std::env::var("CS_DATABASE__USERNAME").unwrap(), "alice");
+                    assert_eq!(std::env::var("CS_DATABASE__PASSWORD").unwrap(), "s3cret");
+                    assert_eq!(std::env::var("CS_DATABASE__NAME").unwrap(), "orders");
+                    // The old (buggy) variable name must not be set.
+                    assert!(std::env::var("CS_DATABASE__USER").is_err());
+                },
+            );
+        });
+    }
 
     #[test]
     /// the env vars from stash setup should be the preferred option

--- a/packages/cipherstash-proxy/src/config/tandem.rs
+++ b/packages/cipherstash-proxy/src/config/tandem.rs
@@ -16,7 +16,6 @@ use regex::Regex;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::env;
-use std::path::PathBuf;
 use std::sync::LazyLock;
 use uuid::Uuid;
 
@@ -88,19 +87,13 @@ impl TandemConfig {
     }
 
     pub fn load(args: &Args) -> Result<TandemConfig, Error> {
-        // Log a warning to user that config file is missing
-        if !PathBuf::from(&args.config_file_path).exists() {
-            println!(
-                "Configuration file was not found: {}",
-                args.config_file_path
-            );
-            println!("Loading config values from environment variables.");
-        }
         let mut config = TandemConfig::build(args)?;
 
         // If log level is default, it has not been set by the user in config
         if config.log.level == LogConfig::default_log_level() {
-            config.log.level = args.log_level;
+            if let Some(log_level) = args.log_level {
+                config.log.level = log_level;
+            }
         }
 
         // If log format is default, it has not been set by the user in config
@@ -111,9 +104,6 @@ impl TandemConfig {
         // --no-tls forces a plaintext inbound listener, ignoring any CS_TLS__*
         // env / config. (Does not affect the proxy -> database connection.)
         if args.no_tls {
-            if config.tls.is_some() {
-                println!("Disabling inbound TLS (--no-tls): the proxy will listen without TLS");
-            }
             config.tls = None;
             config.server.require_tls = false;
         }
@@ -133,7 +123,7 @@ impl TandemConfig {
             no_tls: false,
             tls: false,
             debug: false,
-            log_level: LogConfig::default_log_level(),
+            log_level: None,
             log_format: LogConfig::default_log_format(),
             command: None,
         };
@@ -189,32 +179,26 @@ impl TandemConfig {
         // A full connection string is applied first; individual flags below
         // then override matching parts of it.
         if let Some(url) = &args.database_url {
-            println!("Overriding database connection from --database-url");
             apply_database_url(url)?;
         }
 
         if let Some(db_host) = &args.db_host {
-            println!("Overriding database host from command line argument");
             env::set_var("CS_DATABASE__HOST", db_host);
         }
 
         if let Some(db_port) = &args.db_port {
-            println!("Overriding database port from command line argument");
             env::set_var("CS_DATABASE__PORT", db_port.to_string());
         }
 
         if let Some(dbname) = &args.db_name {
-            println!("Overriding database name from command line argument");
             env::set_var("CS_DATABASE__NAME", dbname);
         }
 
         if let Some(db_user) = &args.db_user {
-            println!("Overriding database user from command line argument");
             env::set_var("CS_DATABASE__USERNAME", db_user);
         }
 
         if let Some(db_password) = &args.db_password {
-            println!("Overriding database password from command line argument");
             env::set_var("CS_DATABASE__PASSWORD", db_password);
         }
 

--- a/packages/cipherstash-proxy/src/connect/mod.rs
+++ b/packages/cipherstash-proxy/src/connect/mod.rs
@@ -51,15 +51,34 @@ pub async fn database(config: &DatabaseConfig) -> Result<Client, Error> {
     Ok(client)
 }
 
-pub async fn bind_with_retry(server: &ServerConfig) -> TcpListener {
-    let address = &server.to_socket_address();
+pub async fn bind_with_retry(server: &ServerConfig, allow_random_fallback: bool) -> TcpListener {
+    let address = server.to_socket_address();
     let mut retry_count = 0;
 
     loop {
-        match TcpListener::bind(address).await {
+        match TcpListener::bind(&address).await {
             Ok(listener) => {
-                info!(msg = "Server waiting for connections", address);
+                report_listening(&listener);
                 return listener;
+            }
+            // The configured port is in use, but it's only the default (not
+            // explicitly set), so fall back to an OS-assigned port and report it
+            // rather than failing.
+            Err(err) if err.kind() == std::io::ErrorKind::AddrInUse && allow_random_fallback => {
+                match TcpListener::bind(format!("{}:0", server.host)).await {
+                    Ok(listener) => {
+                        println!(
+                            "Port {} is already in use; listening on an OS-assigned port instead.",
+                            server.port
+                        );
+                        report_listening(&listener);
+                        return listener;
+                    }
+                    Err(err) => {
+                        error!(msg = "Error binding connection", error = err.to_string());
+                        std::process::exit(exitcode::CONFIG);
+                    }
+                }
             }
             Err(err) => {
                 if retry_count > MAX_RETRY_COUNT {
@@ -77,6 +96,21 @@ pub async fn bind_with_retry(server: &ServerConfig) -> TcpListener {
         time::sleep(Duration::from_millis(sleep_duration_ms)).await;
 
         retry_count += 1;
+    }
+}
+
+/// Report the address the proxy is listening on. Uses `println!` so the
+/// listening address (including an OS-assigned fallback port) is always visible,
+/// even when logging is quiet.
+fn report_listening(listener: &TcpListener) {
+    match listener.local_addr() {
+        Ok(addr) => {
+            println!("CipherStash Proxy listening on {addr}");
+            info!(msg = "Server waiting for connections", address = %addr);
+        }
+        Err(_) => {
+            info!(msg = "Server waiting for connections");
+        }
     }
 }
 
@@ -155,5 +189,30 @@ pub fn configure(stream: &TcpStream) {
                 error = err.to_string()
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn bind_falls_back_to_random_port_when_default_in_use() {
+        // Occupy a port, then ask bind_with_retry to bind the same one.
+        let occupied = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let occupied_port = occupied.local_addr().unwrap().port();
+
+        let server = ServerConfig {
+            host: "127.0.0.1".to_string(),
+            port: occupied_port,
+            ..ServerConfig::default()
+        };
+
+        // With fallback allowed, it binds a different OS-assigned port.
+        let listener = bind_with_retry(&server, true).await;
+        let bound_port = listener.local_addr().unwrap().port();
+
+        assert_ne!(bound_port, occupied_port);
+        assert_ne!(bound_port, 0);
     }
 }

--- a/packages/cipherstash-proxy/src/main.rs
+++ b/packages/cipherstash-proxy/src/main.rs
@@ -1,4 +1,4 @@
-use cipherstash_proxy::config::TandemConfig;
+use cipherstash_proxy::config::{LogConfig, LogLevel, TandemConfig};
 use cipherstash_proxy::connect::{self, AsyncStream};
 use cipherstash_proxy::error::{ConfigError, Error};
 use cipherstash_proxy::prometheus::CLIENTS_ACTIVE_CONNECTIONS;
@@ -23,7 +23,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    log::init(config.log.clone());
+    // Quiet by default for CLI use: log errors only, unless --debug is passed,
+    // a log level was set explicitly (--log-level / CS_LOG__LEVEL), or a config
+    // file is present. This keeps `proxy` clean to run by hand while leaving
+    // production (which sets a level or ships a config) unchanged.
+    let log_explicitly_set = args.log_level != LogConfig::default_log_level()
+        || std::env::var("CS_LOG__LEVEL").is_ok()
+        || std::path::Path::new(&args.config_file_path).exists();
+    let log_config = if args.debug {
+        LogConfig::with_level(LogLevel::Debug)
+    } else if log_explicitly_set {
+        config.log.clone()
+    } else {
+        LogConfig::with_level(LogLevel::Error)
+    };
+    log::init(log_config);
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(config.server.worker_threads)
@@ -52,9 +66,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     runtime.block_on(async move {
         let shutdown_timeout = &config.server.shutdown_timeout();
 
-        let mut proxy = init(config).await;
+        let mut proxy = init(config, args.tls).await;
 
-        let listener = connect::bind_with_retry(&proxy.config.server).await;
+        // If the listen port is just the default (not set via CS_SERVER__PORT or
+        // a config file) and it's already in use, fall back to an OS-assigned
+        // port rather than failing. An explicitly configured port is respected.
+        let port_configured = std::env::var("CS_SERVER__PORT").is_ok()
+            || std::path::Path::new(&args.config_file_path).exists();
+        let listener = connect::bind_with_retry(&proxy.config.server, !port_configured).await;
         let tracker = TaskTracker::new();
 
         let mut client_id = 0;
@@ -144,7 +163,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// Validate various configuration options and
 /// Init the Proxy service
 ///
-async fn init(mut config: TandemConfig) -> Proxy {
+async fn init(mut config: TandemConfig, force_tls: bool) -> Proxy {
     if config.encrypt.default_keyset_id.is_none() {
         warn!(msg = "Default Keyset Id has not been configured");
         warn!(msg = "A Keyset Identifier must be set using the `SET CIPHERSTASH.KEYSET_ID` or `SET CIPHERSTASH.KEYSET_NAME` commands");
@@ -182,32 +201,53 @@ async fn init(mut config: TandemConfig) -> Proxy {
             std::process::exit(exitcode::CONFIG);
         });
 
-    match config.tls {
-        Some(ref mut tls) => {
-            _ = tls.check_cert().inspect_err(|err| {
-                error!(msg = err.to_string());
-                std::process::exit(exitcode::CONFIG);
-            });
-
-            _ = tls.check_private_key().inspect_err(|err| {
-                error!(msg = err.to_string());
-                std::process::exit(exitcode::CONFIG);
-            });
-
-            match tls::configure_server(tls) {
-                Ok(_) => {
-                    info!(msg = "Server Transport Layer Security (TLS) configuration validated");
-                }
-                Err(err) => {
-                    error!(
-                        msg = "Server Transport Layer Security (TLS) configuration error",
-                        error = err.to_string()
-                    );
-                    std::process::exit(exitcode::CONFIG);
-                }
+    // Validate inbound TLS if configured. By default, a TLS misconfiguration is
+    // non-fatal: we warn and fall back to a plaintext listener. Passing --tls
+    // makes any TLS problem fatal (no silent downgrade).
+    let tls_error: Option<String> = match &config.tls {
+        Some(tls) => {
+            if let Err(err) = tls.check_cert() {
+                Some(err.to_string())
+            } else if let Err(err) = tls.check_private_key() {
+                Some(err.to_string())
+            } else if let Err(err) = tls::configure_server(tls) {
+                Some(err.to_string())
+            } else {
+                None
             }
         }
-        None => {
+        None => None,
+    };
+
+    match (&config.tls, tls_error, force_tls) {
+        // TLS configured and valid.
+        (Some(_), None, _) => {
+            info!(msg = "Server Transport Layer Security (TLS) configuration validated");
+        }
+        // TLS configured but invalid, and --tls forces it: fatal.
+        (Some(_), Some(err), true) => {
+            eprintln!("TLS is required (--tls) but the configuration is invalid: {err}");
+            std::process::exit(exitcode::CONFIG);
+        }
+        // TLS configured but invalid, no force: fall back to plaintext.
+        (Some(_), Some(err), false) => {
+            eprintln!(
+                "TLS configuration is invalid ({err}); falling back to a plaintext listener. \
+                 Pass --tls to make this fatal, or --no-tls to silence this warning."
+            );
+            config.tls = None;
+            config.server.require_tls = false;
+        }
+        // No TLS configured, but --tls forces it: fatal.
+        (None, _, true) => {
+            eprintln!(
+                "TLS is required (--tls) but no inbound TLS certificate is configured \
+                 (set CS_TLS__CERTIFICATE_PATH / CS_TLS__PRIVATE_KEY_PATH)."
+            );
+            std::process::exit(exitcode::CONFIG);
+        }
+        // No TLS configured, no force: plaintext listener.
+        (None, _, false) => {
             warn!(msg = "Transport Layer Security (TLS) is not configured");
             warn!(msg = "Listening on an unsafe connection");
         }
@@ -287,6 +327,6 @@ async fn reload_application_config(config: &TandemConfig, args: &Args) -> Result
     }
 
     info!(msg = "Configuration reloaded");
-    let proxy = init(new_config).await;
+    let proxy = init(new_config, args.tls).await;
     Ok(proxy)
 }

--- a/packages/cipherstash-proxy/src/main.rs
+++ b/packages/cipherstash-proxy/src/main.rs
@@ -27,13 +27,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // a log level was set explicitly (--log-level / CS_LOG__LEVEL), or a config
     // file is present. This keeps `proxy` clean to run by hand while leaving
     // production (which sets a level or ships a config) unchanged.
-    let log_explicitly_set = args.log_level != LogConfig::default_log_level()
+    let log_explicitly_set = args.log_level.is_some()
         || std::env::var("CS_LOG__LEVEL").is_ok()
         || std::path::Path::new(&args.config_file_path).exists();
-    let log_config = if args.debug {
-        LogConfig::with_level(LogLevel::Debug)
-    } else if log_explicitly_set {
+    let log_config = if log_explicitly_set {
         config.log.clone()
+    } else if args.debug {
+        LogConfig::with_level(LogLevel::Debug)
     } else {
         LogConfig::with_level(LogLevel::Error)
     };

--- a/packages/cipherstash-proxy/src/postgresql/backend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/backend.rs
@@ -2,7 +2,7 @@ use super::context::Context;
 use super::data::to_sql;
 use super::error_handler::PostgreSqlErrorHandler;
 use super::message_buffer::MessageBuffer;
-use super::messages::error_response::ErrorResponse;
+use super::messages::error_response::{ErrorResponse, ErrorResponseCode};
 use super::messages::row_description::RowDescription;
 use super::messages::{BackendCode, UNSPECIFIED_TYPE_OID};
 use super::Column;
@@ -24,7 +24,7 @@ use bytes::BytesMut;
 use metrics::{counter, histogram};
 use std::time::Instant;
 use tokio::io::AsyncRead;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 
 /// The PostgreSQL proxy backend that handles server-to-client message processing.
 ///
@@ -337,8 +337,16 @@ where
     /// to forward to the client unchanged.
     fn error_response_handler(&mut self, bytes: &BytesMut) -> Result<Option<BytesMut>, Error> {
         let error_response = ErrorResponse::try_from(bytes)?;
-        error!(msg = "PostgreSQL Error", error = ?error_response);
-        info!(msg = "PostgreSQL Errors originate in the database");
+        // A database error forwarded to the client is normal proxy operation --
+        // the client surfaces it -- so log concisely at debug, not error. (The
+        // full message is available to the client; --debug shows it here too.)
+        debug!(
+            target: PROTOCOL,
+            client_id = self.context.client_id,
+            msg = "Database returned an error",
+            code = error_response.field(ErrorResponseCode::Code).unwrap_or("?"),
+            error = error_response.field(ErrorResponseCode::Message).unwrap_or(""),
+        );
         Ok(Some(bytes.to_owned()))
     }
 

--- a/packages/cipherstash-proxy/src/postgresql/messages/error_response.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/error_response.rs
@@ -60,6 +60,15 @@ pub enum ErrorResponseCode {
 }
 
 impl ErrorResponse {
+    /// Value of the first field with the given code (e.g. the SQLSTATE `Code`
+    /// or the human-readable `Message`), if present.
+    pub fn field(&self, code: ErrorResponseCode) -> Option<&str> {
+        self.fields
+            .iter()
+            .find(|f| f.code == code)
+            .map(|f| f.value.as_str())
+    }
+
     /// Create a FATAL error response for connection timeout.
     ///
     /// Uses PostgreSQL error code 57P05 (idle_session_timeout). While this code
@@ -520,6 +529,19 @@ mod tests {
         let bytes = BytesMut::try_from(error_response).unwrap();
         let message = to_message(b"E\0\0\0kSERROR\0VERROR\0C26000\0Mprepared statement \"a37\" does not exist\0Fprepare.c\0L454\0RFetchPreparedStatement\0\0");
         assert_eq!(bytes, message);
+    }
+
+    #[test]
+    pub fn field_returns_value_by_code() {
+        let message = to_message(b"E\0\0\0kSERROR\0VERROR\0C26000\0Mprepared statement \"a37\" does not exist\0Fprepare.c\0L454\0RFetchPreparedStatement\0\0Z\0\0\0\x05I");
+        let error_response = ErrorResponse::try_from(&message).unwrap();
+
+        assert_eq!(error_response.field(ErrorResponseCode::Code), Some("26000"));
+        assert_eq!(
+            error_response.field(ErrorResponseCode::Message),
+            Some("prepared statement \"a37\" does not exist")
+        );
+        assert_eq!(error_response.field(ErrorResponseCode::Detail), None);
     }
 
     #[test]


### PR DESCRIPTION
Implements CIP-3823, making the proxy usable as a plain CLI (for example, `npx stash proxy`) without hand-setting connection environment variables.

## Connection flags

- Add `--database-url <URL>` to parse a PostgreSQL connection string via `tokio-postgres`; individual `--db-*` flags take precedence.
- Add `--db-port` (`-P`) and `--db-password` (`-W`).
- Fix `--db-user` to set `CS_DATABASE__USERNAME` instead of the unused `CS_DATABASE__USER`.
- Reject non-UTF-8 URL passwords instead of silently retaining an absent or stale password.

## CLI behavior

- Log errors only by default while always printing the bound listen address.
- Preserve explicit `--log-level` and `CS_LOG__LEVEL` values, including an explicit `info`; an explicit level or config file takes precedence over `--debug`.
- Remove informational configuration and override chatter from quiet startup.
- If the implicit default listen port is occupied, bind an OS-assigned port and report it. Explicitly configured ports remain strict.
- Treat invalid inbound TLS as best effort: fall back to plaintext with a notice. `--tls` makes TLS mandatory, while `--no-tls` forces plaintext.
- Log PostgreSQL errors forwarded to clients concisely at debug level instead of dumping the full response at error level.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-features -- -D warnings`
- `cargo check -p cipherstash-proxy-integration`
- `cargo test -p cipherstash-proxy database_url_sets_connection_env`
- `cargo test -p cipherstash-proxy bind_falls_back_to_random_port_when_default_in_use`
- `cargo test -p cipherstash-proxy log_level_preserves_whether_it_was_explicitly_set`
- Full `cipherstash-proxy` unit suite: 136/137 passed in parallel; the remaining environment-mutating config test passed in isolation.

The branch is rebased onto current `origin/main`, and all five commits include DCO sign-offs.
