### PR TITLE
spike(npm): prototype `npx stash proxy` distribution

### DIFF
--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,0 +1,8 @@
+# Native binaries are build artifacts, not source — populated by build-binaries.sh
+packages/*/bin/cipherstash-proxy
+packages/*/bin/cipherstash-proxy.exe
+
+# npm install / pack output
+**/node_modules/
+**/package-lock.json
+*.tgz

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,82 @@
+# `npx stash proxy` — npm distribution prototype
+
+Proof-of-concept for shipping CipherStash Proxy through npm so it runs as
+`npx stash proxy [...]`, with **no native bindings** — the npm package is a thin
+launcher around the existing prebuilt Rust binary (the esbuild / Biome / SWC
+pattern).
+
+## Why this shape (not N-API bindings)
+
+Proxy is a standalone server (its own tokio runtime, listeners, TLS, signals).
+We don't need to call it from JS in-process, so a native Node addon would add
+lifecycle/complexity for no benefit. Instead: npm *distributes* the binary and a
+tiny JS shim *launches* it.
+
+## Layout
+
+```
+npm/
+  packages/
+    stash/                       # meta package — `bin: stash`
+      bin/stash.js               # dispatch `stash proxy [...]` -> exec binary
+      lib/resolve.js             # pick the platform package for this host
+      package.json               # optionalDependencies = the platform packages
+    proxy-darwin-arm64/          # one package per target, each ships one binary
+    proxy-darwin-x64/            #   package.json sets os/cpu so npm installs
+    proxy-linux-x64/             #   only the matching one on a given host
+    proxy-linux-arm64/
+  build-binaries.sh              # populate the host's platform package
+  demo.sh                        # end-to-end local proof
+```
+
+How resolution works: the meta package lists each `@cipherstash/proxy-<os>-<arch>`
+as an **optionalDependency**. Each platform package declares `os`/`cpu`, so npm
+installs only the one matching the host. The shim `require.resolve()`s the binary
+from that package and `exec`s it, forwarding argv, stdio, exit code, and signals.
+
+## Try it (local, no registry)
+
+```bash
+bash npm/demo.sh
+```
+
+This builds the host binary, `npm install`s the meta package (which pulls in just
+the matching platform package), then runs `npx . proxy --version`,
+`... proxy --help`, and an unknown-subcommand case. The binaries are git-ignored
+build artifacts; `build-binaries.sh` regenerates them.
+
+> Locally we use `file:` optionalDependencies and `npx .` so it works offline.
+> In production these become published, versioned packages and the command is
+> literally `npx stash proxy` (or `npx @cipherstash/stash proxy`).
+
+## What production needs
+
+1. **Release CI matrix** builds `cipherstash-proxy` for every target:
+   - macOS arm64 / x64 — **build on a macOS runner** so the linker ad-hoc-signs
+     for free (enough to run on Apple Silicon; **no Developer ID / notarization
+     needed** for CLI-installed binaries — npm doesn't set the Gatekeeper
+     quarantine attribute).
+   - Linux x64 / arm64 (glibc; add musl for Alpine if wanted).
+   - Windows x64 later (`.exe`; CLI use sidesteps SmartScreen).
+2. Publish each platform package (`@cipherstash/proxy-<os>-<arch>`) plus the meta
+   `stash` package, all at the same version, pinned exactly.
+3. The meta package's `optionalDependencies` reference the published versions
+   instead of `file:` paths.
+
+## The code-signing win (the original motivation)
+
+- **Avoided:** macOS notarization + Developer ID certificates, and Windows
+  Authenticode — the expensive, account-bound parts. npm-installed CLI binaries
+  aren't quarantined, so Gatekeeper/SmartScreen don't block them.
+- **Still required (but free/automatic):** an *ad-hoc* signature on Apple
+  Silicon, which the macOS linker applies during the build. `build-binaries.sh`
+  re-asserts it with `codesign -s -`.
+
+## Caveats
+
+- Requires Node/npx on the host. Great for dev laptops & CI; **k8s should keep
+  using the Docker image / raw binary** — npm is an additional channel.
+- `npx` for a long-running server is slightly unconventional but works (runs in
+  the foreground; signals are forwarded).
+- This is a throwaway prototype: packages are `private: true` and versioned
+  `0.0.0-prototype` to prevent accidental publish.

--- a/npm/README.md
+++ b/npm/README.md
@@ -45,6 +45,12 @@ the matching platform package), then runs `npx . proxy --version`,
 `... proxy --help`, and an unknown-subcommand case. The binaries are git-ignored
 build artifacts; `build-binaries.sh` regenerates them.
 
+The launcher's argument interpretation has dependency-free unit coverage:
+
+```bash
+(cd npm/packages/stash && npm test)
+```
+
 > Locally we use `file:` optionalDependencies and `npx .` so it works offline.
 > In production these become published, versioned packages and the command is
 > literally `npx stash proxy` (or `npx @cipherstash/stash proxy`).

--- a/npm/build-binaries.sh
+++ b/npm/build-binaries.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Populate the per-platform packages with prebuilt proxy binaries.
+#
+# Prototype scope: builds/copies the binary for the CURRENT host into its
+# platform package. In production this is replaced by a CI matrix that builds
+# every target on the appropriate runner (macOS runners ad-hoc-sign for free;
+# Linux runners produce glibc/musl builds), then publishes each platform package.
+#
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${HERE}/.." && pwd)"
+
+case "$(uname -s)-$(uname -m)" in
+  Darwin-arm64) pkg=proxy-darwin-arm64 ;;
+  Darwin-x86_64) pkg=proxy-darwin-x64 ;;
+  Linux-aarch64) pkg=proxy-linux-arm64 ;;
+  Linux-x86_64) pkg=proxy-linux-x64 ;;
+  *) echo "Unsupported host: $(uname -s)-$(uname -m)" >&2; exit 1 ;;
+esac
+
+echo "Building cipherstash-proxy (release) for host -> ${pkg}"
+( cd "${REPO_ROOT}" && cargo build --release -p cipherstash-proxy )
+
+dest="${HERE}/packages/${pkg}/bin"
+mkdir -p "${dest}"
+cp -f "${REPO_ROOT}/target/release/cipherstash-proxy" "${dest}/cipherstash-proxy"
+chmod +x "${dest}/cipherstash-proxy"
+
+# macOS arm64 requires at least an ad-hoc signature to execute. Binaries linked
+# on macOS are ad-hoc-signed automatically, but re-assert it to be safe.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  codesign --force --sign - "${dest}/cipherstash-proxy" 2>/dev/null || true
+fi
+
+echo "Installed $(du -h "${dest}/cipherstash-proxy" | cut -f1) binary into ${pkg}/bin/"

