### PR TITLE
[1/1] chore: configure agent skill conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,10 @@ For significant releases, write an `ANNOUNCEMENT.md` for the GitHub Discussions 
 
 Issues are tracked in **Linear** (team: Product Engineering, key `CIP-`), not GitHub Issues. GitHub holds code and PRs only. See `docs/agents/issue-tracker.md`.
 
+### Triage labels
+
+**Defaults** — the five canonical roles, each label string equal to its name. Only `wontfix` exists in Linear today; the rest are created on demand. See `docs/agents/triage-labels.md`.
+
 ### Domain docs
 
 **Multi-context** — the root `CONTEXT-MAP.md` points at per-package `CONTEXT.md` files under `packages/*/`. See `docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,3 +238,13 @@ For significant releases, write an `ANNOUNCEMENT.md` for the GitHub Discussions 
    > Critical information users must know.
    ```
 4. After copying content to GitHub Discussions, delete `ANNOUNCEMENT.md` from the repo
+
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked in **Linear** (team: Product Engineering, key `CIP-`), not GitHub Issues. GitHub holds code and PRs only. See `docs/agents/issue-tracker.md`.
+
+### Domain docs
+
+**Multi-context** — the root `CONTEXT-MAP.md` points at per-package `CONTEXT.md` files under `packages/*/`. See `docs/agents/domain.md`.

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,39 @@
+# Context Map
+
+CipherStash Proxy is a Cargo workspace. Each context below owns a distinct domain
+vocabulary. Read the `CONTEXT.md` for the context you're working in before exploring
+its code.
+
+Per-context `CONTEXT.md` files are created lazily by `/domain-modeling` as terms get
+resolved — a missing one is expected, not a gap to fill upfront.
+
+| Context | Path | Domain |
+|---|---|---|
+| Proxy | `packages/cipherstash-proxy/` | PostgreSQL wire protocol, session and message handling, client authentication, TLS, ZeroKMS key management, encrypt/decrypt of column values |
+| EQL Mapper | `packages/eql-mapper/` | SQL parsing, type inference over statements, schema analysis, transformation rules that rewrite plaintext SQL into EQL v2 operations |
+| Integration | `packages/cipherstash-proxy-integration/` | End-to-end test harness — container fixtures, encrypted-scenario coverage across the proxy and mapper together |
+| Showcase | `packages/showcase/` | Healthcare example data model demonstrating EQL v2 encryption with realistic relationships |
+
+`packages/eql-mapper-macros/` is proc-macro support for EQL Mapper, not a context of its
+own — treat it as part of the EQL Mapper context.
+
+## Shared vocabulary
+
+Terms defined once for the whole system live here rather than in any one context.
+
+- **EQL v2** — Encrypt Query Language; the SQL-level encoding that makes encrypted
+  values searchable.
+- **`eql_v2_encrypted`** — the PostgreSQL column type holding an encrypted value.
+- **ZeroKMS** — CipherStash's key management service, which the proxy calls to encrypt
+  and decrypt.
+- **Keyset** — the ZeroKMS key collection a workspace encrypts against.
+
+## Cross-context term collisions
+
+Terms that mean different things depending on where you are. Resolve them against your
+own context.
+
+- **Type** — a PostgreSQL wire-protocol type in Proxy; an inferred SQL expression type
+  in EQL Mapper.
+- **Index** — a PostgreSQL index in Proxy; a searchable-encryption index (ORE, match,
+  unique) in EQL Mapper and EQL config.

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -9,13 +9,31 @@ resolved — a missing one is expected, not a gap to fill upfront.
 
 | Context | Path | Domain |
 |---|---|---|
-| Proxy | `packages/cipherstash-proxy/` | PostgreSQL wire protocol, session and message handling, client authentication, TLS, ZeroKMS key management, encrypt/decrypt of column values |
-| EQL Mapper | `packages/eql-mapper/` | SQL parsing, type inference over statements, schema analysis, transformation rules that rewrite plaintext SQL into EQL v2 operations |
+| Proxy | [`packages/cipherstash-proxy/`](./packages/cipherstash-proxy/CONTEXT.md) | PostgreSQL wire protocol, connection and message handling, client authentication, TLS, ZeroKMS key management, encrypt/decrypt of column values |
+| EQL Mapper | [`packages/eql-mapper/`](./packages/eql-mapper/CONTEXT.md) | SQL parsing, type inference over statements, schema analysis, transformation rules that rewrite plaintext SQL into EQL v2 operations |
 | Integration | `packages/cipherstash-proxy-integration/` | End-to-end test harness — container fixtures, encrypted-scenario coverage across the proxy and mapper together |
 | Showcase | `packages/showcase/` | Healthcare example data model demonstrating EQL v2 encryption with realistic relationships |
 
 `packages/eql-mapper-macros/` is proc-macro support for EQL Mapper, not a context of its
 own — treat it as part of the EQL Mapper context.
+
+## Relationships
+
+- **Proxy → EQL Mapper**: Proxy loads the database schema and hands it over with each
+  column marked native or encrypted; EQL Mapper returns a type-checked, rewritten
+  statement. Proxy then reads the per-node EQL term shapes back out to decide how to
+  encrypt each value.
+- **Identity across the seam**: EQL Mapper's `TableColumn` and Proxy's `Identifier` are
+  the same `table.column` pair under two names. That pair is the only key joining a typed
+  AST node to its encryption config.
+- **Capability across the seam — currently broken.** Proxy marks every encrypted column
+  with *all* `EqlTrait`s (`packages/cipherstash-proxy/src/proxy/schema/manager.rs:146`)
+  because it derives them from the PostgreSQL column type alone. The column encrypt
+  config, which knows the SEM terms actually configured, is loaded by a separate manager
+  that never meets the schema loader. EQL Mapper's bound checking is therefore
+  unreachable in production: a query needing `Ord` on a column with no ordering SEM term
+  type-checks cleanly and fails later. Read `EqlTraits` on a column as *intended*
+  capability, not observed.
 
 ## Shared vocabulary
 
@@ -27,6 +45,22 @@ Terms defined once for the whole system live here rather than in any one context
 - **ZeroKMS** — CipherStash's key management service, which the proxy calls to encrypt
   and decrypt.
 - **Keyset** — the ZeroKMS key collection a workspace encrypts against.
+- **SEM (searchable encrypted metadata)** — the encrypted material stored alongside a
+  value that makes some operation on it possible without decryption. A **SEM term** is
+  one such piece of metadata; ORE, unique, match and SteVec are SEM **types**.
+- **EqlTrait** — a *capability* an encrypted column has: equality, ordering, token
+  match, JSON traversal, containment. Several SEM types can satisfy the same trait, so
+  the relationship is many-to-one: SEM terms are the storage, traits are what the storage
+  buys you.
+
+  Say **capability/trait** when you mean what a query may do, and **SEM term** when you
+  mean what is written to the column. Do not call either an **index** — that word is
+  reserved for a PostgreSQL index.
+
+  > The EQL config JSON and `cipherstash_client`'s `ColumnConfig` still spell SEM terms
+  > `indexes` / `IndexType`. That spelling is a wire and storage format shared with EQL
+  > and customer-authored config, so it is not ours to rename unilaterally — prefer SEM
+  > in prose and new code, and read `indexes` in those payloads as "SEM terms".
 
 ## Cross-context term collisions
 
@@ -35,5 +69,19 @@ own context.
 
 - **Type** — a PostgreSQL wire-protocol type in Proxy; an inferred SQL expression type
   in EQL Mapper.
-- **Index** — a PostgreSQL index in Proxy; a searchable-encryption index (ORE, match,
-  unique) in EQL Mapper and EQL config.
+- **Index** — means a PostgreSQL index in *both* contexts (EQL Mapper's only use of the
+  word is GIN indexes). Where it appears meaning searchable encryption — the `indexes`
+  key in EQL config, `IndexType`, "Unknown Index Term" — read it as **SEM term** and see
+  the shared vocabulary above.
+- **Column** — an encrypted column's runtime config in Proxy; a schema column or a
+  projection column in EQL Mapper. Also `DataColumn` (a wire value) and
+  `RowDescriptionField` (a result descriptor) in Proxy.
+- **Statement** — a type-analysed statement in Proxy; the parsed AST or a
+  `TypeCheckedStatement` in EQL Mapper. Four senses are live in Proxy alone.
+- **Term** — the *shape* of an encrypted payload (`EqlTerm`) in EQL Mapper; a piece of
+  searchable encrypted metadata in Proxy and EQL config. Qualify as *EQL term* or
+  *SEM term*.
+- **Projection** — a type in EQL Mapper's lattice; in Proxy, a positional list where a
+  missing entry means "native, do not encrypt".
+- **Session** — banned in Proxy (see its `CONTEXT.md`); PostgreSQL owns the word, and the
+  code has used it for both a connection and a single statement.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23,7 +14,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "generic-array",
 ]
 
@@ -36,6 +27,21 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures 0.2.17",
+ "zeroize",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
  "zeroize",
 ]
 
@@ -193,12 +199,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
-name = "array-init"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,9 +321,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -332,14 +332,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -432,30 +433,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backtrace"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "backtrace-ext"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
-dependencies = [
- "backtrace",
-]
-
-[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,6 +519,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -737,15 +723,15 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
 ]
 
 [[package]]
 name = "cipherstash-client"
