### PR TITLE
fix: access-key token expiry parsed as relative — tokens never refresh (CIP-3233); release 2.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.2.4] - 2026-06-18
+
 ### Fixed
 
 - **ZeroKMS authentication failures ~15 minutes after startup (access keys)**: Fixed the root cause of access tokens never being renewed when authenticating with an access key. The token's lifetime was misread, so renewal never triggered and every encrypt/decrypt operation began failing (`ZeroKMS error: Request not authorized`, "Could not decrypt data") roughly 15 minutes — the token lifetime — after connecting, recovering only on restart. Tokens now renew correctly ahead of expiry. This resolves the remaining cases not addressed by the 2.2.3 fix.
@@ -271,7 +273,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Integration with CipherStash ZeroKMS.
 - Encrypt Query Language (EQL) for indexing and searching encrypted data.
 
-[Unreleased]: https://github.com/cipherstash/proxy/compare/v2.2.3...HEAD
+[Unreleased]: https://github.com/cipherstash/proxy/compare/v2.2.4...HEAD
+[2.2.4]: https://github.com/cipherstash/proxy/compare/v2.2.3...v2.2.4
 [2.2.3]: https://github.com/cipherstash/proxy/compare/v2.2.2...v2.2.3
 [2.2.2]: https://github.com/cipherstash/proxy/compare/v2.2.1...v2.2.2
 [2.2.1]: https://github.com/cipherstash/proxy/compare/v2.2.0-alpha.1...v2.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **ZeroKMS authentication failures ~15 minutes after startup (access keys)**: Fixed the root cause of access tokens never being renewed when authenticating with an access key. The token's lifetime was misread, so renewal never triggered and every encrypt/decrypt operation began failing (`ZeroKMS error: Request not authorized`, "Could not decrypt data") roughly 15 minutes — the token lifetime — after connecting, recovering only on restart. Tokens now renew correctly ahead of expiry. This resolves the remaining cases not addressed by the 2.2.3 fix.
+
 ## [2.2.3] - 2026-06-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-proxy"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "eql-mapper-macros"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -4212,7 +4212,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "showcase"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "rand 0.9.2",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["packages/*"]
 exclude = ["vendor/stack-auth"]
 
 [workspace.package]
-version = "2.2.3"
+version = "2.2.4"
 edition = "2021"
 
 [profile.dev]

--- a/vendor/stack-auth/src/access_key_refresher.rs
+++ b/vendor/stack-auth/src/access_key_refresher.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use url::Url;
 
