### PR TITLE
chore(eql): mise tasks to install a local EQL v3 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ rust-toolchain.toml
 /packages/cipherstash-proxy/eql-version-at-build-time.txt
 /cipherstash-encrypt.sql
 /cipherstash-encrypt-uninstall.sql
+/cipherstash-encrypt-v3.sql
+/cipherstash-encrypt-v3-uninstall.sql
 
 # credentials for local dev
 .env.proxy.docker

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -424,7 +424,24 @@ EQL is a required dependency and the database setup uses the latest release.
 
 To use a different version of EQL, set the path to the desired EQL release file in the `CS_EQL_PATH` environment variable.
 
+#### Installing a local EQL v3 build
 
+To install a locally built EQL v3 schema (the `eql_v3` schema) into the test PostgreSQL container, alongside the existing v2 flow:
+
+```shell
+# Build the v3 artifact in your encrypt-query-language checkout (branch eql_v3)
+cd ../encrypt-query-language
+mise run build
+# writes release/cipherstash-encrypt.sql and release/cipherstash-encrypt-uninstall.sql
+
+# Install it into the running test postgres
+cd ../proxy
+CS_EQL_V3_PATH=../encrypt-query-language/release mise run postgres:eql:v3:setup
+```
+
+`postgres:eql:v3:setup` copies the install/uninstall SQL from `$CS_EQL_V3_PATH` (as `cipherstash-encrypt-v3.sql` / `cipherstash-encrypt-v3-uninstall.sql` in the repo root), drops any existing `eql_v3` schema, and installs the new one.
+
+Note: unlike `postgres:setup`, this does **not** apply `tests/sql/schema.sql` — that fixture is still EQL v2. Use `postgres:eql:v3:teardown` to just uninstall EQL v3.
 
 #### Convention: PostgreSQL ports
 

--- a/mise.toml
+++ b/mise.toml
@@ -593,6 +593,42 @@ else
 fi
 """
 
+[tasks."eql:v3:copy"]
+description = "Copy a locally built EQL v3 install/uninstall SQL (requires CS_EQL_V3_PATH)"
+run = """
+#!/bin/bash
+set -eu
+if [ -z "${CS_EQL_V3_PATH:-}" ]; then
+  echo "error: CS_EQL_V3_PATH is not set"
+  echo "error: Set it to a directory containing a locally built EQL v3 artifact, e.g."
+  echo "error:   (cd ../encrypt-query-language && mise run build)  # writes release/cipherstash-encrypt.sql"
+  echo "error:   CS_EQL_V3_PATH=../encrypt-query-language/release mise run postgres:eql:v3:setup"
+  exit 65
+fi
+echo "Using EQL v3: ${CS_EQL_V3_PATH}/cipherstash-encrypt.sql"
+cp "${CS_EQL_V3_PATH}/cipherstash-encrypt.sql" "{{config_root}}/cipherstash-encrypt-v3.sql"
+echo "Using EQL v3: ${CS_EQL_V3_PATH}/cipherstash-encrypt-uninstall.sql"
+cp "${CS_EQL_V3_PATH}/cipherstash-encrypt-uninstall.sql" "{{config_root}}/cipherstash-encrypt-v3-uninstall.sql"
+"""
+
+[tasks."postgres:eql:v3:teardown"]
+depends = ["eql:v3:copy"]
+description = "Uninstalls EQL v3 (drops the eql_v3 schema) from the database"
+run = """
+#!/bin/bash
+mise run postgres:fail_if_not_running
+cat "{{config_root}}/cipherstash-encrypt-v3-uninstall.sql" | docker exec -i postgres${CONTAINER_SUFFIX:-} psql postgresql://${CS_DATABASE__USERNAME}:${CS_DATABASE__PASSWORD_ESCAPED_FOR_TESTS}@${CS_DATABASE__HOST}:${CS_DATABASE__PORT}/${CS_DATABASE__NAME} -f-
+"""
+
+[tasks."postgres:eql:v3:setup"]
+depends = ["postgres:eql:v3:teardown"]
+description = "Installs a locally built EQL v3 into the database (no tests/sql/schema.sql; that fixture is still v2)"
+run = """
+#!/bin/bash
+mise run postgres:fail_if_not_running
+cat "{{config_root}}/cipherstash-encrypt-v3.sql" | docker exec -i postgres${CONTAINER_SUFFIX:-} psql postgresql://${CS_DATABASE__USERNAME}:${CS_DATABASE__PASSWORD_ESCAPED_FOR_TESTS}@${CS_DATABASE__HOST}:${CS_DATABASE__PORT}/${CS_DATABASE__NAME} -f-
+"""
+
 [tasks."test:integration:lang:python"]
 dir = "{{config_root}}/tests"
 description = "Runs python tests"


### PR DESCRIPTION
## Summary

Adds opt-in mise tasks to install a locally built EQL v3 schema into the test Postgres, alongside the existing v2 flow (which is untouched):

- `eql:v3:copy` — copies `cipherstash-encrypt.sql`/`-uninstall.sql` from `$CS_EQL_V3_PATH` (e.g. `../encrypt-query-language/release` after `mise run build` there) as `cipherstash-encrypt-v3.sql`/`-v3-uninstall.sql` (distinct names; gitignored)
- `postgres:eql:v3:setup` / `postgres:eql:v3:teardown` — install/drop the `eql_v3` schema via psql in the Postgres container, mirroring the v2 task pattern (with `ON_ERROR_STOP=1`)

Deliberately does **not** apply `tests/sql/schema.sql` (still v2); the v3 fixture lands in the stacked follow-up PR. Documented in DEVELOPMENT.md ("Installing a local EQL v3 build").

**No merge gate** — this has no eql-bindings dependency and changes no runtime code; verified live (`eql_v2` and `eql_v3` schemas coexist; v2 setup unchanged before/after).

Linear: CIP-3343 (parent CIP-3299).