-version = "0.34.1-alpha.4"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3d67cc26d8422509d2c20644576124e7344a4bf14ded06c7affa8dc18aabca"
+checksum = "6c8714a2997ab5a8cc2c871f01dcae9ff7c6b342ed51c5c0d7c8edd4d954c9d1"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -753,9 +739,9 @@ dependencies = [
  "async-trait",
  "base16ct",
  "base64",
+ "base64ct",
  "base85",
  "blake3",
- "cfg-if",
  "chrono",
  "cipherstash-config",
  "cipherstash-core",
@@ -771,16 +757,12 @@ dependencies = [
  "log",
  "miette",
  "opaque-debug",
- "open 3.2.0",
  "orderable-bytes",
  "ore-rs",
  "percent-encoding",
  "rand 0.8.6",
- "recipher 0.2.2",
+ "recipher 0.2.3",
  "reqwest",
- "reqwest-middleware",
- "reqwest-retry",
- "reqwest-tracing",
  "rmp-serde",
  "rust-stemmers",
  "rust_decimal",
@@ -800,7 +782,7 @@ dependencies = [
  "url",
  "uuid",
  "vitaminc",
- "vitaminc-protected",
+ "vitaminc-protected 0.2.0-pre.1",
  "winnow 0.6.26",
  "zeroize",
  "zerokms-protocol",
@@ -808,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-config"
-version = "0.34.1-alpha.4"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283fa04db19f9bf2cb2f09e8c1505a15560310bc50fdc066734072c616aa8ca9"
+checksum = "56cde3aaa5e2916a40530932f142c37ad6202835a6d221ce6c46fc14bfec8fc5"
 dependencies = [
  "bitflags",
  "serde",
@@ -820,10 +802,11 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-core"
-version = "0.34.1-alpha.4"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bb7181053c3fc35569e0800fa7510c85ee2bffee21abbd2a7aeb498f5f0972"
+checksum = "1946988e0b7f9de259d85b10c9c1fd7e1327751103b808c2c6e930b9a87c25c9"
 dependencies = [
+ "getrandom 0.2.15",
  "hmac",
  "lazy_static",
  "num-bigint",
@@ -881,7 +864,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
- "vitaminc-protected",
+ "vitaminc-protected 0.1.0-pre4.2",
  "x509-parser",
 ]
 
@@ -954,15 +937,14 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cllw-ore"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d007a5be83ae12adbd17543f9631d64090d761c029d2f8f7eb8f8ddb2a87caf"
+checksum = "4f73a23cbc15404d9b314c03b16a888f798dbc681bceeb2e18674f602f9da02d"
 dependencies = [
  "blake3",
  "chrono",
  "hex",
  "orderable-bytes",
- "postgres-types",
  "rust_decimal",
  "subtle",
  "thiserror 1.0.69",
@@ -977,7 +959,7 @@ checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
 dependencies = [
  "cipher",
  "dbl",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1158,6 +1140,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,9 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "cts-common"
-version = "0.34.1-alpha.4"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b26644e630f2e690194c6b61f5b613b768061750f2060cf4db73ddb8058d284"
+checksum = "fe2acdda527057d48061433ace5378d8452f10d6787f78e0e69b1cddacc57082"
 dependencies = [
  "arrayvec",
  "axum",
@@ -1182,6 +1173,7 @@ dependencies = [
  "diesel",
  "either",
  "fake 3.1.0",
+ "getrandom 0.4.2",
  "http",
  "miette",
  "nom 8.0.0",
@@ -1388,9 +1380,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1799,7 +1801,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc3655aa6818d65bc620d6911f05aa7b6aeb596291e1e9f79e52df85583d1e30"
 dependencies = [
- "rustix 0.38.44",
+ "rustix",
  "windows-targets 0.52.6",
 ]
 
@@ -1837,18 +1839,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
+name = "ghash"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
 
 [[package]]
 name = "h2"
@@ -1976,7 +1984,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2024,6 +2032,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2365,12 +2382,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_ci"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2497,12 +2508,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
-
-[[package]]
 name = "litemap"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2565,7 +2570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2627,18 +2632,10 @@ version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a955165f87b37fd1862df2a59547ac542c77ef6d17c666f619d1ad22dd89484"
 dependencies = [
- "backtrace",
- "backtrace-ext",
  "cfg-if",
  "miette-derive",
- "owo-colors",
- "supports-color",
- "supports-hyperlinks",
- "supports-unicode",
- "terminal_size",
- "textwrap",
  "thiserror 1.0.69",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2814,15 +2811,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2846,16 +2834,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "open"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2078c0039e6a54a0c42c28faa984e115fb4c2d5bf2208f77d1961002df8576f8"
-dependencies = [
- "pathdiff",
- "windows-sys 0.42.0",
-]
 
 [[package]]
 name = "open"
@@ -2927,12 +2905,6 @@ dependencies = [
  "thiserror 1.0.69",
  "zeroize",
 ]
-
-[[package]]
-name = "owo-colors"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 
 [[package]]
 name = "parking"
@@ -3114,7 +3086,6 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613283563cd90e1dfc3518d548caee47e0e725455ed619881f5cf21f36de4b48"
 dependencies = [
- "array-init",
  "bytes",
  "chrono",
  "fallible-iterator",
@@ -3388,9 +3359,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -3491,13 +3462,13 @@ dependencies = [
 
 [[package]]
 name = "recipher"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b3561e1082283a4c064635b7886aa4d24db57a43ac31c55930c10797ab5cdeb"
+checksum = "9398dce78ddfce08f93e9d9a3ac64d9b0a4fed478c0a82003c6e4c90dc245125"
 dependencies = [
  "aes",
- "async-trait",
  "cmac",
+ "getrandom 0.2.15",
  "hex",
  "hex-literal",
  "opaque-debug",
@@ -3635,71 +3606,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest-middleware"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199dda04a536b532d0cc04d7979e39b1c763ea749bf91507017069c00b96056f"
-dependencies = [
- "anyhow",
- "async-trait",
- "http",
- "reqwest",
- "serde",
- "thiserror 2.0.18",
- "tower-service",
-]
-
-[[package]]
-name = "reqwest-retry"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2412db2af7d2268e7a5406be0431f37d9eb67ff390f35b395716f5f06c2eaa"
-dependencies = [
- "anyhow",
- "async-trait",
- "futures",
- "getrandom 0.2.15",
- "http",
- "hyper",
- "reqwest",
- "reqwest-middleware",
- "retry-policies",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "wasmtimer",
-]
-
-[[package]]
-name = "reqwest-tracing"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5c1a1510677d43dce9e9c0c07fc5db8772c0e5a43e4f9cef75a11affa05a578"
-dependencies = [
- "anyhow",
- "async-trait",
- "getrandom 0.2.15",
- "http",
- "matchit",
- "reqwest",
- "reqwest-middleware",
- "tracing",
-]
-
-[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
-
-[[package]]
-name = "retry-policies"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
-dependencies = [
- "rand 0.9.2",
-]
 
 [[package]]
 name = "ring"
@@ -3793,12 +3703,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3831,20 +3735,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.9.3",
+ "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
 
@@ -4192,7 +4083,7 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4339,13 +4230,16 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stack-auth"
-version = "0.34.1-alpha.4"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1c9c640571eba8fa5a705ccebe5c5e50aa27d4d51f4ec1614ffd1841b8a13a"
 dependencies = [
  "aquamarine",
+ "base64",
  "cts-common",
  "jsonwebtoken",
  "miette",
- "open 5.3.3",
+ "open",
  "reqwest",
  "serde",
  "serde_json",
@@ -4356,16 +4250,17 @@ dependencies = [
  "url",
  "uuid",
  "vitaminc",
- "vitaminc-protected",
+ "vitaminc-protected 0.2.0-pre.1",
+ "web-time",
  "zeroize",
  "zerokms-protocol",
 ]
 
 [[package]]
 name = "stack-profile"
-version = "0.34.1-alpha.4"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd61bc4129d2258ec1ba89d742558308560fc0f585f9c24d478685def8efd14"
+checksum = "192a90bfa46efe194c2b8beae5523f6214714574c7e8a210c78021259f100e79"
 dependencies = [
  "dirs",
  "gethostname",
@@ -4422,27 +4317,6 @@ name = "subtle-ng"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
-
-[[package]]
-name = "supports-color"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
-dependencies = [
- "is_ci",
-]
-
-[[package]]
-name = "supports-hyperlinks"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f44ed3c63152de6a9f90acbea1a110441de43006ea51bcce8f436196a288b"
-
-[[package]]
-name = "supports-unicode"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
@@ -4526,26 +4400,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
 dependencies = [
  "parking_lot",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
-dependencies = [
- "rustix 1.0.3",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
-dependencies = [
- "unicode-linebreak",
- "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -4943,9 +4797,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"
@@ -4964,12 +4818,6 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "unicode-linebreak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"
@@ -4999,12 +4847,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5016,7 +4858,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -5095,9 +4937,11 @@ checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "atomic",
  "getrandom 0.3.2",
+ "js-sys",
  "md-5",
  "serde",
  "sha1_smol",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5150,39 +4994,40 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vitaminc"
-version = "0.1.0-pre4.2"
+version = "0.2.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c8b739a2cb1e528e77a69267728532f52d2d5ce18ae2839e26c797859fe9015"
+checksum = "d69481bc78bc3227d6c70d8aae6437c79badbf54fd9ec90c1b4ae2553068a989"
 dependencies = [
  "vitaminc-aead",
  "vitaminc-encrypt",
- "vitaminc-protected",
+ "vitaminc-protected 0.2.0-pre.1",
  "vitaminc-random",
  "vitaminc-traits",
 ]
 
 [[package]]
 name = "vitaminc-aead"
-version = "0.1.0-pre4.2"
+version = "0.2.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c29cef4d4b0d018c4223d366017d2a9756012acf76e25011aaca877f3c74904"
+checksum = "be80f3a3d83e69a786b97a831d660449a0437ccac3b3e369bf590afcb45569b0"
 dependencies = [
  "bytes",
  "serde",
- "vitaminc-protected",
+ "vitaminc-protected 0.2.0-pre.1",
  "vitaminc-random",
  "zeroize",
 ]
 
 [[package]]
 name = "vitaminc-encrypt"
-version = "0.1.0-pre4.2"
+version = "0.2.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e3869aaf60ebb95ccbdfcf003985132325b4d1ac6f5d945ad2fbb9149afd3a"
+checksum = "7477ef8ac925a75aacf5dbddfd4b17fd32f35ee9fb4a7c45ac3db80fd9ad4006"
 dependencies = [
+ "aes-gcm",
  "aws-lc-rs",
  "vitaminc-aead",
- "vitaminc-protected",
+ "vitaminc-protected 0.2.0-pre.1",
  "vitaminc-random",
  "zeroize",
 ]
@@ -5194,11 +5039,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af693c39d3cd1c818ef6267539433c6ceca87840b12d24124adbc9c8ecba1709"
 dependencies = [
  "bitvec",
- "digest",
+ "digest 0.10.7",
  "serde",
  "serde_bytes",
  "subtle",
- "vitaminc-protected-derive",
+ "vitaminc-protected-derive 0.1.0-pre4.2",
+ "zeroize",
+]
+
+[[package]]
+name = "vitaminc-protected"
+version = "0.2.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8472e2b76b5dedaf429708393964c3cc6f7ee40e6a43ed420288e3e4900c6af"
+dependencies = [
+ "bitvec",
+ "digest 0.11.3",
+ "serde",
+ "serde_bytes",
+ "subtle",
+ "vitaminc-protected-derive 0.2.0-pre.1",
  "zeroize",
 ]
 
@@ -5214,23 +5074,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "vitaminc-random"
-version = "0.1.0-pre4.2"
+name = "vitaminc-protected-derive"
+version = "0.2.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9de431cb93359d293ec7e70d05d87117a57f34bfc5bc94f040b81d4dd1afd6"
+checksum = "b01e1715676d8bf606314c2a51df0793c01bd743bae4bc00643d68f766ee1e91"
 dependencies = [
- "rand 0.10.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "vitaminc-random"
+version = "0.2.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0785c13f839240523ba8db6535384a5e8d4fe2b2f28bbddcfcb5fd6de825996"
+dependencies = [
+ "getrandom 0.4.2",
+ "rand 0.10.2",
  "thiserror 2.0.18",
- "vitaminc-protected",
+ "vitaminc-protected 0.2.0-pre.1",
  "vitaminc-random-derives",
  "zeroize",
 ]
 
 [[package]]
 name = "vitaminc-random-derives"
-version = "0.1.0-pre4.2"
+version = "0.2.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49d33ac4682235551d25c874525c20e03d4c863b39f556391f52f7a2083bfbdf"
+checksum = "01e750eefb1f49940f589b2d397e2323d5df4b62bfb33b4e40e1d20a35c3f167"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5239,16 +5111,16 @@ dependencies = [
 
 [[package]]
 name = "vitaminc-traits"
-version = "0.1.0-pre4.2"
+version = "0.2.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c25a9e51d24c3befddd71e907dd4ae9f21cfbaae065fb0ef5202e5d21cd198d0"
+checksum = "3794e2c028cff00f40caea05ab6dce38181a94e13c0aaee640e7b867369780eb"
 dependencies = [
  "anyhow",
  "bytes",
  "rmp-serde",
  "serde",
  "thiserror 2.0.18",
- "vitaminc-protected",
+ "vitaminc-protected 0.2.0-pre.1",
  "vitaminc-random",
  "zeroize",
 ]
@@ -5427,20 +5299,6 @@ dependencies = [
  "hashbrown 0.15.2",
  "indexmap",
  "semver",
-]
-
-[[package]]
-name = "wasmtimer"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot",
- "pin-utils",
- "slab",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -5664,21 +5522,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.1",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6275,15 +6118,16 @@ dependencies = [
 
 [[package]]
 name = "zerokms-protocol"
-version = "0.12.9"
+version = "0.12.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2f045e2ee975a3d448419245c4621ea8844d2a004c63a96277181dc7cf8483"
+checksum = "16f731f2de99e66396928faef44b02b39288dc9a93f77a4a3e1dcdc33c1adad0"
 dependencies = [
  "base64",
  "cipherstash-config",
  "const-hex",
  "cts-common",
  "fake 2.10.0",
+ "getrandom 0.2.15",
  "opaque-debug",
  "rand 0.8.6",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,9 @@ debug = true
 
 [workspace.dependencies]
 sqltk = { version = "0.10.0" }
-cipherstash-client = { version = "=0.34.1-alpha.4" }
-cipherstash-config = { version = "=0.34.1-alpha.4" }
-cts-common = { version = "=0.34.1-alpha.4" }
+cipherstash-client = { version = "=0.42.0" }
+cipherstash-config = { version = "=0.42.0" }
+cts-common = { version = "=0.42.0" }
 
 thiserror = "2.0.9"
 tokio = { version = "1.44.2", features = ["full"] }
@@ -59,12 +59,6 @@ tracing-subscriber = { version = "^0.3.20", features = [
   "std",
 ] }
 
-# HOTFIX (CIP-3159): backport the stack-auth token-refresh CancelGuard fix onto
-# the 0.34.1-alpha.4 source that cipherstash-client 0.34.1-alpha.4 pins. Without
-# this, a cancelled get_token() future could strand `refresh_in_progress = true`,
-# wedging all later refreshes and causing ZeroKMS "Request not authorized" exactly
-# ~15 min (token TTL) after startup. The patch keeps version 0.34.1-alpha.4 so it
-# satisfies cipherstash-client's exact pin while replacing the registry source.
-# Remove once Proxy moves to a cipherstash-client built against stack-auth >= 0.36.0.
-[patch.crates-io]
-stack-auth = { path = "vendor/stack-auth" }
+# The CIP-3159 stack-auth hotfix patch was removed here: cipherstash-client 0.42.0
+# requires stack-auth ^0.42.0, which carries the CancelGuard token-refresh fix
+# upstream (landed in stack-auth 0.36.0). vendor/stack-auth is now unreferenced.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,61 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when
+exploring the codebase.
+
+This is a **multi-context** repo — a Cargo workspace whose packages carry distinct
+domain vocabularies.
+
+## Before exploring, read these
+
+- **`CONTEXT-MAP.md`** at the repo root — it points at one `CONTEXT.md` per context.
+  Read each one relevant to the topic.
+- **`docs/adr/`** — system-wide architectural decisions.
+- **`packages/<name>/docs/adr/`** — context-scoped decisions for that package.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence;
+don't suggest creating them upfront. The `/domain-modeling` skill (reached via
+`/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms
+or decisions actually get resolved.
+
+Note that `ARCHITECTURE.md` at the repo root already describes system structure. It is
+not a glossary — read it for orientation, but domain *terms* belong in `CONTEXT.md`.
+
+## File structure
+
+This repo is a Cargo workspace, so contexts live under `packages/`, not `src/`:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                                  ← system-wide decisions
+└── packages/
+    ├── cipherstash-proxy/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                          ← context-specific decisions
+    └── eql-mapper/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a
+hypothesis, a test name), use the term as defined in the relevant `CONTEXT.md`. Don't
+drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're
+inventing language the project doesn't use (reconsider) or there's a real gap (note it
+for `/domain-modeling`).
+
+Watch for terms that mean different things in different contexts. "Type", for example,
+means a PostgreSQL wire type in `cipherstash-proxy` and an inferred SQL type in
+`eql-mapper`. That divergence is exactly why this repo is multi-context — resolve the
+term against the context you're working in, not the other one.
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently
+overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,73 @@
+# Issue Tracker
+
+Issues for this repo live in **Linear**, not GitHub Issues.
+
+- **Workspace:** CipherStash
+- **Team:** Product Engineering
+- **Issue key prefix:** `CIP-` (e.g. `CIP-3233`)
+
+GitHub (`cipherstash/proxy`) holds code, branches, and pull requests. It is not the
+issue tracker. Do not run `gh issue create` for this repo.
+
+## How to read and write issues
+
+Two access paths exist. **Prefer the CLI for writes.**
+
+### `linear-cli` (preferred)
+
+The `linear` command (`@schpet/linear-cli`, or `npx @schpet/linear-cli`) — see the
+`linear-cli` skill for full usage.
+
+```bash
+linear issue list
+linear issue view CIP-3233
+linear issue create --title "..." --description-file /path/to/desc.md
+linear issue update CIP-3233 --status "In Progress"
+```
+
+Always pass markdown via `--description-file` / `--body-file` rather than inline
+arguments — inline content produces literal `\n` sequences in the Linear UI.
+
+### Linear MCP tools (fallback, and for querying)
+
+`mcp__claude_ai_Linear__*` — good for search and read-heavy work
+(`list_issues`, `get_issue`, `save_issue`). Note these are
+interactively authenticated and **may be unavailable in headless or cron runs**, so
+anything scripted should prefer the CLI.
+
+## Statuses
+
+The Product Engineering workflow:
+
+| Status | Type |
+|---|---|
+| `Backlog` | backlog |
+| `Todo` | unstarted |
+| `In Progress` | started |
+| `In Review` | started |
+| `Done` | completed |
+| `Canceled` | canceled |
+| `Duplicate` | duplicate |
+
+## How the skills should use this
+
+- **`to-tickets`** — create one Linear issue per tracer-bullet ticket in team
+  Product Engineering, starting in `Todo`. Express blocking edges as **native Linear
+  blocked-by relations**, not as prose in the description and not as files under
+  `.scratch/`. Any issue whose blockers are `Done` is grabbable.
+- **`implement`** — take an issue by its `CIP-####` key. Move it to `In Progress` when
+  work starts, and `In Review` when the PR opens. Leave the move to `Done` to the
+  human merging.
+- **`to-spec`** — link the resulting spec back to the originating issue as a comment or
+  attachment on the Linear issue.
+- **`code-review`** — the "Spec" axis reads the originating `CIP-####` issue for intent.
+
+## Linking PRs to issues
+
+Reference the issue key in the PR title or body (e.g. `CIP-3233`) so Linear's GitHub
+integration attaches the PR to the issue automatically.
+
+## PRs as a request surface
+
+**Off.** External pull requests are not treated as incoming triage requests for this
+repo. Flip this flag if that changes.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,25 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to
+the actual label strings used in this repo's issue tracker (Linear, team Product
+Engineering — see [issue-tracker.md](./issue-tracker.md)).
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the
+corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.
+
+## Creating the labels
+
+Only `wontfix` currently exists on the Product Engineering team. The other four are
+created lazily — the first time `triage` needs one, create it on the team rather than
+failing. These are workspace-level Linear labels, unparented; do not nest them under the
+existing `Product` / `R&D` / `Issue type` groups.

--- a/docs/plans/2026-07-20-eql-v3-type-checker-handoff.md
+++ b/docs/plans/2026-07-20-eql-v3-type-checker-handoff.md
@@ -1,0 +1,397 @@
+# EQL v3 type checker — session handoff
+
+**Date:** 2026-07-20
+**Branch:** `chore/agent-skills-setup` (PR #415)
+**Purpose:** carry context into a fresh session for `/grill-with-docs` on extending the
+EQL Mapper type checker for EQL v3.
+
+This is a handoff, not a spec. It records what is already true, what was already decided,
+and what is still open. The design itself has not started.
+
+---
+
+## 1. How to use this
+
+Open a fresh session, reference this file, and run `/grill-with-docs`. The design questions
+in §8 are the agenda. Everything above them is evidence gathered so the grill does not have
+to re-derive it.
+
+Glossaries exist and should be updated as terms get resolved:
+`CONTEXT-MAP.md`, `packages/eql-mapper/CONTEXT.md`, `packages/cipherstash-proxy/CONTEXT.md`.
+
+---
+
+## 2. Where the branch is
+
+Five commits, unpushed beyond #415's first. In order:
+
+| Commit | What |
+|---|---|
+| `3d33c8ed` | Agent skills config (issue tracker, domain docs) |
+| `74b63721` | Domain glossaries for Proxy and EQL Mapper |
+| `64c658f2` | Deps: cipherstash-client `0.34.1-alpha.4` → `0.42.0`, EQL `2.3.0-pre.3` → `3.0.1` |
+| `b3f293d7` | Encrypt path moved to `encrypt_eql_v3`; v2 retired |
+| `a10b60cd` | v3 decrypt for scalar + SteVec |
+| `387ca790` | Adopted the 0.42.0 representation; workspace compiles |
+
+**State:** the workspace compiles, `cargo fmt` and `cargo clippy --all-targets` are clean.
+**Nothing has been run.** Compiling is not working — `eql-mapper` still emits `eql_v2_encrypted`
+casts and `eql_v2.*` calls into every rewritten statement, so nothing works end to end.
+229 `eql_v2` references remain repo-wide.
+
+The vendored `stack-auth` CIP-3159 patch was dropped (0.42.0 requires `stack-auth ^0.42.0`,
+which carries the CancelGuard fix upstream). `vendor/stack-auth/` is still on disk, unreferenced.
+
+---
+
+## 3. The EQL v3 model
+
+EQL 3.0 removes the `eql_v2` schema entirely. The single opaque `eql_v2_encrypted`
+**composite** type is replaced by **53 typed domains over jsonb**, two-dimensional:
+
+**Token type** × **capability suffix**
+
+- Tokens: `integer`, `smallint`, `bigint`, `date`, `timestamp`, `numeric`, `text`,
+  `boolean`, `real`, `double`, `json`
+- Suffixes: *(none)*, `_eq`, `_ord`, `_ord_ope`, `_ord_ore`, `_match`, `_search`, `_search_ore`
+
+Column domains live in `public` (`public.eql_v3_integer_ord`); query-operand twins live in
+`eql_v3` (`eql_v3.query_integer_ord`). 39 query twins, enumerated separately.
+
+Capability is a property of the **type**, and the domain's CHECK enforces that the payload
+actually carries the required terms — so a missing term fails on insert, not later at query time.
+
+### SEM terms (the storage beneath a capability)
+
+| Suffix | Operators | Term |
+|---|---|---|
+| *(none)* | — (storage only) | `c` |
+| `_eq` | `=` `<>` | `hm` (HMAC-256) |
+| `_ord` | `=` `<>` `<` `<=` `>` `>=`, MIN/MAX | `op` (CLLW-OPE) |
+| `_ord_ope` | as `_ord` | `op` |
+| `_ord_ore` | as `_ord` | `ob` (block-ORE) |
+| `_match` | `@@` | `bf` (bloom filter) |
+| `_search` | all | `hm` + `op` + `bf` |
+| `_search_ore` | all | `hm` + `ob` + `bf` |
+
+Text is the exception: `text_ord*` carries `hm` **as well as** the ordering term, because
+lexicographic ORE/OPE over text is not equality-lossless.
+
+> **Upstream doc bug.** `eql-bindings` `src/v3/mod.rs:26` claims "`ob` for `_ord`/`_ord_ore`,
+> `op` for `_ord_ope`". The generated code disagrees — `IntegerOrd` requires `op`,
+> `IntegerOrdOre` requires `ob`. Trust `term_json_keys_static()`, not that module doc.
+
+### Vocabulary
+
+`EqlTrait` is a **capability**; a **SEM term** (searchable encrypted metadata) is the storage
+that satisfies it. Many-to-one. Neither is an "index" — that word is reserved for a PostgreSQL
+index. The EQL config JSON and `cipherstash_client`'s `ColumnConfig` still spell SEM terms
+`indexes`/`IndexType`; that is a shared wire format and not ours to rename.
+
+---
+
+## 4. Upstream facts worth knowing
+
+**`eql-bindings` 3.0.1** (crates.io) is generated from `eql-domains::CATALOG` by `eql-codegen` —
+the same catalog that generates the SQL. Light deps (serde, serde_json, schemars, ts-rs).
+
+The useful part for us:
+
+```rust
+IntegerOrd::sql_domain_static()      // "public.eql_v3_integer_ord"
+IntegerOrd::term_json_keys_static()  // Some(&["op"])
+```
+
+`v3::all()` enumerates the 53 stored domains, `all_query()` the 39 query twins. Inverting
+`all()` gives a **typname → (token type, required SEM terms)** map straight from the catalog,
+which cannot drift from the SQL. `sql.rs` also embeds `INSTALL_SQL`/`UNINSTALL_SQL` as consts,
+which could replace the `curl` in `mise.toml`'s `eql:download`.
+
+**Containment is gone.** `@>`/`<@` survive only as internal blockers that raise (CIP-3517).
+Fuzzy match is `@@` via `eql_v3.matches`.
+
+**`boolean` is storage-only by design** — no `_eq`, no `_ord`, every operator blocked, because
+a two-value column leaks its distribution under any index.
+
+### The 0.41.1 / 0.42.0 SteVec split — UNRESOLVED
+
+cipherstash-client changed the v3 SteVec wire format and nothing else followed:
+
+| | 0.41.1 (protect-ffi, eql-bindings 3.0.1) | 0.42.0 (what Proxy now pins) |
+|---|---|---|
+| Document | `{v,k,i,sv}` | `{v,k,i,**h**,sv}` |
+| Entry `c` | self-describing mp_base85 record | raw base85 AEAD bytes |
+| Key material | per entry | once, in `h` |
+| Nonce / AAD | data key IV | `selector[..12]` / all 16 selector bytes |
+
+EQL 3.0.1's SQL CHECK accepts **both** (it never forbids extra keys), so the database will not
+catch a mismatch. ProtectJS and Proxy writing encrypted jsonb to the same table would produce
+mutually undecryptable documents. Either Proxy pins back to 0.41.1 or protect-ffi and
+eql-bindings move forward. Not Proxy's call alone. **This is orthogonal to the type checker
+work but blocks shipping.**
+
+### CLLW-ORE data is stranded
+
+`from_v2` returns `UnconvertibleOreTerm` for `oc` SteVec entries — re-encryption is the only
+path. `cipherstash-config` now models this: `IndexType::SteVec { mode }` where
+`SteVecMode::Compat` (CLLW-OPE, `op`) is the default and v3-compatible, and `SteVecMode::Standard`
+(CLLW-ORE, `oc`) is documented upstream as "the legacy v2 protocol, still used by Proxy".
+This is CIP-3233 made explicit in the config model.
+
+---
+
+## 5. Impact map — the type system
+
+Three parallel agents surveyed `eql-mapper`. Findings, with the conflicts resolved.
+
+### Where encrypted types come from
+
+**Only two production sites** construct an `EqlValue` from schema data:
+
+- `inference/unifier/types.rs:508-517` — `Projection::new_from_schema_table`
+- `inference/infer_type_impls/insert_statement.rs:40-49` — INSERT target columns
+
+Both produce `EqlTerm::Full`. Everything else clones. Upstream of both:
+`packages/cipherstash-proxy/src/proxy/schema/manager.rs:142-148`, which matches the single
+string `"eql_v2_encrypted"` and hardcodes `EqlTraits::all()`. **That one match arm is where the
+53-domain mapping has to go.**
+
+### The shapes that must widen
+
+- `EqlValue(TableColumn, EqlTraits)` — `unifier/types.rs:274`
+- `ColumnKind::{Native, Eql(EqlTraits)}` — `model/schema.rs:41-45`
+- `Column::eql(name, features)` — `model/schema.rs:48`
+- `SchemaTableColumn` — `model/schema.rs:63`
+
+There is **no field anywhere in eql-mapper holding a plaintext scalar type for an encrypted
+column.** The `_ord` half of `eql_v3_integer_ord` is derivable from `EqlTraits`; the `integer`
+half is derivable from nothing in the package.
+
+### Two authorities on the scalar type, no reconciliation
+
+The scalar type already exists in the system as `ColumnType`, sourced from the **encrypt config**
+and consumed at `cipherstash-proxy/src/postgresql/data/from_sql.rs:123-292` and
+`context/column.rs:68-86`. Under v3 the **Postgres type name** also encodes it. A config/schema
+disagreement is currently undetectable.
+
+### Encrypted columns never unify with each other
+
+`unifier/types.rs:121` — *"An encrypted column never shares a type with another encrypted column."*
+`unify_types.rs:84-121`: two EQL terms unify iff their `EqlValue`s are `==`, so `TableColumn`
+identity dominates. `users.email = orders.email` is already a type error.
+
+**Therefore a token type is redundant for `Full`/`Full` unification.** Same column → same token
+type, always.
+
+### Literals are inference sinks — CORRECTED FINDING
+
+Two agents disagreed here; resolved by reading the code.
+
+`infer_type_impls/value.rs:19` — a non-placeholder literal unifies with `self.fresh_tvar()`,
+an **unbound variable**, not `Native`. And `(Eql, Native)` is a hard error
+(`unify_types.rs:68-70`).
+
+So `WHERE encrypted_col = 'literal'` works because the literal has no type of its own and
+**absorbs the column's**. Consequence: adding a token type to `EqlValue` buys **zero** literal
+checking — there is nothing for `eql_v3_integer_ord = 'abc'` to contradict. Getting that check
+would require literals to carry a syntactic type they deliberately do not have.
+
+This is not the same as "Native satisfies all bounds". That escape hatch
+(`unifier/eql_traits.rs:279`) is about **bound satisfaction**, not cross-kind unification.
+
+### Bound checking is dead code today
+
+`Unifier::satisfy_bounds` (`unifier/mod.rs:235-248`) and `Type::must_implement`
+(`unifier/types.rs:451-460`) can never fail in production, because:
+
+- every column gets `EqlTraits::all()` (`manager.rs:146`)
+- `Native` ⇒ `ALL_TRAITS` (`eql_traits.rs:279`)
+- `Type::Var` short-circuits to `Ok(())` (`mod.rs:236`)
+
+**Two latent bugs will become user-visible the moment these go live:**
+
+1. `EqlTraits::difference` (`eql_traits.rs:223-231`) is implemented as **XOR**, not set
+   difference. `UnsatisfiedBounds` will report the symmetric difference — listing traits the
+   type *has* but the bound never required.
+2. `must_implement` (`types.rs:456`) passes its operands **reversed** relative to
+   `satisfy_bounds` (`mod.rs:245`). Harmless only because XOR is commutative.
+
+Fix both before making bounds reachable.
+
+### Associated types
+
+`AssociatedTypeSelector { eql_trait, type_name }` (`types.rs:236`) is keyed on
+`(EqlTrait, &'static str)` only. Resolution (`eql_traits.rs:56-115`) maps
+`Eq::Only`/`Ord::Only`/`Contain::Only` → `Partial`, `TokenMatch::Tokenized` → `Tokenized`,
+`JsonLike::{Path,Accessor}` → `JsonPath`/`JsonAccessor`.
+
+**If the token type lives inside `EqlValue`, this machinery needs no change** — every arm does
+`eql_col.clone()`, so it propagates free. Do **not** add a field to `AssociatedTypeSelector`:
+it would break the `lhs.selector == rhs.selector` equality at `unify_types.rs:160` for a
+dimension already determined by `impl_ty`.
+
+---
+
+## 6. Impact map — the SQL surface
+
+### The entire v2 SQL surface is three call sites
+
+Six rules, composed at `type_checked_statement.rs:153-160`. Only three emit SQL.
+
+**`helpers.rs:6-27`** — `cast_as_encrypted`. The single source of every
+`::JSONB::eql_v2_encrypted` cast. Takes **only** an `ast::Value` — no `EqlTerm`, no
+`TableColumn`, no traits. The cast target is a hardcoded `Ident::new("eql_v2_encrypted")`
+at line 17. **This is the one place the v3 domain name would be chosen.**
+
+**`cast_params_as_encrypted.rs:51`** — emits `$1::JSONB::eql_v2_encrypted`. Its gate at line 67
+matches `Some(Type::Value(Value::Eql(_)))` — **the `EqlTerm` is available and discarded by the
+`_`, one line before use.** That is the hook for selecting a `query_<name>` twin.
+
+**`cast_literals_as_encrypted.rs:33`** — emits `'<ciphertext>'::JSONB::eql_v2_encrypted`. Gated
+on map membership, not type. Holds **no `node_types` field at all** (line 13), so it cannot see
+type info even in principle. Needs plumbing, not just a pattern change.
+
+**`rewrite_standard_sql_fns_on_eql_types.rs:59-61`** — blindly prepends `eql_v2` to any
+`pg_catalog.*` name. Emits `eql_v2.{count,min,max,jsonb_path_query,jsonb_path_query_first,
+jsonb_path_exists,jsonb_array_length,jsonb_array_elements,jsonb_array_elements_text}`.
+Note it emits `eql_v2.count`, which **is not in the declaration table** — a name the type
+registry cannot round-trip.
+
+**`rewrite_containment_ops.rs:54-57,86-87`** — `@>` → `eql_v2.jsonb_contains`,
+`<@` → `eql_v2.jsonb_contained_by`. Motivated by GIN index usage, not just type dispatch.
+
+`preserve_effective_aliases.rs` and `fail_on_placeholder_change.rs` emit nothing.
+
+### Rules that exist only because v2 had one opaque type
+
+`RewriteStandardSqlFnsOnEqlTypes` — PG cannot dispatch `min`/`max`/`jsonb_*` on one opaque
+jsonb-backed type, so they are shadowed by hand-written `eql_v2.` overloads. Under v3, PG
+resolves overloads by argument type natively — **but only if v3 ships operator/function
+overloads bound to those domains.** Redundant *conditional on* that, and that is overload
+resolution, not capability-in-the-type. Different mechanisms; verify before assuming.
+
+`RewriteContainmentOps` — same root cause: `@>` cannot be defined on a bare opaque type
+without conflicting with jsonb's own operator.
+
+**Not in this category:** the two cast rules (still needed, only the target changes),
+`PreserveEffectiveAliases` (projection naming, orthogonal), `FailOnPlaceholderChange` (assertion).
+
+### Discipline to preserve
+
+`rewrite_containment_ops.rs:92-99` uses `mem::replace` against a throwaway `Value::Null` rather
+than cloning, specifically so operand `NodeKey` identity survives for the cast rules that run
+after it. **Clone there and literal encryption inside containment expressions silently breaks.**
+
+---
+
+## 7. Impact map — declarations and macros
+
+### Operator → EqlTrait, in full (`inference/sql_types/sql_decls.rs:16-31`)
+
+| Operator | Signature | Trait |
+|---|---|---|
+| `=` `<>` | `<T>(T op T) -> Native` | `Eq` |
+| `<` `<=` `>` `>=` | `<T>(T op T) -> Native` | `Ord` |
+| `->` `->>` | `<T>(T op <T as JsonLike>::Accessor) -> T` | `JsonLike` |
+| `@>` `<@` | `<T>(T op T) -> Native` | `Contain` |
+| `~~` `!~~` `~~*` `!~~*` | `<T>(T op <T as TokenMatch>::Tokenized) -> Native` | `TokenMatch` |
+
+No `@@` is declared. Anything unlisted falls to `Fallback`, which forces lhs, rhs and result
+to `Type::native()` (`sql_binary_operator_types.rs:40-44`).
+
+Functions at `sql_decls.rs:58-79`: `min`/`max` require `Ord`; the `jsonb_*` family requires
+`JsonLike`; `jsonb_array`/`jsonb_contains`/`jsonb_contained_by` require `Contain`; **`count`
+has no bound at all** and accepts any `T` including EQL.
+
+### The macro grammar is capability-only by construction
+
+`eql-mapper-macros/src/parse_type_decl.rs:11-25` — the entire custom-keyword vocabulary is
+`Accessor, Contain, EQL, Eq, Full, JsonLike, Native, Only, Ord, Partial, Path, SetOf, TokenMatch`.
+Every one is a trait name, an associated-type name, or a type constructor. **Not one names a
+data type.**
+
+`EQL(customer.age: Ord)` is expressible. "Encrypted integer with Ord" is not — not in the
+keyword table, not in the grammar, not in the generated `EqlValue`. A v3 port needs a new
+lexical class, new productions in `EqlTerm` (`:289-331`) and `VarDecl` (`:70-91`), and a
+widened payload. Work is concentrated in that one file.
+
+`@@` will not parse today: `token::At` at `:480` unconditionally expects a following `Gt`.
+
+### Things that become ambiguous with a token type
+
+1. **`<T>(T = T)` — the core ambiguity.** One tvar currently conflates *same column*, *same
+   token type*, and *any encrypted*. Indistinguishable today because encrypted identity **is**
+   the column.
+2. **`EqlTerm::Partial`'s union-on-unify** (`unify_types.rs:91`) accumulates capabilities
+   monotonically. If capability is fixed by the domain, you cannot union your way into a
+   capability the column does not have.
+3. **The payload-less variants** — `JsonAccessor`, `JsonPath`, `Tokenized` all return
+   `EqlTraits::none()` (`eql_traits.rs:320-322`). "A tokenized *what*" needs answering.
+4. **`Native` ⇒ `ALL_TRAITS`** and **`Type::Var` ⇒ `Ok(())`** are two independent wildcards in
+   the bound checker.
+
+### Pre-existing gaps this work will expose
+
+- **`Expr::Like`/`ILike` bypass the trait system entirely.** `infer_type_impls/expr.rs:115-131`
+  only unifies the result with `Native` — never requires `TokenMatch`, never produces a
+  `Tokenized` term. The `~~` declarations fire only on the operator form. LIKE on an encrypted
+  column is currently unchecked.
+- **`schema_delta.rs:447,479,529` uses `EqlTraits::default()`** (all false) while the loader uses
+  `all()` (all true). The two paths disagree. Invisible while bounds are dead.
+- **Empty projections** return `EqlTraits::none()` (`eql_traits.rs:310`) while the
+  `satisfy_bounds` doc (`mod.rs:220`) says they satisfy all bounds. Doc and code disagree.
+- `EqlTrait` parse error string (`parse_type_decl.rs:172`) is stale — omits `Contain`.
+
+### Removing `Contain` touches
+
+Keyword table (`parse_type_decl.rs:13`), enum (`eql_traits.rs:23`), assoc types (`:39`),
+resolution (`:73`, `:101-105`), `ALL_TRAITS` (`:154`), struct field (`:145`), `add_mut` (`:200`),
+`to_eql_trait_impls!` (`schema.rs:225-227`), two operators (`sql_decls.rs:25-26`), three
+functions (`sql_decls.rs:76-78`).
+
+---
+
+## 8. Open design questions — the grill agenda
+
+**The framing question.** The research says the token type's job is **naming a v3 domain at
+cast time**, not type checking: it is redundant for unification (§5), and it buys no literal
+checking (§5). So — does it belong in the type lattice at all, or should the transformation
+rules look the domain up from the schema by `TableColumn` at emit time and leave the lattice
+alone? The second is materially cheaper and nothing found so far rules it out. **Settle this
+before anything else; most other answers follow from it.**
+
+Then:
+
+1. If it does go in the lattice: inside `EqlValue` (associated types come free, all six
+   unification arms come free) or on `EqlTerm` (six explicit merges)?
+2. `_ord` vs `_ord_ope` vs `_ord_ore` — identical operators, different SEM terms. Does the type
+   checker distinguish them, or is that purely a cast-target concern?
+3. `integer_eq` and `bigint_eq` are byte-identical on the wire but different domains. Type error
+   to compare? (Note: already a type error via `TableColumn` identity — is that enough?)
+4. What replaces `Contain`? `@>`/`<@` are **directional**; `@@`/`eql_v3.matches` is **symmetric**.
+   `<@` has nowhere to go. Delete the trait, or repoint at `@@` and lose direction?
+5. Do bounds go live? Real errors for `ORDER BY` on an `_eq` column — but the domain CHECK
+   catches it anyway, and `sql_decls.rs:49` states the existing philosophy is *"let the database
+   do its job."* Does v3 change that stance?
+6. Params must cast to `eql_v3.query_<name>` twins, not the stored domain. Does the mapper need
+   the query inventory too, or can the twin name be derived by prefixing?
+7. Which authority owns an encrypted column's scalar type — `pg_type` or the encrypt config?
+   Should the other be cross-checked?
+8. Does `eql-bindings` become a dependency of `eql-mapper` (inverting `all()` into a
+   typname → capability map), or does the mapper keep its own table?
+
+### Prerequisites, whatever the design
+
+- Fix `EqlTraits::difference` XOR bug and the reversed `must_implement` operands **before**
+  bounds become reachable.
+- Reconcile `schema_delta.rs`'s `default()` with the loader's `all()`.
+- Verify whether EQL 3 ships operator/function overloads bound to the domains — that alone
+  decides whether `RewriteStandardSqlFnsOnEqlTypes` retires.
+
+---
+
+## 9. Related memory
+
+`~/.claude/projects/-Users-jamessadler-cipherstash-proxy/memory/`:
+`eql-3-upgrade-in-flight.md`, `cip-3233-client-038-ore-cllw-break.md`,
+`proxy-222-stackauth-15min-auth-bug.md`.

--- a/mise.local.example.toml
+++ b/mise.local.example.toml
@@ -15,7 +15,7 @@ CS_CLIENT_KEY = "client-key"
 CS_CLIENT_ID = "client-id"
 
 # The release of EQL that the proxy tests will use and releases will be built with
-CS_EQL_VERSION = "eql-2.3.0-pre.3"
+CS_EQL_VERSION = "eql-3.0.1"
 
 # TLS variables are required for providing TLS to Proxy's clients.
 # CS_TLS__TYPE can be either "Path" or "Pem" (case-sensitive).

--- a/mise.toml
+++ b/mise.toml
@@ -34,7 +34,7 @@ CS_PROXY__HOST = "host.docker.internal"
 # Misc
 DOCKER_CLI_HINTS = "false" # Please don't show us What's Next.
 
-CS_EQL_VERSION = "eql-2.3.0-pre.3"
+CS_EQL_VERSION = "eql-3.0.1"
 
 
 [tools]

--- a/packages/cipherstash-proxy/CONTEXT.md
+++ b/packages/cipherstash-proxy/CONTEXT.md
@@ -1,0 +1,115 @@
+# Proxy
+
+Speaks the PostgreSQL wire protocol to client applications, hands their SQL to EQL Mapper
+for type checking and rewriting, encrypts and decrypts column values through ZeroKMS, and
+forwards everything to the real database. It owns everything about *connections* and
+*ciphertext*; it owns nothing about type inference.
+
+## Language
+
+### Connections and statements
+
+**Connection**:
+One client application's TCP connection to Proxy, from startup to termination. All
+per-client state hangs off it.
+_Avoid_: session — PostgreSQL already owns that word for something else, and this
+codebase has used it for both a connection and a single statement.
+
+**Context**:
+The mutable state belonging to one connection — its prepared statements, portals,
+pending describes and executes, and keyset.
+
+**Frontend** / **Backend**:
+The two halves of the proxy pipeline by direction of travel: Frontend carries client to
+database, Backend carries database to client. These are *not* the PostgreSQL protocol's
+frontend/backend roles, and Backend is not the database.
+
+**Statement**:
+A type-analysed SQL statement — its param columns, projection columns, literal columns
+and PostgreSQL param type OIDs. The parsed AST and EQL Mapper's `TypeCheckedStatement`
+are different things; do not call either of them a Statement here.
+
+**Portal**:
+A prepared statement bound to parameter values, ready to execute. Either `Encrypted`,
+carrying the analysed statement, or `Passthrough` when nothing in it is encrypted.
+
+**Statement metrics scope**:
+The measurement window around a single statement — opened at Parse or Query, closed when
+the statement completes. Many of these occur per connection.
+_Avoid_: session (`start_session`, `SessionId` and the
+`..._statements_session_duration_seconds` metric all use this sense and are misnamed).
+
+**Passthrough**:
+Traffic forwarded without encryption or rewriting. Three independent conditions produce
+it and they are not interchangeable: no encrypt config is loaded, mapping is disabled by
+configuration, or `SET CIPHERSTASH.UNSAFE_DISABLE_MAPPING` was issued on this connection.
+Name the condition rather than saying "passthrough" alone.
+
+### Encryption
+
+**Column**:
+An encrypted column as this crate sees it — its `Identifier`, its column config, its
+resolved PostgreSQL type, and the EQL term shape it takes in the current statement.
+_Avoid_: confusing with EQL Mapper's schema/projection columns, or with `DataColumn`
+(a value on the wire) and `RowDescriptionField` (a result descriptor).
+
+**Identifier**:
+The `table.column` pair that keys the encrypt config. EQL Mapper calls the same thing a
+`TableColumn`.
+
+**Encrypt credentials**:
+The CipherStash client credentials Proxy authenticates to ZeroKMS with — client id,
+client key, default keyset. Read from `[encrypt]` / `CS_ENCRYPT__*`.
+_Avoid_: `EncryptConfig`, which currently names this *and* an unrelated struct.
+
+**Column encrypt config**:
+The per-column encryption configuration — which columns are encrypted and with which SEM
+terms — read from the EQL config table in the *database* at runtime, and reloaded when
+DDL is observed.
+_Avoid_: `EncryptConfig`; also "encrypt schema", despite `ReloadCommand::EncryptSchema`
+naming the reload of this thing.
+
+**Client id**:
+Ambiguous — always qualify. The **connection number** is the incrementing counter stamped
+on log lines to correlate one connection's traffic. The **CipherStash client id** is the
+credential UUID from `CS_ENCRYPT__CLIENT_ID`. They share a name and a field spelling and
+are otherwise unrelated.
+
+**Keyset**:
+The ZeroKMS collection of keys a workspace encrypts against. Addressed by UUID or by
+name, and selectable per connection via `SET CIPHERSTASH.KEYSET_ID` / `KEYSET_NAME`.
+
+**Scoped cipher**:
+A cipher bound to exactly one keyset. Cached per keyset, so switching keyset switches
+cipher.
+
+**Plaintext**:
+A value in its typed, pre-encryption form. The boundary type between PostgreSQL wire
+values and ZeroKMS.
+
+**EQL ciphertext**:
+An encrypted value in the shape stored in the database. What encryption produces and
+decryption consumes.
+
+**Store** / **Query** operation:
+The two directions of encryption. Storing writes a value with all its SEM terms; querying
+produces only the term needed to match. The statement's EQL term shape decides which.
+
+### Control plane
+
+**`SET CIPHERSTASH.*`**:
+Proxy's in-band control API, intercepted rather than forwarded — `KEYSET_ID`,
+`KEYSET_NAME`, `UNSAFE_DISABLE_MAPPING`. These are the supported spellings; log messages
+that print `CIPHERSTASH.DISABLE_MAPPING` are wrong.
+
+**Reload**:
+Re-reading state from the database after observed DDL. Two independent things reload: the
+database schema, and the column encrypt config.
+
+## Note on `session`
+
+This glossary bans `session` because the code uses it for two different things and
+PostgreSQL uses it for a third. The identifiers `SessionId`, `start_session`,
+`finish_session` and the Prometheus metric name all still carry it. Read them as
+*statement metrics scope*; the doc comments on `Frontend` and `Backend` that say "session
+context" mean *connection*.

--- a/packages/cipherstash-proxy/src/error.rs
+++ b/packages/cipherstash-proxy/src/error.rs
@@ -254,6 +254,15 @@ pub enum EncryptError {
     #[error("InvalidIndexTerm")]
     InvalidIndexTerm,
 
+    /// EQL v3 SteVec (jsonb) documents carry the key header once at the document
+    /// root and raw AEAD bytes per entry, so an `EncryptedRecord` has to be
+    /// reassembled from `h` + `sv[0].c` before it can be decrypted.
+    /// cipherstash-client exposes no `decrypt_eql_v3`, and reassembling the
+    /// record here would hard-code the envelope layout. Blocked until the client
+    /// provides a v3 decrypt path.
+    #[error("Decrypting EQL v3 jsonb (SteVec) columns is not yet supported")]
+    SteVecV3DecryptUnsupported,
+
     #[error(
         "KeysetId `{id}` could not be parsed using `SET CIPHERSTASH.KEYSET_ID`. KeysetId should be a valid UUID. For help visit {}#encrypt-keyset-id-could-not-be-parsed",
         ERROR_DOC_BASE_URL

--- a/packages/cipherstash-proxy/src/error.rs
+++ b/packages/cipherstash-proxy/src/error.rs
@@ -254,6 +254,13 @@ pub enum EncryptError {
     #[error("InvalidIndexTerm")]
     InvalidIndexTerm,
 
+    /// EQL v3 orders encrypted jsonb entries by the CLLW-OPE (`op`) term and has
+    /// no representation for CLLW-ORE (`oc`), so a column configured for
+    /// Standard-mode ste_vec cannot be encrypted. The column has to be
+    /// reconfigured and its data re-encrypted.
+    #[error("An encrypted jsonb column is configured for ORE ordering, which EQL v3 does not support. For help visit {}#encrypt-ste-vec-ore-mode-unsupported", ERROR_DOC_BASE_URL)]
+    SteVecOreModeUnsupported,
+
     /// `sv[0]` is the decryption root of a SteVec document, so an empty `sv`
     /// array leaves nothing to decrypt.
     #[error("Encrypted jsonb value has no root entry and cannot be decrypted")]
@@ -350,10 +357,28 @@ impl From<cipherstash_client::eql::EqlError> for EncryptError {
             cipherstash_client::eql::EqlError::ColumnConfigurationMismatch { table, column } => {
                 Self::ColumnConfigurationMismatch { table, column }
             }
-            cipherstash_client::eql::EqlError::CouldNotDecryptDataForKeyset { keyset_id } => {
-                Self::CouldNotDecryptDataForKeyset { keyset_id }
-            }
+            // cipherstash-client 0.42.0 added a `#[source]` zerokms::Error here
+            // so callers can walk the chain to the underlying RetrieveKeyError.
+            // Proxy's variant carries only the keyset id, so the chain stops at
+            // this boundary — worth threading through if a keyset decrypt
+            // failure ever needs diagnosing from Proxy's logs alone.
+            cipherstash_client::eql::EqlError::CouldNotDecryptDataForKeyset {
+                keyset_id, ..
+            } => Self::CouldNotDecryptDataForKeyset { keyset_id },
             cipherstash_client::eql::EqlError::InvalidIndexTerm => Self::InvalidIndexTerm,
+
+            // EQL v3 orders jsonb entries by the byte-comparable CLLW-OPE `op`
+            // term and has no CLLW-ORE (`oc`) representation, so a SteVec column
+            // still configured in Standard mode cannot be written at all.
+            cipherstash_client::eql::EqlError::UnsupportedSteVecOreInV3 => {
+                Self::SteVecOreModeUnsupported
+            }
+
+            cipherstash_client::eql::EqlError::UnsupportedV3QueryTerm => Self::InvalidIndexTerm,
+
+            // Only reachable by asking the client for a v2 payload, which Proxy
+            // never does — v3 is the only envelope it speaks.
+            cipherstash_client::eql::EqlError::UnsupportedSteVecInV2 => Self::InvalidIndexTerm,
             cipherstash_client::eql::EqlError::MissingCiphertext(identifier) => {
                 Self::ColumnCouldNotBeDeserialised {
                     table: identifier.table,

--- a/packages/cipherstash-proxy/src/error.rs
+++ b/packages/cipherstash-proxy/src/error.rs
@@ -254,14 +254,15 @@ pub enum EncryptError {
     #[error("InvalidIndexTerm")]
     InvalidIndexTerm,
 
-    /// EQL v3 SteVec (jsonb) documents carry the key header once at the document
-    /// root and raw AEAD bytes per entry, so an `EncryptedRecord` has to be
-    /// reassembled from `h` + `sv[0].c` before it can be decrypted.
-    /// cipherstash-client exposes no `decrypt_eql_v3`, and reassembling the
-    /// record here would hard-code the envelope layout. Blocked until the client
-    /// provides a v3 decrypt path.
-    #[error("Decrypting EQL v3 jsonb (SteVec) columns is not yet supported")]
-    SteVecV3DecryptUnsupported,
+    /// `sv[0]` is the decryption root of a SteVec document, so an empty `sv`
+    /// array leaves nothing to decrypt.
+    #[error("Encrypted jsonb value has no root entry and cannot be decrypted")]
+    SteVecMissingRootEntry,
+
+    /// A SteVec entry's selector is the source of both AEAD bindings (nonce and
+    /// AAD), so it must be exactly 16 hex-encoded bytes.
+    #[error("Encrypted jsonb entry has an invalid selector '{selector}'")]
+    SteVecSelectorInvalid { selector: String },
 
     #[error(
         "KeysetId `{id}` could not be parsed using `SET CIPHERSTASH.KEYSET_ID`. KeysetId should be a valid UUID. For help visit {}#encrypt-keyset-id-could-not-be-parsed",

--- a/packages/cipherstash-proxy/src/lib.rs
+++ b/packages/cipherstash-proxy/src/lib.rs
@@ -16,13 +16,20 @@ pub use crate::config::{DatabaseConfig, ServerConfig, TandemConfig, TlsConfig};
 pub use crate::log::init;
 pub use crate::proxy::Proxy;
 pub use cipherstash_client::encryption::Plaintext;
-pub use cipherstash_client::eql::{EqlCiphertext, Identifier};
+// EQL v3 is the only wire envelope Proxy speaks. The v2 types
+// (`EqlCiphertext`, `EqlOutput`, `EqlQueryPayload`) are deliberately not
+// re-exported — v2 support is retired, so anything still reaching for them
+// should fail to resolve rather than silently keep writing v2 payloads.
+pub use cipherstash_client::eql::{
+    EqlCiphertextV3 as EqlCiphertext, EqlOutputV3 as EqlOutput,
+    EqlQueryPayloadV3 as EqlQueryPayload, Identifier,
+};
 
 use std::mem;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub const EQL_SCHEMA_VERSION: u16 = 2;
+pub const EQL_SCHEMA_VERSION: u16 = 3;
 
 pub const SIZE_U8: usize = mem::size_of::<u8>();
 pub const SIZE_I16: usize = mem::size_of::<i16>();

--- a/packages/cipherstash-proxy/src/postgresql/backend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/backend.rs
@@ -19,8 +19,8 @@ use crate::prometheus::{
     ROWS_PASSTHROUGH_TOTAL, ROWS_TOTAL, SERVER_BYTES_RECEIVED_TOTAL,
 };
 use crate::proxy::EncryptionService;
+use crate::EqlCiphertext;
 use bytes::BytesMut;
-use cipherstash_client::eql::EqlCiphertext;
 use metrics::{counter, histogram};
 use std::time::Instant;
 use tokio::io::AsyncRead;
@@ -538,7 +538,7 @@ where
         for (col, ct) in projection_columns.iter().zip(ciphertexts) {
             match (col, ct) {
                 (Some(col), Some(ct)) => {
-                    if col.identifier != ct.identifier {
+                    if &col.identifier != ct.identifier() {
                         return Err(EncryptError::ColumnConfigurationMismatch {
                             table: col.identifier.table.to_owned(),
                             column: col.identifier.column.to_owned(),
@@ -553,8 +553,8 @@ where
                 // ciphertext with no column configuration is bad
                 (None, Some(ct)) => {
                     return Err(EncryptError::ColumnConfigurationMismatch {
-                        table: ct.identifier.table.to_owned(),
-                        column: ct.identifier.column.to_owned(),
+                        table: ct.identifier().table.to_owned(),
+                        column: ct.identifier().column.to_owned(),
                     }
                     .into());
                 }
@@ -749,7 +749,7 @@ mod tests {
             _keyset_id: Option<KeysetIdentifier>,
             _plaintexts: Vec<Option<cipherstash_client::encryption::Plaintext>>,
             _columns: &[Option<Column>],
-        ) -> Result<Vec<Option<crate::EqlCiphertext>>, Error> {
+        ) -> Result<Vec<Option<crate::EqlOutput>>, Error> {
             Ok(vec![])
         }
 

--- a/packages/cipherstash-proxy/src/postgresql/context/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/context/mod.rs
@@ -752,7 +752,7 @@ where
         &self,
         plaintexts: Vec<Option<cipherstash_client::encryption::Plaintext>>,
         columns: &[Option<Column>],
-    ) -> Result<Vec<Option<crate::EqlCiphertext>>, Error> {
+    ) -> Result<Vec<Option<crate::EqlOutput>>, Error> {
         let keyset_id = self.keyset_identifier();
 
         self.encryption
@@ -1077,7 +1077,7 @@ mod tests {
             _keyset_id: Option<KeysetIdentifier>,
             _plaintexts: Vec<Option<cipherstash_client::encryption::Plaintext>>,
             _columns: &[Option<Column>],
-        ) -> Result<Vec<Option<crate::EqlCiphertext>>, Error> {
+        ) -> Result<Vec<Option<crate::EqlOutput>>, Error> {
             Ok(vec![])
         }
 

--- a/packages/cipherstash-proxy/src/postgresql/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/frontend.rs
@@ -27,7 +27,7 @@ use crate::prometheus::{
     STATEMENTS_PASSTHROUGH_TOTAL, STATEMENTS_UNMAPPABLE_TOTAL,
 };
 use crate::proxy::EncryptionService;
-use crate::EqlCiphertext;
+use crate::EqlOutput;
 use bytes::BytesMut;
 use cipherstash_client::encryption::Plaintext;
 use eql_mapper::{self, EqlMapperError, EqlTerm, TypeCheckedStatement};
@@ -582,13 +582,13 @@ where
     /// # Returns
     ///
     /// Vector of encrypted values corresponding to each literal, with `None` for
-    /// literals that don't require encryption and `Some(EqlCiphertext)` for encrypted values.
+    /// literals that don't require encryption and `Some(EqlOutput)` for encrypted values.
     async fn encrypt_literals(
         &mut self,
         session_id: SessionId,
         typed_statement: &TypeCheckedStatement<'_>,
         literal_columns: &Vec<Option<Column>>,
-    ) -> Result<Vec<Option<EqlCiphertext>>, Error> {
+    ) -> Result<Vec<Option<EqlOutput>>, Error> {
         let literal_values = typed_statement.literal_values();
         if literal_values.is_empty() {
             debug!(target: MAPPER,
@@ -643,7 +643,7 @@ where
     async fn transform_statement(
         &mut self,
         typed_statement: &TypeCheckedStatement<'_>,
-        encrypted_literals: &Vec<Option<EqlCiphertext>>,
+        encrypted_literals: &Vec<Option<EqlOutput>>,
     ) -> Result<Option<ast::Statement>, Error> {
         // Convert literals to ast Expr
         let mut encrypted_expressions = vec![];
@@ -1042,7 +1042,7 @@ where
         session_id: Option<SessionId>,
         bind: &Bind,
         statement: &Statement,
-    ) -> Result<Vec<Option<crate::EqlCiphertext>>, Error> {
+    ) -> Result<Vec<Option<crate::EqlOutput>>, Error> {
         let plaintexts =
             bind.to_plaintext(&statement.param_columns, &statement.postgres_param_types)?;
 

--- a/packages/cipherstash-proxy/src/postgresql/messages/bind.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/bind.rs
@@ -5,10 +5,10 @@ use crate::postgresql::context::column::Column;
 use crate::postgresql::data::bind_param_from_sql;
 use crate::postgresql::format_code::FormatCode;
 use crate::postgresql::protocol::BytesMutReadString;
+use crate::EqlOutput;
 use crate::{SIZE_I16, SIZE_I32};
 use bytes::{Buf, BufMut, BytesMut};
 use cipherstash_client::encryption::Plaintext;
-use cipherstash_client::eql::EqlCiphertext;
 use postgres_types::Type;
 use std::fmt::{self, Display, Formatter};
 use std::io::Cursor;
@@ -81,7 +81,7 @@ impl Bind {
         Ok(plaintexts)
     }
 
-    pub fn rewrite(&mut self, encrypted: Vec<Option<EqlCiphertext>>) -> Result<(), Error> {
+    pub fn rewrite(&mut self, encrypted: Vec<Option<EqlOutput>>) -> Result<(), Error> {
         for (idx, ct) in encrypted.iter().enumerate() {
             if let Some(ct) = ct {
                 let json = serde_json::to_value(ct)?;

--- a/packages/cipherstash-proxy/src/postgresql/messages/data_row.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/data_row.rs
@@ -1,13 +1,17 @@
 use super::{BackendCode, NULL};
+use crate::EqlCiphertext;
 use crate::{
     error::{EncryptError, Error, ProtocolError},
     log::DECRYPT,
     postgresql::Column,
 };
 use bytes::{Buf, BufMut, BytesMut};
-use cipherstash_client::eql::EqlCiphertext;
 use std::io::Cursor;
 use tracing::{debug, error};
+
+/// Leading byte of `jsonb`'s binary wire format. PostgreSQL has only ever
+/// emitted version 1.
+const JSONB_BINARY_VERSION: u8 = 1;
 
 #[derive(Debug, Clone)]
 pub struct DataRow {
@@ -179,61 +183,33 @@ impl TryFrom<&mut DataColumn> for EqlCiphertext {
     type Error = Error;
 
     fn try_from(col: &mut DataColumn) -> Result<Self, Error> {
-        if let Some(bytes) = &col.bytes {
-            if &bytes[0..=1] == b"(\"" {
-                // Text encoding
-                // Encrypted record is in the form ("{}")
-                // json data can be extracted by dropping the first and last two bytes to remove (" and ")
-                let start = 2;
-                let end = bytes.len() - 2;
-                let sliced = &bytes[start..end];
+        // EQL v3 column types (`eql_v3_text_eq`, `eql_v3_integer_ord`, …) are
+        // DOMAINS over `jsonb`, so a value arrives with jsonb's representation.
+        //
+        // EQL v2's `eql_v2_encrypted` was a composite type, which is why this
+        // used to strip a `("…")` wrapper in text and a 12-byte rowtype header
+        // in binary. Neither exists any more — a domain is wire-identical to its
+        // base type.
+        //
+        //   text   — the JSON object itself, no wrapper and no doubled quotes
+        //   binary — a 1-byte jsonb version header followed by the JSON text
+        //
+        // The two are told apart by the leading byte: the version header is
+        // `0x01`, and JSON text for an EQL payload always starts with `{`.
+        let Some(bytes) = &col.bytes else {
+            return Err(EncryptError::ColumnCouldNotBeParsed.into());
+        };
 
-                let input = String::from_utf8_lossy(sliced).to_string();
-                let input = input.replace("\"\"", "\"");
+        let json = match bytes.first() {
+            Some(&JSONB_BINARY_VERSION) => &bytes[1..],
+            Some(_) => &bytes[..],
+            None => return Err(EncryptError::ColumnCouldNotBeParsed.into()),
+        };
 
-                match serde_json::from_str(&input) {
-                    Ok(e) => return Ok(e),
-                    Err(err) => {
-                        debug!(target: DECRYPT, error = err.to_string());
-                        return Err(err.into());
-                    }
-                }
-            } else {
-                // BINARY ENCODING
-                // 12 bytes for the binary rowtype header
-                // plus 1 byte for the jsonb header (value of 1)
-                // [Int32] Number of fields (N)
-                // [Int32] OID of the field’s type
-                // [Int32] Length of the field (in bytes), or -1 for NULL
-
-                let start = 4 + 4;
-                let end = 4 + 4 + 4;
-
-                let mut len_bytes = [0u8; 4]; // Create a fixed-size array
-                len_bytes.copy_from_slice(&bytes[start..end]);
-
-                let len = i32::from_be_bytes(len_bytes);
-
-                if len == NULL {
-                    return Err(EncryptError::ColumnIsNull.into());
-                }
-
-                let start = 12 + 1;
-                let sliced = &bytes[start..];
-
-                match serde_json::from_slice(sliced) {
-                    Ok(e) => {
-                        return Ok(e);
-                    }
-                    Err(err) => {
-                        debug!(target: DECRYPT, error = err.to_string());
-                        return Err(err.into());
-                    }
-                }
-            }
-        }
-
-        Err(EncryptError::ColumnCouldNotBeParsed.into())
+        serde_json::from_slice(json).map_err(|err| {
+            debug!(target: DECRYPT, error = err.to_string());
+            err.into()
+        })
     }
 }
 
@@ -283,8 +259,8 @@ mod tests {
         assert!(encrypted[1].is_some());
 
         assert_eq!(
-            column_config[1].as_ref().unwrap().identifier,
-            encrypted[1].as_ref().unwrap().identifier
+            &column_config[1].as_ref().unwrap().identifier,
+            encrypted[1].as_ref().unwrap().identifier()
         );
     }
 
@@ -332,8 +308,8 @@ mod tests {
         assert!(encrypted[0].is_some());
 
         assert_eq!(
-            column_config[0].as_ref().unwrap().identifier,
-            encrypted[0].as_ref().unwrap().identifier
+            &column_config[0].as_ref().unwrap().identifier,
+            encrypted[0].as_ref().unwrap().identifier()
         );
     }
 
@@ -373,8 +349,8 @@ mod tests {
         // etc
 
         assert_eq!(
-            column_config[2].as_ref().unwrap().identifier,
-            encrypted[2].as_ref().unwrap().identifier
+            &column_config[2].as_ref().unwrap().identifier,
+            encrypted[2].as_ref().unwrap().identifier()
         );
     }
 

--- a/packages/cipherstash-proxy/src/proxy/encrypt_config/manager.rs
+++ b/packages/cipherstash-proxy/src/proxy/encrypt_config/manager.rs
@@ -248,7 +248,9 @@ fn canonical_to_map(canonical: CanonicalEncryptionConfig) -> Result<EncryptConfi
 mod tests {
     use super::*;
     use cipherstash_client::eql::Identifier;
-    use cipherstash_config::column::{ArrayIndexMode, IndexType, TokenFilter, Tokenizer};
+    use cipherstash_config::column::{
+        ArrayIndexMode, IndexType, SteVecMode, TokenFilter, Tokenizer,
+    };
     use cipherstash_config::ColumnType;
     use serde_json::json;
 
@@ -518,6 +520,7 @@ mod tests {
                 prefix: "event-data".into(),
                 term_filters: vec![],
                 array_index_mode: ArrayIndexMode::ALL,
+                mode: SteVecMode::Compat,
             },
         );
     }

--- a/packages/cipherstash-proxy/src/proxy/mod.rs
+++ b/packages/cipherstash-proxy/src/proxy/mod.rs
@@ -88,7 +88,7 @@ impl Proxy {
     pub async fn eql_version(config: &TandemConfig) -> Result<Option<String>, Error> {
         let client = connect::database(&config.database).await?;
         let rows = client
-            .query("SELECT eql_v2.version() AS version;", &[])
+            .query("SELECT eql_v3.version() AS version;", &[])
             .await;
 
         let version = match rows {
@@ -156,7 +156,7 @@ pub trait EncryptionService: Send + Sync {
         keyset_id: Option<KeysetIdentifier>,
         plaintexts: Vec<Option<Plaintext>>,
         columns: &[Option<Column>],
-    ) -> Result<Vec<Option<crate::EqlCiphertext>>, Error>;
+    ) -> Result<Vec<Option<crate::EqlOutput>>, Error>;
 
     /// Decrypt values retrieved from the database
     async fn decrypt(

--- a/packages/cipherstash-proxy/src/proxy/zerokms/zerokms.rs
+++ b/packages/cipherstash-proxy/src/proxy/zerokms/zerokms.rs
@@ -10,12 +10,13 @@ use crate::{
     proxy::EncryptionService,
 };
 use cipherstash_client::{
-    encryption::{Plaintext, QueryOp},
+    encryption::{DecryptOptions, Plaintext, QueryOp},
     eql::{
-        decrypt_eql, encrypt_eql, EqlCiphertext, EqlDecryptOpts, EqlEncryptOpts, EqlOperation,
+        encrypt_eql_v3, EqlCiphertextV3, EqlEncryptOpts, EqlOperation, EqlOutputV3,
         PreparedPlaintext,
     },
     schema::column::IndexType,
+    zerokms::WithContext,
 };
 use eql_mapper::EqlTermVariant;
 use metrics::{counter, histogram};
@@ -157,7 +158,7 @@ impl EncryptionService for ZeroKms {
         keyset_id: Option<KeysetIdentifier>,
         plaintexts: Vec<Option<Plaintext>>,
         columns: &[Option<Column>],
-    ) -> Result<Vec<Option<EqlCiphertext>>, Error> {
+    ) -> Result<Vec<Option<EqlOutputV3>>, Error> {
         debug!(target: ENCRYPT, msg="Encrypt", ?keyset_id, default_keyset_id = ?self.default_keyset_id);
 
         // A keyset is required if no default keyset has been configured
@@ -222,16 +223,16 @@ impl EncryptionService for ZeroKms {
         // Use default opts since cipher is already initialized with the correct keyset
         let opts = EqlEncryptOpts::default();
 
-        debug!(target: ENCRYPT, msg="Calling encrypt_eql", count = prepared_plaintexts.len());
+        debug!(target: ENCRYPT, msg="Calling encrypt_eql_v3", count = prepared_plaintexts.len());
         let encrypt_start = Instant::now();
-        let encrypted = encrypt_eql(cipher, prepared_plaintexts, &opts)
+        let encrypted = encrypt_eql_v3(cipher, prepared_plaintexts, &opts)
             .await
             .map_err(EncryptError::from)?;
         let encrypt_duration = encrypt_start.elapsed();
-        debug!(target: ENCRYPT, msg="encrypt_eql completed", count = encrypted.len(), duration_ms = encrypt_duration.as_millis());
+        debug!(target: ENCRYPT, msg="encrypt_eql_v3 completed", count = encrypted.len(), duration_ms = encrypt_duration.as_millis());
 
         // Reconstruct the result vector with None values in the right places
-        let mut result: Vec<Option<EqlCiphertext>> = vec![None; plaintexts.len()];
+        let mut result: Vec<Option<EqlOutputV3>> = vec![None; plaintexts.len()];
         for (idx, ciphertext) in indices.into_iter().zip(encrypted.into_iter()) {
             result[idx] = Some(ciphertext);
         }
@@ -247,7 +248,7 @@ impl EncryptionService for ZeroKms {
     async fn decrypt(
         &self,
         keyset_id: Option<KeysetIdentifier>,
-        ciphertexts: Vec<Option<EqlCiphertext>>,
+        ciphertexts: Vec<Option<EqlCiphertextV3>>,
     ) -> Result<Vec<Option<Plaintext>>, Error> {
         debug!(target: ENCRYPT, msg="Decrypt", ?keyset_id, default_keyset_id = ?self.default_keyset_id);
 
@@ -258,32 +259,52 @@ impl EncryptionService for ZeroKms {
 
         let cipher = self.init_cipher(keyset_id.clone()).await?;
 
-        // Collect indices and ciphertexts for non-None values
+        // Collect indices and the root records for non-None values.
+        //
+        // cipherstash-client has no `decrypt_eql_v3` counterpart to
+        // `encrypt_eql_v3` — the v2 `decrypt_eql` only accepts `EqlCiphertext`.
+        // For scalar payloads that costs us nothing: `EncryptedPayloadV3.c` is
+        // the same `EncryptedRecord` the v2 path would have unwrapped, and
+        // `EncryptedRecord` is itself `Decryptable`, so we hand it straight to
+        // the cipher. SteVec documents are the part that genuinely needs the
+        // client (see `SteVecV3DecryptUnsupported`).
         let mut indices: Vec<usize> = Vec::new();
-        let mut ciphertexts_to_decrypt: Vec<EqlCiphertext> = Vec::new();
+        let mut records_to_decrypt = Vec::new();
 
         for (idx, ct_opt) in ciphertexts.iter().enumerate() {
             if let Some(ct) = ct_opt {
+                let record = match ct {
+                    EqlCiphertextV3::Encrypted(payload) => payload.ciphertext.clone(),
+                    EqlCiphertextV3::SteVec(_) => {
+                        return Err(EncryptError::SteVecV3DecryptUnsupported.into())
+                    }
+                };
                 indices.push(idx);
-                ciphertexts_to_decrypt.push(ct.clone());
+                records_to_decrypt.push(record);
             }
         }
 
         // If no ciphertexts to decrypt, return all None
-        if ciphertexts_to_decrypt.is_empty() {
+        if records_to_decrypt.is_empty() {
             return Ok(vec![None; ciphertexts.len()]);
         }
 
-        // Use default opts since cipher is already initialized with the correct keyset
-        let opts = EqlDecryptOpts::default();
+        // Default opts: the cipher is already scoped to the right keyset, and
+        // Proxy does not set a lock context.
+        let opts = DecryptOptions::default();
 
-        debug!(target: ENCRYPT, msg="Calling decrypt_eql", count = ciphertexts_to_decrypt.len());
+        debug!(target: ENCRYPT, msg="Decrypting EQL v3 records", count = records_to_decrypt.len());
         let decrypt_start = Instant::now();
-        let decrypted = decrypt_eql(cipher, ciphertexts_to_decrypt, &opts)
+        let decrypted = cipher
+            .decrypt(records_to_decrypt, &opts)
             .await
+            .map_err(ZeroKMSError::from)?
+            .into_iter()
+            .map(|bytes| Plaintext::from_slice(&bytes))
+            .collect::<Result<Vec<_>, _>>()
             .map_err(EncryptError::from)?;
         let decrypt_duration = decrypt_start.elapsed();
-        debug!(target: ENCRYPT, msg="decrypt_eql completed", count = decrypted.len(), duration_ms = decrypt_duration.as_millis());
+        debug!(target: ENCRYPT, msg="Decrypt completed", count = decrypted.len(), duration_ms = decrypt_duration.as_millis());
 
         // Reconstruct the result vector with None values in the right places
         let mut result: Vec<Option<Plaintext>> = vec![None; ciphertexts.len()];

--- a/packages/cipherstash-proxy/src/proxy/zerokms/zerokms.rs
+++ b/packages/cipherstash-proxy/src/proxy/zerokms/zerokms.rs
@@ -16,8 +16,9 @@ use cipherstash_client::{
         PreparedPlaintext,
     },
     schema::column::IndexType,
-    zerokms::WithContext,
+    zerokms::{Decryptable, EncryptedRecord, RecordWithNonce, RetrieveKeyPayload},
 };
+use std::convert::Infallible;
 use eql_mapper::EqlTermVariant;
 use metrics::{counter, histogram};
 use moka::future::Cache;
@@ -33,6 +34,75 @@ use super::{init_zerokms_client, ScopedCipher, ZerokmsClient};
 
 /// Memory size of a single ScopedCipher instance for cache weighing
 const SCOPED_CIPHER_SIZE: usize = std::mem::size_of::<ScopedCipher>();
+
+/// An EQL v3 stored payload reduced to something the cipher can decrypt.
+///
+/// The two arms are not interchangeable, which is why this exists rather than a
+/// plain `Vec<RecordWithNonce>`: `RecordWithNonce` unconditionally reports a
+/// nonce override and an AAD selector, so wrapping a scalar record in one would
+/// decrypt against a nonce the value was never encrypted with.
+#[derive(Debug)]
+enum V3Record {
+    /// A scalar payload's `c` — self-describing, nonce derived from the data
+    /// key's IV, nothing bound into the AAD.
+    Scalar(EncryptedRecord),
+    /// A SteVec document's root entry, reassembled from the document's `h`
+    /// header. Nonce and AAD both derive from the entry's selector.
+    SteVecRoot(RecordWithNonce),
+}
+
+impl Decryptable for V3Record {
+    type Error = Infallible;
+
+    fn keyset_id(&self) -> Option<Uuid> {
+        match self {
+            V3Record::Scalar(record) => record.keyset_id(),
+            V3Record::SteVecRoot(record) => record.keyset_id(),
+        }
+    }
+
+    fn retrieve_key_payload(&self) -> Result<RetrieveKeyPayload<'_>, Self::Error> {
+        match self {
+            V3Record::Scalar(record) => record.retrieve_key_payload(),
+            V3Record::SteVecRoot(record) => record.retrieve_key_payload(),
+        }
+    }
+
+    fn into_encrypted_record(self) -> Result<EncryptedRecord, Self::Error> {
+        match self {
+            V3Record::Scalar(record) => record.into_encrypted_record(),
+            V3Record::SteVecRoot(record) => record.into_encrypted_record(),
+        }
+    }
+
+    fn nonce_override(&self) -> Option<[u8; 12]> {
+        match self {
+            V3Record::Scalar(_) => None,
+            V3Record::SteVecRoot(record) => record.nonce_override(),
+        }
+    }
+
+    fn aad_selector(&self) -> Option<[u8; 16]> {
+        match self {
+            V3Record::Scalar(_) => None,
+            V3Record::SteVecRoot(record) => record.aad_selector(),
+        }
+    }
+}
+
+/// Decode a SteVec entry's hex-encoded tokenized selector into the 16 bytes the
+/// AEAD binding needs.
+fn decode_ste_vec_selector(selector: &str) -> Result<[u8; 16], EncryptError> {
+    let bytes = hex::decode(selector).map_err(|_| EncryptError::SteVecSelectorInvalid {
+        selector: selector.to_string(),
+    })?;
+
+    bytes
+        .try_into()
+        .map_err(|_| EncryptError::SteVecSelectorInvalid {
+            selector: selector.to_string(),
+        })
+}
 
 #[derive(Clone)]
 pub struct ZeroKms {
@@ -263,20 +333,39 @@ impl EncryptionService for ZeroKms {
         //
         // cipherstash-client has no `decrypt_eql_v3` counterpart to
         // `encrypt_eql_v3` — the v2 `decrypt_eql` only accepts `EqlCiphertext`.
-        // For scalar payloads that costs us nothing: `EncryptedPayloadV3.c` is
-        // the same `EncryptedRecord` the v2 path would have unwrapped, and
-        // `EncryptedRecord` is itself `Decryptable`, so we hand it straight to
-        // the cipher. SteVec documents are the part that genuinely needs the
-        // client (see `SteVecV3DecryptUnsupported`).
+        // We assemble the decryptable record ourselves, which is what
+        // protect-ffi does too (`encrypted_record_from_value`).
+        //
+        // Scalar: `c` is already the `EncryptedRecord` the v2 path would have
+        // unwrapped, and `EncryptedRecord` is `Decryptable`.
+        //
+        // SteVec: the document holds the key material once in the `h` header
+        // and each entry carries only raw AEAD bytes, so the record has to be
+        // reassembled from the header plus the ROOT entry (`sv[0]`, the same
+        // decryption-root invariant v2 had). The selector is the AEAD binding —
+        // its first 12 bytes are the nonce and all 16 go into the AAD — which is
+        // why the reassembled record is a `RecordWithNonce`.
         let mut indices: Vec<usize> = Vec::new();
-        let mut records_to_decrypt = Vec::new();
+        let mut records_to_decrypt: Vec<V3Record> = Vec::new();
 
         for (idx, ct_opt) in ciphertexts.iter().enumerate() {
             if let Some(ct) = ct_opt {
                 let record = match ct {
-                    EqlCiphertextV3::Encrypted(payload) => payload.ciphertext.clone(),
-                    EqlCiphertextV3::SteVec(_) => {
-                        return Err(EncryptError::SteVecV3DecryptUnsupported.into())
+                    EqlCiphertextV3::Encrypted(payload) => {
+                        V3Record::Scalar(payload.ciphertext.clone())
+                    }
+                    EqlCiphertextV3::SteVec(document) => {
+                        let root = document
+                            .ste_vec
+                            .first()
+                            .ok_or(EncryptError::SteVecMissingRootEntry)?;
+
+                        let selector = decode_ste_vec_selector(&root.selector)?;
+                        V3Record::SteVecRoot(
+                            document
+                                .key_header
+                                .record_with_selector(root.ciphertext.clone(), selector),
+                        )
                     }
                 };
                 indices.push(idx);

--- a/packages/cipherstash-proxy/src/proxy/zerokms/zerokms.rs
+++ b/packages/cipherstash-proxy/src/proxy/zerokms/zerokms.rs
@@ -18,10 +18,10 @@ use cipherstash_client::{
     schema::column::IndexType,
     zerokms::{Decryptable, EncryptedRecord, RecordWithNonce, RetrieveKeyPayload},
 };
-use std::convert::Infallible;
 use eql_mapper::EqlTermVariant;
 use metrics::{counter, histogram};
 use moka::future::Cache;
+use std::convert::Infallible;
 use std::{
     borrow::Cow,
     sync::Arc,
@@ -285,9 +285,14 @@ impl EncryptionService for ZeroKms {
             }
         }
 
-        // If no plaintexts to encrypt, return all None
+        // If no plaintexts to encrypt, return all None.
+        //
+        // Built by iteration rather than `vec![None; n]`: that needs `Clone`,
+        // and `EqlOutputV3` does not derive it (neither does the v2
+        // `EqlOutput` — the ciphertext types are `Clone`, the output wrappers
+        // are not).
         if prepared_plaintexts.is_empty() {
-            return Ok(vec![None; plaintexts.len()]);
+            return Ok((0..plaintexts.len()).map(|_| None).collect());
         }
 
         // Use default opts since cipher is already initialized with the correct keyset
@@ -302,7 +307,7 @@ impl EncryptionService for ZeroKms {
         debug!(target: ENCRYPT, msg="encrypt_eql_v3 completed", count = encrypted.len(), duration_ms = encrypt_duration.as_millis());
 
         // Reconstruct the result vector with None values in the right places
-        let mut result: Vec<Option<EqlOutputV3>> = vec![None; plaintexts.len()];
+        let mut result: Vec<Option<EqlOutputV3>> = (0..plaintexts.len()).map(|_| None).collect();
         for (idx, ciphertext) in indices.into_iter().zip(encrypted.into_iter()) {
             result[idx] = Some(ciphertext);
         }

--- a/packages/eql-mapper/CONTEXT.md
+++ b/packages/eql-mapper/CONTEXT.md
@@ -1,0 +1,102 @@
+# EQL Mapper
+
+Parses SQL, infers a type for every node, and rewrites statements that touch encrypted
+columns into their EQL v2 equivalents. It knows nothing about the PostgreSQL wire
+protocol, ZeroKMS, or ciphertext — it reasons about types and rewrites syntax.
+
+## Language
+
+### The type system
+
+**Type**:
+A node's inferred type in this crate's own lattice — either a resolved `Value`, a
+unification `Var`, or an `Associated` type. Never a PostgreSQL wire type.
+_Avoid_: SQL type, Postgres type (those belong to Proxy).
+
+**Value**:
+A *resolved* type — one of `Eql`, `Native`, `Array`, `Projection`, `SetOf`. It means
+"value type", not a datum. The SQL AST's literal node is also called `Value`; when both
+are in scope, alias the AST one.
+_Avoid_: using bare `Value` for a SQL literal.
+
+**Native**:
+A column or expression that is not encrypted. Native types satisfy *every* `EqlTrait`
+bound — that is a deliberate escape hatch for the type checker, not a claim about the
+database.
+
+**EqlValue**:
+The identity of an encrypted column paired with the capabilities configured for it —
+a `TableColumn` plus `EqlTraits`.
+
+**EqlTrait**:
+A class of operation an encrypted value supports: `Eq`, `Ord`, `TokenMatch`, `JsonLike`,
+`Contain`. A **capability**, not a storage structure — several SEM terms can satisfy one
+trait. See the shared vocabulary in `CONTEXT-MAP.md`.
+_Avoid_: index, index type (those name the storage, not the capability).
+
+**EqlTraits**:
+A set of `EqlTrait`s. Read in two opposite directions depending on position: as
+*required bounds* on a `Var`, and as *implemented capabilities* on an `EqlValue`.
+_Avoid_: features, bounds, trait_impls as distinct concepts — they are all this one type.
+
+**EqlTerm**:
+The shape of encrypted payload a node needs — `Full`, `Partial`, `JsonAccessor`,
+`JsonPath`, `Tokenized`. `Partial` is a subset of `Full`, not an unresolved type.
+_Avoid_: "term" meaning an encrypted search term; that sense belongs to Proxy.
+
+**Projection**:
+The resultset shape of a statement or subquery — an ordered list of optionally-named
+column types.
+
+**alias**:
+The *effective name* of a projection column, which is the user's alias when one was
+written and the underlying schema column name otherwise. Identifier resolution matches
+against it.
+_Avoid_: reading `alias` as "user-supplied alias only".
+
+### Naming and resolution
+
+**Relation**:
+Anything you can select from — a table, view, CTE, or derived subquery — reduced to a
+name plus a projection type.
+
+**Scope**:
+The lexical frame holding the relations visible at a point in the statement.
+
+**TableColumn**:
+The `table.column` identity of an encrypted column. It is the join key to Proxy's
+encrypt config.
+_Avoid_: identifier (Proxy uses that for its own type).
+
+**Schema**:
+The database's tables and columns as this crate sees them, each column marked `Native`
+or `Eql`. Loaded from the live database, not from a migration file.
+
+**Overlay**:
+A per-transaction mask over the loaded `Schema` recording DDL that has run but not
+committed. A table is either shadowed by a new definition or hidden as dropped.
+
+### Output
+
+**TypeCheckedStatement**:
+The result of type checking — the projection, params, literals and node types, plus the
+entry point that applies transformations.
+
+**TransformationRule**:
+A composable mutation of the typed AST that rewrites plaintext SQL into EQL v2
+operations. Tuples of rules are themselves rules.
+_Avoid_: using "rule" for a typing rule; those are operator/function signature
+declarations.
+
+**Param**:
+A `$N` placeholder position in the statement. Its PostgreSQL type OID is Proxy's
+concern, not this crate's.
+
+## Known model gap
+
+The trait-bounds machinery here is complete — `satisfy_bounds` and `UnsatisfiedBounds`
+exist and work — but Proxy currently feeds every encrypted column `EqlTraits::all()`
+(`packages/cipherstash-proxy/src/proxy/schema/manager.rs:146`) rather than the traits its
+configured SEM terms actually provide. So bound violations cannot be caught at type-check
+time in production today. Treat `EqlTraits` on an `EqlValue` as *intended* capability,
+not observed capability, until that join exists.

--- a/packages/eql-mapper/src/type_checked_statement.rs
+++ b/packages/eql-mapper/src/type_checked_statement.rs
@@ -123,7 +123,7 @@ impl<'ast> TypeCheckedStatement<'ast> {
             )));
         }
 
-        for (key, _) in encrypted_literals.iter() {
+        for key in encrypted_literals.keys() {
             if !self.literal_exists_for_node_key(*key) {
                 return Err(EqlMapperError::Transform(String::from(
                     "encrypted literals refers to a literal node which is not present in the SQL statement"


### PR DESCRIPTION
<!-- git-queue:begin -->
### 📚 Queued PR &nbsp;·&nbsp; 1 of 1

Part of a queue. The PRs merge in FIFO order — the numbered order below, #1 first. Merging one supersedes the PRs after it until the author runs `git queue sync` (rebases the rest onto the merged base) and `git queue submit` (retargets their PRs).

1. ⏳🟢 **[#415 `chore/agent-skills-setup`](https://github.com/cipherstash/proxy/pull/415) → `main`** &nbsp;👈 **this PR**

<sub>✅ approved · ♻️ changes requested · ⏳ review pending &nbsp;|&nbsp; 🟣 merged · 🟢 open · ⚫ closed &nbsp;—&nbsp; status as of the last `git queue submit`.</sub>
<sub>🥞 Managed by git-queue — do not edit this list by hand.</sub>
<!-- git-queue:end -->

---

Configures this repo for the [mattpocock engineering skills](https://github.com/mattpocock/skills) — the per-repo conventions those skills read before doing anything.

No product code is touched. Docs and `CLAUDE.md` only.

## What's here

**Issue tracker** (`docs/agents/issue-tracker.md`) — records that issues live in **Linear** (team Product Engineering, `CIP-` prefix), not GitHub Issues. Covers the `linear-cli` / MCP access paths, the workflow statuses, and how each skill should move an issue through them. Also pins the convention that markdown goes via `--description-file`, since inline args render literal `\n` in the Linear UI.

**Triage labels** (`docs/agents/triage-labels.md`) — maps the five canonical triage roles to our label strings. Kept as the defaults. Only `wontfix` exists on the team today; the other four are created on demand, and the file notes they should stay unparented rather than joining the existing `Product` / `R&D` / `Issue type` groups.

**Domain docs** (`CONTEXT-MAP.md`, `docs/agents/domain.md`) — multi-context layout, since this is a Cargo workspace with genuinely distinct vocabularies per package. The map names the four contexts and, more usefully, records the **cross-context term collisions**: "type" means a wire-protocol type in Proxy but an inferred SQL expression type in EQL Mapper; "index" means a Postgres index in Proxy but a searchable-encryption index in EQL Mapper.

Per-package `CONTEXT.md` files are deliberately **not** created upfront — they're written lazily as terms actually get resolved, so a missing one is expected rather than a gap.

## Note

No `CIP-` ticket — this is repo configuration rather than product work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for navigating the workspace’s domain documentation and context-specific terminology.
  * Documented issue tracking workflows, statuses, PR linking, and agent-related issue handling.
  * Added canonical triage roles, labels, and label-creation guidance.
  * Added a context map covering package ownership, domains, shared vocabulary, and term differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->