--- a/npm/build-binaries.sh
+++ b/npm/build-binaries.sh
@@ -28,9 +28,10 @@ cp -f "${REPO_ROOT}/target/release/cipherstash-proxy" "${dest}/cipherstash-proxy
 chmod +x "${dest}/cipherstash-proxy"
 
 # macOS arm64 requires at least an ad-hoc signature to execute. Binaries linked
-# on macOS are ad-hoc-signed automatically, but re-assert it to be safe.
-if [[ "$(uname -s)" == "Darwin" ]]; then
-  codesign --force --sign - "${dest}/cipherstash-proxy" 2>/dev/null || true
+# on macOS are ad-hoc-signed automatically, but re-assert it and fail if the
+# staged artifact cannot be signed.
+if [[ "${pkg}" == "proxy-darwin-arm64" ]]; then
+  codesign --force --sign - "${dest}/cipherstash-proxy"
 fi
 
 echo "Installed $(du -h "${dest}/cipherstash-proxy" | cut -f1) binary into ${pkg}/bin/"

--- a/npm/demo.sh
+++ b/npm/demo.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# End-to-end local proof of `npx stash proxy`:
+#   1. build + install the host binary into its platform package
+#   2. npm install the meta package (resolves the matching platform package
+#      via os/cpu-filtered optionalDependencies)
+#   3. invoke through npx and through the `stash` bin, exercising arg passthrough
+#
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+META="${HERE}/packages/stash"
+
+echo "== 1. populate host platform binary =="
+bash "${HERE}/build-binaries.sh"
+
+echo "== 2. install meta package (resolves platform optionalDependency) =="
+( cd "${META}" && npm install --silent )
+echo "installed platform packages:"
+ls "${META}/node_modules/@cipherstash" 2>/dev/null || echo "  (none — check os/cpu match)"
+
+echo "== 3a. npx <local> proxy --version =="
+( cd "${META}" && npx . proxy --version )
+
+echo "== 3b. npx <local> proxy --help (subcommand passthrough) =="
+( cd "${META}" && npx . proxy --help | head -20 )
+
+echo "== 3c. exit codes are forwarded =="
+( cd "${META}" && npx . proxy --version ) >/dev/null 2>&1; echo "  proxy --version -> exit $? (expect 0)"
+( cd "${META}" && npx . frobnicate ) >/dev/null 2>&1; echo "  unknown subcommand -> exit $? (expect non-zero)"
+
+echo "== done =="

--- a/npm/demo.sh
+++ b/npm/demo.sh
@@ -26,6 +26,11 @@ echo "== 3b. npx <local> proxy --help (subcommand passthrough) =="
 
 echo "== 3c. exit codes are forwarded =="
 ( cd "${META}" && npx . proxy --version ) >/dev/null 2>&1; echo "  proxy --version -> exit $? (expect 0)"
-( cd "${META}" && npx . frobnicate ) >/dev/null 2>&1; echo "  unknown subcommand -> exit $? (expect non-zero)"
+if ( cd "${META}" && npx . frobnicate ) >/dev/null 2>&1; then
+  echo "  unknown subcommand unexpectedly succeeded" >&2
+  exit 1
+else
+  echo "  unknown subcommand -> non-zero exit (as expected)"
+fi
 
 echo "== done =="

--- a/npm/packages/proxy-darwin-arm64/package.json
+++ b/npm/packages/proxy-darwin-arm64/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@cipherstash/proxy-darwin-arm64",
+  "version": "0.0.0-prototype",
+  "private": true,
+  "description": "CipherStash Proxy native binary for macOS arm64",
+  "os": ["darwin"],
+  "cpu": ["arm64"],
+  "files": ["bin/cipherstash-proxy"]
+}

--- a/npm/packages/proxy-darwin-x64/package.json
+++ b/npm/packages/proxy-darwin-x64/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@cipherstash/proxy-darwin-x64",
+  "version": "0.0.0-prototype",
+  "private": true,
+  "description": "CipherStash Proxy native binary for macOS x86_64",
+  "os": ["darwin"],
+  "cpu": ["x64"],
+  "files": ["bin/cipherstash-proxy"]
+}

--- a/npm/packages/proxy-linux-arm64/package.json
+++ b/npm/packages/proxy-linux-arm64/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@cipherstash/proxy-linux-arm64",
+  "version": "0.0.0-prototype",
+  "private": true,
+  "description": "CipherStash Proxy native binary for Linux arm64 (glibc)",
+  "os": ["linux"],
+  "cpu": ["arm64"],
+  "files": ["bin/cipherstash-proxy"]
+}

--- a/npm/packages/proxy-linux-x64/package.json
+++ b/npm/packages/proxy-linux-x64/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@cipherstash/proxy-linux-x64",
+  "version": "0.0.0-prototype",
+  "private": true,
+  "description": "CipherStash Proxy native binary for Linux x86_64 (glibc)",
+  "os": ["linux"],
+  "cpu": ["x64"],
+  "files": ["bin/cipherstash-proxy"]
+}