@@ -67,15 +66,17 @@ impl Refresher for AccessKeyRefresher {
         }
 
         let auth_resp: AuthoriseResponse = resp.json().await?;
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
 
         Ok(Token {
             access_token: auth_resp.access_token,
             token_type: "Bearer".to_string(),
-            expires_at: now + auth_resp.expiry,
+            // CTS `/api/authorise` returns `expiry` as an ABSOLUTE Unix epoch (it is
+            // the JWT `exp` claim), NOT a relative duration. The previous `now + expiry`
+            // pushed the local expiry decades into the future, so `AutoRefresh` never
+            // considered the token expired and never refreshed it — the token then
+            // silently died at its real (~15 min) `exp` and every request failed until
+            // the process restarted. Use the value as-is. See CIP-3233.
+            expires_at: auth_resp.expiry,
             refresh_token: None,
             region: None,
             client_id: None,
@@ -107,10 +108,17 @@ mod tests {
     use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    fn auth_response_json(access: &str, expiry: u64) -> serde_json::Value {
+    /// Build a mock `/api/authorise` response. CTS returns `expiry` as an
+    /// ABSOLUTE Unix epoch (the JWT `exp` claim), so model that faithfully: the
+    /// token is valid for `expires_in_secs` from now.
+    fn auth_response_json(access: &str, expires_in_secs: u64) -> serde_json::Value {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
         serde_json::json!({
             "accessToken": access,
-            "expiry": expiry
+            "expiry": now + expires_in_secs
         })
     }
 
@@ -144,6 +152,50 @@ mod tests {
             client_id: None,
             device_instance_id: None,
         }
+    }
+
+    // ---- Regression: CTS `expiry` is an absolute epoch (CIP-3233) ----
+
+    /// CTS `/api/authorise` returns `expiry` as an ABSOLUTE Unix epoch (the JWT
+    /// `exp` claim), not a relative duration. The refresher must use it as-is.
+    ///
+    /// Pre-fix (`expires_at = now + expiry`), this token's `expires_at` lands
+    /// ~decades in the future, so `is_expired()` is never true — the token never
+    /// refreshes and silently dies at its real ~15-minute `exp`. The assertion
+    /// below fails under the pre-fix arithmetic (`expires_in()` ≈ 1.7e9) and
+    /// passes with the fix (`expires_in()` ≈ 900).
+    #[tokio::test]
+    async fn access_key_expiry_is_absolute_epoch_not_relative() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let absolute_expiry = now + 900; // a 15-minute token, as an absolute epoch
+
+        let mut mocks = MockSet::new();
+        mocks.mock(move |when, then| {
+            when.post().path("/api/authorise");
+            then.json(serde_json::json!({
+                "accessToken": "tok",
+                "expiry": absolute_expiry
+            }));
+        });
+        let server = start_server(mocks).await;
+
+        let refresher =
+            AccessKeyRefresher::new(SecretToken::new("CSAKid.secret"), server.url(""), None);
+        let token = refresher.refresh(&()).await.unwrap();
+
+        assert!(
+            token.expires_in() <= 1000,
+            "expires_in should be ~900s (absolute `expiry` used as-is); got {} \
+             — pre-fix `now + expiry` yields ~1.7e9",
+            token.expires_in()
+        );
+        assert!(
+            !token.is_expired(),
+            "a fresh 15-minute token must not be reported as already expired"
+        );
     }
 
     // ---- Initial auth tests ----
@@ -405,9 +457,15 @@ mod tests {
         state.counting.enter();
         tokio::time::sleep(state.delay).await;
         state.counting.exit();
+        // CTS returns `expiry` as an absolute epoch (JWT `exp`); model a token
+        // valid for 1 hour from now.
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
         axum::Json(serde_json::json!({
             "accessToken": "refreshed-token",
-            "expiry": 3600
+            "expiry": now + 3600
         }))
     }
 


### PR DESCRIPTION
## Summary

Fixes the **actual** root cause of the customer's "ZeroKMS auth fails ~15 minutes after startup" issue, which the 2.2.3 CancelGuard backport (CIP-3159) did **not** resolve. Ships as **2.2.4**.

Linear: **CIP-3233**.

**NOTE: this fix is for the vendored `stack-auth` - the permanent fix is in https://github.com/cipherstash/cipherstash-suite/pull/2036**

## Root cause

`stack-auth`'s access-key refresher computed the token's local expiry as `now + auth_resp.expiry`. But CTS `/api/authorise` returns `expiry` as an **absolute Unix epoch** — it is literally the JWT `exp` claim — not a relative duration. The sum lands ~decades in the future, so `AutoRefresh` never considers the token expired and **never refreshes it**. ZeroKMS enforces the JWT's real ~15-minute `exp`, so every encrypt/decrypt 401s ~15 minutes after a process starts and stays broken until restart.

Confirmed against a live production token:
```
response.expiry = 1781744121   == JWT exp = 1781744121   (absolute epoch)
JWT iat         = 1781743221
exp - iat       = 900          (the default token lifetime)
```
Pre-fix, stack-auth computed `expires_at = 1781743221 + 1781744121 ≈ year 2083`.

## The fix

```rust
// vendor/stack-auth/src/access_key_refresher.rs
- expires_at: now + auth_resp.expiry,
+ expires_at: auth_resp.expiry,        // CTS `expiry` is already an absolute epoch
```
(The OAuth path is untouched — it correctly uses the relative `expires_in`.)

## Tests

- **Corrected the access-key test fixtures.** They mocked `expiry` as a small *relative* value (`3600`), which is exactly what hid the bug. They now model an **absolute epoch** (`now + N`) like the real CTS.
- **Added a regression test** (`access_key_expiry_is_absolute_epoch_not_relative`): mocks an absolute `expiry` and asserts the resulting `expires_in()` ≈ the intended TTL. Verified it **fails** under the pre-fix `now + expiry` arithmetic (`expires_in()` ≈ 1.7e9) and **passes** with the fix.
- Full vendored crate suite: **107 passed**. `cargo check -p cipherstash-proxy` clean. Release version/changelog drift guard satisfied locally.

## Notes

- The 2.2.3 CancelGuard change stays — it's legitimate hardening for a real (but different) cancellation race; it just wasn't this bug.
- This bug is **live upstream** in cipherstash-suite `stack-auth` (HEAD/0.37.0) and affects any long-running access-key consumer. Tracked in CIP-3233 with a cross-repo bump checklist; an upstream fix PR follows. Once Proxy moves to a `cipherstash-client` built against fixed stack-auth, drop the `vendor/stack-auth` + `[patch.crates-io]` workaround.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ZeroKMS authentication failures occurring approximately 15 minutes after startup. Access tokens now renew correctly before expiry, eliminating the need for manual restart recovery.

* **Chores**
  * Version bumped to v2.2.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->