### PR TITLE
chore: prepare v2.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,7 +261,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Integration with CipherStash ZeroKMS.
 - Encrypt Query Language (EQL) for indexing and searching encrypted data.
 
-[Unreleased]: https://github.com/cipherstash/proxy/compare/v2.2.0-alpha.1...HEAD
+[Unreleased]: https://github.com/cipherstash/proxy/compare/v2.2.2...HEAD
+[2.2.2]: https://github.com/cipherstash/proxy/compare/v2.2.1...v2.2.2
+[2.2.1]: https://github.com/cipherstash/proxy/compare/v2.2.0-alpha.1...v2.2.1
 [2.2.0-alpha.1]: https://github.com/cipherstash/proxy/compare/v2.1.22...v2.2.0-alpha.1
 [2.1.22]: https://github.com/cipherstash/proxy/releases/tag/v2.1.22
 [2.1.21]: https://github.com/cipherstash/proxy/releases/tag/v2.1.21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.2.2] - 2026-06-01
+
+### Fixed
+
+- **Passthrough mode memory leak**: Fixed a per-statement memory leak that occurred in passthrough mode (empty encrypt config), where per-statement queues were not drained. Long-running connections could grow unbounded and eventually OOM. ([#400](https://github.com/cipherstash/proxy/issues/400))
+
+## [2.2.1] - 2026-05-14
+
 ### Added
 
 - **OPE (Order-Preserving Encryption) index**: New `ope` index type alongside the existing `ore` for range and `ORDER BY` queries on encrypted columns. Drop-in alternative to `ore` — pick one per column. See the [encrypted indexes documentation](docs/how-to/index.md) for configuration.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-proxy"
-version = "2.2.0-alpha.1"
+version = "2.2.2"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "eql-mapper-macros"
-version = "2.2.0-alpha.1"
+version = "2.2.2"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -4212,7 +4212,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "showcase"
-version = "2.2.0-alpha.1"
+version = "2.2.2"
 dependencies = [
  "rand 0.9.2",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["packages/*"]
 
 [workspace.package]
-version = "2.2.0-alpha.1"
+version = "2.2.2"
 edition = "2021"
 
 [profile.dev]

--- a/packages/cipherstash-proxy/Cargo.toml
+++ b/packages/cipherstash-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cipherstash-proxy"
-version = "2.2.0-alpha.1"
+version.workspace = true
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary

Prepares the **v2.2.2** patch release, which ships the passthrough memory-leak fix (#395, closes #400).

While doing this I found the CHANGELOG and crate version had drifted from the actual releases, so this PR also reconciles them.

## Changes

- **CHANGELOG**: add `[2.2.2]` section for the passthrough memory-leak fix.
- **CHANGELOG**: backfill the missing `[2.2.1]` section. The OPE index entry was still sitting under `[Unreleased]` even though it shipped in v2.2.1 (v2.2.1 points at the OPE merge #390).
- **Version bump**: `[workspace.package] version` `2.2.0-alpha.1` → `2.2.2`. The bump was skipped when v2.2.1 was cut, so the released binary's `CARGO_PKG_VERSION` (`src/lib.rs` `VERSION`) was stale.
- **Drift prevention**: `cipherstash-proxy` now uses `version.workspace = true` instead of a hardcoded version, so there's a single source of truth going forward.

## Release steps (after merge)

1. Merge to `main`.
2. `mise run release v2.2.2` — tags, pushes, creates the GitHub release, and triggers the Docker build/publish workflow.
3. Verify: `docker buildx imagetools inspect cipherstash/proxy:2.2.2`.

## Note

Did not touch `eql-mapper` (independently versioned at `1.0.0`) or `cipherstash-proxy-integration` (`0.1.0`). `eql-mapper-macros` and `showcase` already inherit the workspace version and so move to `2.2.2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a memory leak in passthrough mode where per-statement queues were not properly drained, preventing unbounded memory growth and potential out-of-memory errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->