--- a/npm/packages/stash/bin/stash.js
+++ b/npm/packages/stash/bin/stash.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+"use strict";
+
+// `stash` CLI launcher. For now it dispatches the `proxy` subcommand to the
+// prebuilt cipherstash-proxy binary shipped via the per-platform npm package.
+//
+//   npx stash proxy [proxy args...]
+//
+// The JS layer is intentionally thin: it resolves the right native binary and
+// execs it, forwarding argv, stdio, exit code and termination signals so it
+// behaves like running the binary directly.
+
+const { spawn } = require("child_process");
+const { resolveProxyBinary } = require("../lib/resolve");
+
+function usage() {
+  process.stderr.write(
+    "Usage: stash <command> [args...]\n\n" +
+      "Commands:\n" +
+      "  proxy [args...]   Run CipherStash Proxy (forwards all args)\n"
+  );
+}
+
+const [subcommand, ...rest] = process.argv.slice(2);
+
+if (!subcommand || subcommand === "help" || subcommand === "--help" || subcommand === "-h") {
+  usage();
+  process.exit(subcommand ? 0 : 2);
+}
+
+if (subcommand !== "proxy") {
+  process.stderr.write(`stash: unknown command '${subcommand}'\n\n`);
+  usage();
+  process.exit(2);
+}
+
+let binary;
+try {
+  binary = resolveProxyBinary();
+} catch (err) {
+  process.stderr.write(`stash: ${err.message}\n`);
+  process.exit(1);
+}
+
+const child = spawn(binary, rest, { stdio: "inherit" });
+
+// Forward termination signals so Ctrl-C / orchestrator shutdowns reach the
+// long-running proxy rather than just the Node wrapper.
+for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+  process.on(signal, () => {
+    if (!child.killed) child.kill(signal);
+  });
+}
+
+child.on("error", (err) => {
+  process.stderr.write(`stash: failed to launch proxy: ${err.message}\n`);
+  process.exit(1);
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    // Re-raise so our exit reflects the signal (conventional 128+n).
+    process.exit(128 + (require("os").constants.signals[signal] || 0));
+  }
+  process.exit(code ?? 0);
+});

--- a/npm/packages/stash/bin/stash.js
+++ b/npm/packages/stash/bin/stash.js
@@ -1,23 +1,27 @@
 #!/usr/bin/env node
 "use strict";
 
-// `stash` CLI launcher. For now it dispatches the `proxy` subcommand to the
-// prebuilt cipherstash-proxy binary shipped via the per-platform npm package.
+// `stash` CLI launcher. Dispatches the `proxy` subcommand to the prebuilt
+// cipherstash-proxy binary shipped via the per-platform npm package.
 //
-//   npx stash proxy [proxy args...]
+//   npx stash proxy [proxy args...]            # run the proxy in the foreground
+//   npx stash proxy --psql [proxy args...]     # run the proxy AND open psql through it
 //
 // The JS layer is intentionally thin: it resolves the right native binary and
-// execs it, forwarding argv, stdio, exit code and termination signals so it
-// behaves like running the binary directly.
+// execs it, forwarding argv, stdio, exit code and termination signals. With
+// --psql it additionally waits for the proxy to report its listen address, then
+// launches psql connected to the proxy, and shuts the proxy down on exit.
 
-const { spawn } = require("child_process");
+const { spawn, spawnSync } = require("child_process");
+const os = require("os");
 const { resolveProxyBinary } = require("../lib/resolve");
 
 function usage() {
   process.stderr.write(
     "Usage: stash <command> [args...]\n\n" +
       "Commands:\n" +
-      "  proxy [args...]   Run CipherStash Proxy (forwards all args)\n"
+      "  proxy [args...]          Run CipherStash Proxy (forwards all args)\n" +
+      "  proxy --psql [args...]   Run the proxy and open a psql session through it\n"
   );
 }
 
@@ -42,25 +46,158 @@ try {
   process.exit(1);
 }
 
-const child = spawn(binary, rest, { stdio: "inherit" });
+if (rest.includes("--psql")) {
+  runProxyThenPsql(binary, rest.filter((a) => a !== "--psql"));
+} else {
+  runProxy(binary, rest);
+}
 
