### PR TITLE
fix: satisfy clippy::for_kv_map in type_checked_statement

### DIFF
--- a/packages/eql-mapper/src/type_checked_statement.rs
+++ b/packages/eql-mapper/src/type_checked_statement.rs
@@ -123,7 +123,7 @@ impl<'ast> TypeCheckedStatement<'ast> {
             )));
         }
 
-        for (key, _) in encrypted_literals.iter() {
+        for key in encrypted_literals.keys() {
             if !self.literal_exists_for_node_key(*key) {
                 return Err(EqlMapperError::Transform(String::from(
                     "encrypted literals refers to a literal node which is not present in the SQL statement"


### PR DESCRIPTION
CI on #418 surfaced a pre-existing `clippy::for_kv_map` failure — unrelated to that PR's lockfile deletion, but the deletion let the clippy step run to completion and expose it. CI runs clippy with `-D warnings`, so the lint is a hard error.

`packages/eql-mapper/src/type_checked_statement.rs:126` iterated a map with `.iter()` and immediately discarded the value:

```rust
for (key, _) in encrypted_literals.iter() {
```

Switched to `.keys()`:

```rust
for key in encrypted_literals.keys() {
```

Behaviour is identical; the value was never used.

## Verification

`RUSTFLAGS="-D warnings" cargo clippy --all --all-targets` is clean across the whole workspace (checked there was no second error hiding behind the one that stopped CI's build).