-// Forward termination signals so Ctrl-C / orchestrator shutdowns reach the
-// long-running proxy rather than just the Node wrapper.
-for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
-  process.on(signal, () => {
-    if (!child.killed) child.kill(signal);
+// --- plain proxy: exec the binary and forward everything ---------------------
+
+function runProxy(binary, args) {
+  const child = spawn(binary, args, { stdio: "inherit" });
+  forwardSignals(child);
+  child.on("error", (err) => {
+    process.stderr.write(`stash: failed to launch proxy: ${err.message}\n`);
+    process.exit(1);
+  });
+  child.on("exit", (code, signal) => exitFrom(code, signal));
+}
+
+// --- proxy + psql ------------------------------------------------------------
+
+function runProxyThenPsql(binary, args) {
+  if (!commandExists("psql")) {
+    process.stderr.write(
+      "stash: --psql requires the `psql` client on your PATH, which was not found.\n" +
+        "       Install the PostgreSQL client, or run without --psql and connect manually.\n"
+    );
+    process.exit(1);
+  }
+
+  const conn = connectionInfo(args);
+
+  // stdin: ignore (the proxy is a server and never reads it; psql needs the tty).
+  // stdout: piped so we can detect the listen address.
+  // stderr: inherited so the proxy's few status lines are visible.
+  const proxy = spawn(binary, args, { stdio: ["ignore", "pipe", "inherit"] });
+
+  let psql = null;
+  let launchedPsql = false;
+  let buffered = "";
+
+  proxy.stdout.setEncoding("utf8");
+  proxy.stdout.on("data", (chunk) => {
+    // Echo proxy stdout to our stderr to keep our stdout clean for psql.
+    process.stderr.write(chunk);
+    if (launchedPsql) return;
+
+    buffered += chunk;
+    // The proxy prints e.g. "CipherStash Proxy listening on 0.0.0.0:64335".
+    const match = buffered.match(/listening on \S+?:(\d+)/i);
+    if (match) {
+      launchedPsql = true;
+      psql = launchPsql(parseInt(match[1], 10), conn, proxy);
+    }
+  });
+
+  forwardSignals(proxy);
+
+  proxy.on("error", (err) => {
+    process.stderr.write(`stash: failed to launch proxy: ${err.message}\n`);
+    process.exit(1);
+  });
+
+  proxy.on("exit", (code, signal) => {
+    if (!launchedPsql) {
+      // Proxy died before it was ready (e.g. database unreachable).
+      process.stderr.write("stash: proxy exited before it was ready; not starting psql.\n");
+      exitFrom(code, signal);
+    }
+    // If psql is running, its own exit handler drives our exit.
   });
 }
 
-child.on("error", (err) => {
-  process.stderr.write(`stash: failed to launch proxy: ${err.message}\n`);
-  process.exit(1);
-});
+function launchPsql(port, conn, proxy) {
+  process.stderr.write(`stash: connecting psql to the proxy on 127.0.0.1:${port}\n`);
 
-child.on("exit", (code, signal) => {
+  // Use PG* env so we don't have to URL-escape the connection string. The proxy
+  // presents as the target database, so psql uses the target's user/db; sslmode
+  // is disabled because the local proxy listener is plaintext by default.
+  const env = { ...process.env, PGHOST: "127.0.0.1", PGPORT: String(port), PGSSLMODE: "disable" };
+  if (conn.user) env.PGUSER = conn.user;
+  if (conn.dbname) env.PGDATABASE = conn.dbname;
+  if (conn.password != null) env.PGPASSWORD = conn.password;
+
+  const psql = spawn("psql", [], { stdio: "inherit", env });
+
+  psql.on("error", (err) => {
+    process.stderr.write(`stash: failed to launch psql: ${err.message}\n`);
+    stop(proxy);
+    process.exit(1);
+  });
+
+  psql.on("exit", (code, signal) => {
+    // psql is the foreground session; when it ends, tear the proxy down.
+    stop(proxy);
+    exitFrom(code, signal);
+  });
+
+  return psql;
+}
+
+// Extract user / password / dbname for the psql connection from --database-url
+// (preferred), individual --db-* flags, then CS_DATABASE__* env.
+function connectionInfo(args) {
+  const flag = (name) => {
+    const i = args.indexOf(name);
+    return i !== -1 ? args[i + 1] : undefined;
+  };
+
+  let fromUrl = {};
+  const url = flag("--database-url");
+  if (url) {
+    try {
+      const u = new URL(url);
+      fromUrl = {
+        user: decodeURIComponent(u.username) || undefined,
+        password: u.password ? decodeURIComponent(u.password) : undefined,
+        dbname: u.pathname.replace(/^\//, "") || undefined,
+      };
+    } catch {
+      process.stderr.write(`stash: could not parse --database-url for psql\n`);
+    }
+  }
+
+  return {
+    user: flag("--db-user") ?? fromUrl.user ?? process.env.CS_DATABASE__USERNAME,
+    password: flag("--db-password") ?? fromUrl.password ?? process.env.CS_DATABASE__PASSWORD,
+    dbname: fromUrl.dbname ?? process.env.CS_DATABASE__NAME,
+  };
+}
+
+// --- helpers -----------------------------------------------------------------
+
+function commandExists(cmd) {
+  const probe = spawnSync(cmd, ["--version"], { stdio: "ignore" });
+  return !probe.error;
+}
+
+function stop(child) {
+  if (child && !child.killed) child.kill("SIGTERM");
+}
+
+function forwardSignals(child) {
+  for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+    process.on(signal, () => {
+      if (!child.killed) child.kill(signal);
+    });
+  }
+}
+
+function exitFrom(code, signal) {
   if (signal) {
-    // Re-raise so our exit reflects the signal (conventional 128+n).
-    process.exit(128 + (require("os").constants.signals[signal] || 0));
+    process.exit(128 + (os.constants.signals[signal] || 0));
   }
   process.exit(code ?? 0);
-});
+}

--- a/npm/packages/stash/bin/stash.js
+++ b/npm/packages/stash/bin/stash.js
@@ -211,9 +211,10 @@ function connectionInfo(args) {
 function psqlPromptArgs() {
   const custom = process.env.STASH_PSQL_PROMPT;
   if (custom === "") return [];
-  const ESC = "\x1b";
-  // %[ %] wrap non-printing bytes so psql counts the prompt width correctly.
-  const prompt = custom || `%[${ESC}[36m%]stash%[${ESC}[0m%]:%/%R%# `;
+  // psql renders ESC from its own octal escape `%033` (a literal ESC byte gets
+  // mangled in variable parsing); `%[ %]` wrap the non-printing bytes so psql
+  // counts the prompt width correctly. 36m = cyan, 0m = reset.
+  const prompt = custom || "%[%033[36m%]stash%[%033[0m%]:%/%R%# ";
   return ["--set", `PROMPT1=${prompt}`, "--set", `PROMPT2=${prompt}`];
 }
 

--- a/npm/packages/stash/bin/stash.js
+++ b/npm/packages/stash/bin/stash.js
@@ -134,7 +134,7 @@ function launchPsql(port, conn, proxy) {
   if (conn.dbname) env.PGDATABASE = conn.dbname;
   if (conn.password != null) env.PGPASSWORD = conn.password;
 
-  const psql = spawn("psql", [], { stdio: "inherit", env });
+  const psql = spawn("psql", psqlPromptArgs(), { stdio: "inherit", env });
 
   psql.on("error", (err) => {
     process.stderr.write(`stash: failed to launch psql: ${err.message}\n`);
@@ -204,6 +204,18 @@ function connectionInfo(args) {
 }
 
 // --- helpers -----------------------------------------------------------------
+
+// Branded psql prompt so a via-proxy session is visually distinct (e.g.
+// "stash:dbname=>" with "stash" in cyan). Override the whole prompt with
+// STASH_PSQL_PROMPT, or set it empty to use psql's default / your ~/.psqlrc.
+function psqlPromptArgs() {
+  const custom = process.env.STASH_PSQL_PROMPT;
+  if (custom === "") return [];
+  const ESC = "\x1b";
+  // %[ %] wrap non-printing bytes so psql counts the prompt width correctly.
+  const prompt = custom || `%[${ESC}[36m%]stash%[${ESC}[0m%]:%/%R%# `;
+  return ["--set", `PROMPT1=${prompt}`, "--set", `PROMPT2=${prompt}`];
+}
 
 function commandExists(cmd) {
   const probe = spawnSync(cmd, ["--version"], { stdio: "ignore" });

--- a/npm/packages/stash/bin/stash.js
+++ b/npm/packages/stash/bin/stash.js
@@ -67,15 +67,15 @@ function runProxy(binary, args) {
 // --- proxy + psql ------------------------------------------------------------
 
 function runProxyThenPsql(binary, args) {
-  if (!commandExists("psql")) {
-    process.stderr.write(
-      "stash: --psql requires the `psql` client on your PATH, which was not found.\n" +
-        "       Install the PostgreSQL client, or run without --psql and connect manually.\n"
-    );
-    process.exit(1);
-  }
-
   const conn = connectionInfo(args);
+
+  // Prefer the system psql; fall back to the built-in JS SQL shell when it's
+  // not installed (or when forced via STASH_USE_BUILTIN_SQL=1).
+  const forceBuiltin = process.env.STASH_USE_BUILTIN_SQL === "1";
+  const usePsql = !forceBuiltin && commandExists("psql");
+  if (!usePsql && !forceBuiltin) {
+    process.stderr.write("stash: psql not found on PATH; using the built-in SQL shell instead.\n");
+  }
 
   // stdin: ignore (the proxy is a server and never reads it; psql needs the tty).
   // stdout: piped so we can detect the listen address.
@@ -97,7 +97,12 @@ function runProxyThenPsql(binary, args) {
     const match = buffered.match(/listening on \S+?:(\d+)/i);
     if (match) {
       launchedPsql = true;
-      psql = launchPsql(parseInt(match[1], 10), conn, proxy);
+      const port = parseInt(match[1], 10);
+      if (usePsql) {
+        psql = launchPsql(port, conn, proxy);
+      } else {
+        launchRepl(port, conn, proxy);
+      }
     }
   });
 
@@ -144,6 +149,28 @@ function launchPsql(port, conn, proxy) {
   });
 
   return psql;
+}
+
+// Built-in JS SQL shell (fallback when psql isn't installed).
+function launchRepl(port, conn, proxy) {
+  process.stderr.write(`stash: opening built-in SQL shell to the proxy on 127.0.0.1:${port}\n`);
+  const { runRepl } = require("../lib/repl");
+  runRepl({
+    host: "127.0.0.1",
+    port,
+    user: conn.user,
+    password: conn.password,
+    database: conn.dbname,
+  })
+    .then(() => {
+      stop(proxy);
+      process.exit(0);
+    })
+    .catch((err) => {
+      process.stderr.write(`stash: SQL shell error: ${err.message}\n`);
+      stop(proxy);
+      process.exit(1);
+    });
 }
 
 // Extract user / password / dbname for the psql connection from --database-url

--- a/npm/packages/stash/bin/stash.js
+++ b/npm/packages/stash/bin/stash.js
@@ -13,7 +13,7 @@
 // launches psql connected to the proxy, and shuts the proxy down on exit.
 
 const { spawn, spawnSync } = require("child_process");
-const os = require("os");
+const { connectionInfo } = require("../lib/connection");
 const { resolveProxyBinary } = require("../lib/resolve");
 
 function usage() {
@@ -173,36 +173,6 @@ function launchRepl(port, conn, proxy) {
     });
 }
 
-// Extract user / password / dbname for the psql connection from --database-url
-// (preferred), individual --db-* flags, then CS_DATABASE__* env.
-function connectionInfo(args) {
-  const flag = (name) => {
-    const i = args.indexOf(name);
-    return i !== -1 ? args[i + 1] : undefined;
-  };
-
-  let fromUrl = {};
-  const url = flag("--database-url");
-  if (url) {
-    try {
-      const u = new URL(url);
-      fromUrl = {
-        user: decodeURIComponent(u.username) || undefined,
-        password: u.password ? decodeURIComponent(u.password) : undefined,
-        dbname: u.pathname.replace(/^\//, "") || undefined,
-      };
-    } catch {
-      process.stderr.write(`stash: could not parse --database-url for psql\n`);
-    }
-  }
-
-  return {
-    user: flag("--db-user") ?? fromUrl.user ?? process.env.CS_DATABASE__USERNAME,
-    password: flag("--db-password") ?? fromUrl.password ?? process.env.CS_DATABASE__PASSWORD,
-    dbname: fromUrl.dbname ?? process.env.CS_DATABASE__NAME,
-  };
-}
-
 // --- helpers -----------------------------------------------------------------
 
 // Branded psql prompt so a via-proxy session is visually distinct (e.g.
@@ -228,7 +198,7 @@ function stop(child) {
 }
 
 function forwardSignals(child) {
-  for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+  for (const signal of ["SIGINT", "SIGTERM", "SIGHUP", "SIGQUIT"]) {
     process.on(signal, () => {
       if (!child.killed) child.kill(signal);
     });
@@ -237,7 +207,12 @@ function forwardSignals(child) {
 
 function exitFrom(code, signal) {
   if (signal) {
-    process.exit(128 + (os.constants.signals[signal] || 0));
+    // Exit by the same signal so parent processes observe signal termination,
+    // not merely an equivalent numeric status. Remove our forwarding handler
+    // first to avoid catching the signal again ourselves.
+    process.removeAllListeners(signal);
+    process.kill(process.pid, signal);
+    return;
   }
   process.exit(code ?? 0);
 }

--- a/npm/packages/stash/lib/connection.js
+++ b/npm/packages/stash/lib/connection.js
@@ -1,0 +1,76 @@
+"use strict";
+
+const VALUE_OPTIONS = new Set([
+  "--database-url",
+  "--db-host",
+  "-H",
+  "--db-port",
+  "-P",
+  "--db-user",
+  "-u",
+  "--db-password",
+  "-W",
+  "--config-file-path",
+  "-p",
+  "--log-level",
+  "-l",
+  "--log-format",
+  "-f",
+]);
+
+function optionValue(args, long, short) {
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === long || arg === short) return args[i + 1];
+    if (arg.startsWith(`${long}=`)) return arg.slice(long.length + 1);
+    if (short && arg.startsWith(short) && arg.length > short.length) {
+      return arg.slice(short.length);
+    }
+  }
+  return undefined;
+}
+
+function positionalDatabase(args) {
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--") return args[i + 1];
+    if (VALUE_OPTIONS.has(arg)) {
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("-")) continue;
+    return arg;
+  }
+  return undefined;
+}
+
+// Resolve the SQL client's connection identity using the same precedence as
+// the proxy: individual CLI values, then --database-url, then environment.
+function connectionInfo(args, env = process.env) {
+  let fromUrl = {};
+  const url = optionValue(args, "--database-url");
+  if (url) {
+    try {
+      const parsed = new URL(url);
+      fromUrl = {
+        user: decodeURIComponent(parsed.username) || undefined,
+        password: parsed.password ? decodeURIComponent(parsed.password) : undefined,
+        dbname: decodeURIComponent(parsed.pathname.replace(/^\//, "")) || undefined,
+      };
+    } catch {
+      // The native proxy will report the authoritative URL parse error. The
+      // launcher only needs a best-effort view for the SQL client.
+    }
+  }
+
+  return {
+    user: optionValue(args, "--db-user", "-u") ?? fromUrl.user ?? env.CS_DATABASE__USERNAME,
+    password:
+      optionValue(args, "--db-password", "-W") ??
+      fromUrl.password ??
+      env.CS_DATABASE__PASSWORD,
+    dbname: positionalDatabase(args) ?? fromUrl.dbname ?? env.CS_DATABASE__NAME,
+  };
+}
+
+module.exports = { connectionInfo };

--- a/npm/packages/stash/lib/repl.js
+++ b/npm/packages/stash/lib/repl.js
@@ -1,0 +1,153 @@
+"use strict";
+
+// A small built-in SQL shell used when `psql` isn't available on PATH. It is a
+// convenience fallback, NOT a psql replacement: it runs SQL and prints results,
+// plus a handful of \-commands. Pure JS (the `pg` driver) so it needs no native
+// binaries.
+
+const readline = require("readline");
+
+// Minimal \-command help.
+const HELP = `Commands:
+  \\q             quit
+  \\?             this help
+  \\l             list databases
+  \\dt            list tables
+  \\d [name]      describe a table (or list tables)
+  <sql>;         run SQL (statements end with ;)
+`;
+
+// Map a \-command to the SQL it runs (or a control action).
+function metaCommand(line, dbname) {
+  const [cmd, arg] = line.trim().split(/\s+/, 2);
+  switch (cmd) {
+    case "\\q":
+      return { quit: true };
+    case "\\?":
+      return { help: true };
+    case "\\l":
+      return {
+        sql: "SELECT datname AS name FROM pg_database WHERE datistemplate = false ORDER BY 1;",
+      };
+    case "\\dt":
+      return {
+        sql: `SELECT schemaname AS schema, tablename AS name FROM pg_catalog.pg_tables
+              WHERE schemaname NOT IN ('pg_catalog','information_schema') ORDER BY 1,2;`,
+      };
+    case "\\d":
+      if (!arg) {
+        return metaCommand("\\dt", dbname);
+      }
+      return {
+        sql: `SELECT column_name AS column, data_type AS type, is_nullable AS nullable
+              FROM information_schema.columns WHERE table_name = $1 ORDER BY ordinal_position;`,
+        params: [arg],
+      };
+    default:
+      return { error: `unknown command: ${cmd} (try \\?)` };
+  }
+}
+
+function cell(value) {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+// Render rows (array of objects) as an aligned table.
+function formatTable(fields, rows) {
+  const cols = fields.map((f) => f.name);
+  const widths = cols.map((c) => c.length);
+  const text = rows.map((row) =>
+    cols.map((c, i) => {
+      const s = cell(row[c]);
+      if (s.length > widths[i]) widths[i] = s.length;
+      return s;
+    })
+  );
+  const pad = (s, w) => s + " ".repeat(w - s.length);
+  const lines = [];
+  lines.push(cols.map((c, i) => pad(c, widths[i])).join(" | "));
+  lines.push(widths.map((w) => "-".repeat(w)).join("-+-"));
+  for (const r of text) lines.push(r.map((s, i) => pad(s, widths[i])).join(" | "));
+  lines.push(`(${rows.length} row${rows.length === 1 ? "" : "s"})`);
+  return lines.join("\n");
+}
+
+async function runQuery(client, sql, params) {
+  try {
+    const res = await client.query(sql, params);
+    const results = Array.isArray(res) ? res : [res];
+    for (const r of results) {
+      if (r.fields && r.fields.length > 0) {
+        process.stdout.write(formatTable(r.fields, r.rows) + "\n");
+      } else {
+        process.stdout.write(`${r.command}${r.rowCount != null ? " " + r.rowCount : ""}\n`);
+      }
+    }
+  } catch (err) {
+    process.stderr.write(`ERROR: ${err.message}\n`);
+  }
+}
+
+// Connect to the (proxy) endpoint and run an interactive shell until EOF / \q.
+async function runRepl({ host, port, user, password, database }) {
+  // Lazy require so the `pg` dependency is only loaded on this path.
+  const { Client } = require("pg");
+  const client = new Client({ host, port, user, password, database, ssl: false });
+  await client.connect();
+
+  const label = database || "stash";
+  process.stdout.write(
+    `Built-in SQL shell (psql not found). Connected to ${label} via the proxy. Type \\? for help, \\q to quit.\n`
+  );
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    terminal: Boolean(process.stdin.isTTY),
+  });
+
+  let buffer = "";
+  const promptText = () => (buffer ? "... " : `${label}=> `);
+
+  // Ctrl-C abandons the statement in progress (like psql); Ctrl-D (EOF) ends
+  // the async iterator and exits.
+  rl.on("SIGINT", () => {
+    buffer = "";
+    process.stdout.write("\n" + promptText());
+  });
+
+  process.stdout.write(promptText());
+
+  try {
+    // Async iteration processes one line at a time and awaits each query before
+    // pulling the next, so statements (and the final one) complete in order.
+    for await (const line of rl) {
+      const trimmed = line.trim();
+
+      if (buffer === "" && trimmed.startsWith("\\")) {
+        const action = metaCommand(trimmed, database);
+        if (action.quit) break;
+        if (action.help) process.stdout.write(HELP);
+        else if (action.error) process.stderr.write(action.error + "\n");
+        else if (action.sql) await runQuery(client, action.sql, action.params);
+      } else {
+        buffer += (buffer ? "\n" : "") + line;
+        if (buffer.trimEnd().endsWith(";")) {
+          const sql = buffer;
+          buffer = "";
+          await runQuery(client, sql);
+        }
+      }
+
+      process.stdout.write(promptText());
+    }
+  } finally {
+    rl.close();
+    // Don't block exit waiting for the proxy to close the socket; the caller
+    // tears the proxy down and exits immediately after we return.
+    client.end().catch(() => {});
+  }
+}
+
+module.exports = { runRepl };

--- a/npm/packages/stash/lib/repl.js
+++ b/npm/packages/stash/lib/repl.js
@@ -108,7 +108,12 @@ async function runRepl({ host, port, user, password, database }) {
   });
 
   let buffer = "";
-  const promptText = () => (buffer ? "... " : `${label}=> `);
+  // Branded prompt (e.g. "stash:dbname=>"), with the prefix coloured on a TTY
+  // unless NO_COLOR is set, matching the psql prompt the launcher sets.
+  const useColor = Boolean(process.stdout.isTTY) && !process.env.NO_COLOR;
+  const cyan = useColor ? "\x1b[36m" : "";
+  const reset = useColor ? "\x1b[0m" : "";
+  const promptText = () => `${cyan}stash${reset}:${label}${buffer ? "-> " : "=> "}`;
 
   // Ctrl-C abandons the statement in progress (like psql); Ctrl-D (EOF) ends
   // the async iterator and exits.

--- a/npm/packages/stash/lib/resolve.js
+++ b/npm/packages/stash/lib/resolve.js
@@ -1,0 +1,49 @@
+"use strict";
+
+// Maps the current platform to the per-platform npm package that ships the
+// matching prebuilt `cipherstash-proxy` binary. This mirrors the esbuild /
+// Biome / SWC distribution pattern: the meta package declares each of these as
+// an optionalDependency with `os`/`cpu` constraints, so npm installs only the
+// one matching the host.
+const PLATFORM_PACKAGES = {
+  "darwin-arm64": "@cipherstash/proxy-darwin-arm64",
+  "darwin-x64": "@cipherstash/proxy-darwin-x64",
+  "linux-x64": "@cipherstash/proxy-linux-x64",
+  "linux-arm64": "@cipherstash/proxy-linux-arm64",
+  // win32-x64 would go here once we ship a Windows build.
+};
+
+function platformKey() {
+  return `${process.platform}-${process.arch}`;
+}
+
+function binaryName() {
+  return process.platform === "win32"
+    ? "cipherstash-proxy.exe"
+    : "cipherstash-proxy";
+}
+
+// Resolve the absolute path to the proxy binary for this platform, or throw a
+// clear, actionable error if the platform package isn't installed.
+function resolveProxyBinary() {
+  const key = platformKey();
+  const pkg = PLATFORM_PACKAGES[key];
+  if (!pkg) {
+    throw new Error(
+      `cipherstash-proxy is not available for this platform (${key}). ` +
+        `Supported: ${Object.keys(PLATFORM_PACKAGES).join(", ")}.`
+    );
+  }
+  try {
+    // require.resolve finds the binary inside the installed platform package.
+    return require.resolve(`${pkg}/bin/${binaryName()}`);
+  } catch {
+    throw new Error(
+      `The platform package '${pkg}' is not installed.\n` +
+        `npm should install it automatically as an optionalDependency for ${key}.\n` +
+        `If you used '--no-optional' or '--omit=optional', reinstall without it.`
+    );
+  }
+}
+
+module.exports = { resolveProxyBinary, platformKey, PLATFORM_PACKAGES };

--- a/npm/packages/stash/package.json
+++ b/npm/packages/stash/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "stash",
+  "version": "0.0.0-prototype",
+  "private": true,
+  "description": "Prototype: CipherStash CLI launcher — `npx stash proxy`",
+  "bin": {
+    "stash": "bin/stash.js"
+  },
+  "files": [
+    "bin/",
+    "lib/"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "optionalDependencies": {
+    "@cipherstash/proxy-darwin-arm64": "file:../proxy-darwin-arm64",
+    "@cipherstash/proxy-darwin-x64": "file:../proxy-darwin-x64",
+    "@cipherstash/proxy-linux-x64": "file:../proxy-linux-x64",
+    "@cipherstash/proxy-linux-arm64": "file:../proxy-linux-arm64"
+  }
+}

--- a/npm/packages/stash/package.json
+++ b/npm/packages/stash/package.json
@@ -13,6 +13,9 @@
   "engines": {
     "node": ">=18"
   },
+  "dependencies": {
+    "pg": "^8.13.0"
+  },
   "optionalDependencies": {
     "@cipherstash/proxy-darwin-arm64": "file:../proxy-darwin-arm64",
     "@cipherstash/proxy-darwin-x64": "file:../proxy-darwin-x64",

--- a/npm/packages/stash/package.json
+++ b/npm/packages/stash/package.json
@@ -13,6 +13,9 @@
   "engines": {
     "node": ">=18"
   },
+  "scripts": {
+    "test": "node --test"
+  },
   "dependencies": {
     "pg": "^8.13.0"
   },

--- a/npm/packages/stash/test/connection.test.js
+++ b/npm/packages/stash/test/connection.test.js
@@ -1,0 +1,36 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { connectionInfo } = require("../lib/connection");
+
+test("reads connection details from a database URL", () => {
+  assert.deepEqual(
+    connectionInfo(["--database-url", "postgres://alice:s3cret@db.example/orders%20archive"], {}),
+    { user: "alice", password: "s3cret", dbname: "orders archive" }
+  );
+});
+
+test("individual flags override the URL in all clap-supported forms", () => {
+  assert.deepEqual(
+    connectionInfo(
+      [
+        "--database-url=postgres://url-user:url-pass@db.example/url-db",
+        "-ucli-user",
+        "-W",
+        "cli-pass",
+        "cli-db",
+      ],
+      {}
+    ),
+    { user: "cli-user", password: "cli-pass", dbname: "cli-db" }
+  );
+});
+
+test("falls back to the proxy environment", () => {
+  assert.deepEqual(connectionInfo([], {
+    CS_DATABASE__USERNAME: "env-user",
+    CS_DATABASE__PASSWORD: "env-pass",
+    CS_DATABASE__NAME: "env-db",
+  }), { user: "env-user", password: "env-pass", dbname: "env-db" });
+});

--- a/npm/release-workflow.example.yml
+++ b/npm/release-workflow.example.yml
@@ -1,0 +1,63 @@
+# EXAMPLE — not wired up. Sketch of the release machinery to publish
+# `npx stash proxy` to npm. Named `.example.yml` so it never triggers; copy to
+# .github/workflows/ and fill in secrets/versions to use it.
+#
+# Shape: build cipherstash-proxy for every target on the right runner, assemble
+# one npm package per platform, then publish all platform packages + the meta
+# `stash` package at the same version.
+
+name: npm-release (example)
+
+on:
+  workflow_dispatch:
+  # release:
+  #   types: [published]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          # macOS runners ad-hoc-sign during linking — enough for Apple Silicon,
+          # no Developer ID / notarization needed for CLI-installed binaries.
+          - { os: macos-14,     target: aarch64-apple-darwin,      pkg: proxy-darwin-arm64 }
+          - { os: macos-13,     target: x86_64-apple-darwin,       pkg: proxy-darwin-x64 }
+          - { os: ubuntu-24.04, target: x86_64-unknown-linux-gnu,  pkg: proxy-linux-x64 }
+          - { os: ubuntu-24.04, target: aarch64-unknown-linux-gnu, pkg: proxy-linux-arm64 }
+          # - { os: windows-2022, target: x86_64-pc-windows-msvc,  pkg: proxy-win32-x64 }
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup target add ${{ matrix.target }}
+      # Linux cross-targets need a cross-linker (e.g. cross, or the gcc the repo
+      # already uses for aarch64-unknown-linux-gnu). macOS targets build natively.
+      - run: cargo build --release --locked --target ${{ matrix.target }} -p cipherstash-proxy
+      - name: Assemble platform package
+        run: |
+          dest="npm/packages/${{ matrix.pkg }}/bin"
+          mkdir -p "$dest"
+          cp "target/${{ matrix.target }}/release/cipherstash-proxy" "$dest/"
+          # Re-assert ad-hoc signature on macOS (linker already does this).
+          if [[ "${{ runner.os }}" == "macOS" ]]; then codesign --force --sign - "$dest/cipherstash-proxy"; fi
+      - uses: actions/upload-artifact@v4
+        with: { name: "${{ matrix.pkg }}", path: "npm/packages/${{ matrix.pkg }}" }
+
+  publish:
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with: { path: npm/packages }
+      - uses: actions/setup-node@v4
+        with: { node-version: 22, registry-url: "https://registry.npmjs.org" }
+      - name: Set matching versions
+        run: |
+          # Stamp every platform package + the meta package to $VERSION, and pin
+          # the meta package's optionalDependencies to exact $VERSION (not file:).
+          echo "TODO: bump versions + rewrite optionalDependencies to ^$VERSION"
+      - name: Publish platform packages then meta
+        env: { NODE_AUTH_TOKEN: "${{ secrets.NPM_TOKEN }}" }
+        run: |
+          for p in npm/packages/proxy-*; do (cd "$p" && npm publish --access public); done
+          (cd npm/packages/stash && npm publish --access public)

--- a/npm/release-workflow.example.yml
+++ b/npm/release-workflow.example.yml
@@ -29,9 +29,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup target add ${{ matrix.target }}
-      # Linux cross-targets need a cross-linker (e.g. cross, or the gcc the repo
-      # already uses for aarch64-unknown-linux-gnu). macOS targets build natively.
-      - run: cargo build --release --locked --target ${{ matrix.target }} -p cipherstash-proxy
+      - name: Install Linux arm64 cross toolchain
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        uses: taiki-e/install-action@v2
+        with: { tool: cross }
+      - name: Build native target
+        if: matrix.target != 'aarch64-unknown-linux-gnu'
+        run: cargo build --release --locked --target ${{ matrix.target }} -p cipherstash-proxy
+      - name: Cross-build Linux arm64
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: cross build --release --locked --target ${{ matrix.target }} -p cipherstash-proxy
       - name: Assemble platform package
         run: |
           dest="npm/packages/${{ matrix.pkg }}/bin"


### PR DESCRIPTION
> **Spike / draft implementing CIP-3824.** Stacked on #397 (`dan/cli-connection-flags`); the review diff is limited to `npm/`.

Prototypes distributing CipherStash Proxy through npm so it can be launched with:

```bash
npx stash proxy --database-url postgres://user:pass@host:5432/db
npx stash proxy --psql --database-url postgres://user:pass@host:5432/db
```

## Distribution design

- A thin pure-JavaScript `stash` meta package resolves and launches the correct prebuilt Proxy binary while forwarding argv, stdio, exit status, and common termination signals.
- Four `os`/`cpu`-filtered optional platform packages cover macOS and Linux on arm64 and x64.
- The macOS arm64 staging path applies an ad-hoc signature and fails if signing does not succeed.
- `npm/build-binaries.sh` builds and stages the current host binary.
- `npm/release-workflow.example.yml` sketches a four-target build/publish matrix, including a working Linux arm64 `cross` setup.

## `--psql` workflow

- Starts Proxy and waits for its reported listen address, including an OS-assigned fallback port.
- Launches system `psql`, or a pure-JavaScript SQL shell when `psql` is unavailable.
- Uses a cyan `stash:<db>=>` prompt on interactive terminals.
- Propagates connection URL, individual long/short flags, `--flag=value` forms, positional database name, and environment fallbacks using the same CLI-over-URL-over-environment precedence as Proxy.

## Review fixes

- Fixed the demo's expected-failure assertion so `set -e` no longer terminates it prematurely.
- Extracted connection interpretation from the launcher and added dependency-free unit tests.
- Preserved child signal termination semantics and added `SIGQUIT` forwarding.
- Rebased onto the reviewed #397 head and added required DCO sign-offs to all seven commits.

## Validation

- `node --check` for all launcher modules.
- `npm test`: 3/3 connection-propagation tests pass.
- `bash -n npm/build-binaries.sh npm/demo.sh`.
- `npm pack --dry-run` for the meta package and all four platform packages.
- Full macOS arm64 proof: release build, ad-hoc signing, local npm install, correct platform-package resolution, `npx` version/help passthrough, and exit-code validation.

## Status / decision

This remains a non-publishable prototype: packages are private and versioned `0.0.0-prototype`; no release workflow is active and no platform package has been published.

- [ ] Decide whether to productionize this distribution channel.
- [ ] If yes, wire the example workflow into release CI and define npm access plus synchronized package versioning.
