### PR TITLE
[2/6] feat: EQL v3 type checker driven by per-column domain capability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,6 +832,7 @@ dependencies = [
  "clap",
  "config",
  "cts-common",
+ "eql-bindings",
  "eql-mapper",
  "exitcode",
  "hex",
@@ -1483,6 +1484,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,6 +1517,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "eql-bindings"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6e26dbefb089908aa10521c6efffbe3f5404f9adfa7d43e4244d41c1d6db0"
+dependencies = [
+ "schemars",
+ "serde",
+ "serde_json",
+ "ts-rs",
 ]
 
 [[package]]
@@ -3522,6 +3541,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3875,6 +3914,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3970,6 +4034,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4341,6 +4416,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4400,6 +4486,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
 dependencies = [
  "parking_lot",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -4794,6 +4889,29 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ts-rs"
+version = "10.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e640d9b0964e9d39df633548591090ab92f7a4567bc31d3891af23471a3365c6"
+dependencies = [
+ "lazy_static",
+ "thiserror 2.0.18",
+ "ts-rs-macros",
+]
+
+[[package]]
+name = "ts-rs-macros"
+version = "10.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e9d8656589772eeec2cf7a8264d9cda40fb28b9bc53118ceb9e8c07f8f38730"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "termcolor",
+]
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,10 @@ sqltk = { version = "0.10.0" }
 cipherstash-client = { version = "=0.42.0" }
 cipherstash-config = { version = "=0.42.0" }
 cts-common = { version = "=0.42.0" }
+# EQL v3 domain catalog: maps Postgres domain names to (token type, SEM terms).
+# The authoritative source for a column's domain identity (ADR-0002); only the
+# SchemaManager depends on it, keeping eql-mapper wire-format-agnostic.
+eql-bindings = { version = "=3.0.1" }
 
 thiserror = "2.0.9"
 tokio = { version = "1.44.2", features = ["full"] }

--- a/docs/plans/2026-07-20-eql-v3-type-checker-handoff.md
+++ b/docs/plans/2026-07-20-eql-v3-type-checker-handoff.md
@@ -1,0 +1,397 @@
+# EQL v3 type checker — session handoff
+
+**Date:** 2026-07-20
+**Branch:** `chore/agent-skills-setup` (PR #415)
+**Purpose:** carry context into a fresh session for `/grill-with-docs` on extending the
+EQL Mapper type checker for EQL v3.
+
+This is a handoff, not a spec. It records what is already true, what was already decided,
+and what is still open. The design itself has not started.
+
+---
+
+## 1. How to use this
+
+Open a fresh session, reference this file, and run `/grill-with-docs`. The design questions
+in §8 are the agenda. Everything above them is evidence gathered so the grill does not have
+to re-derive it.
+
+Glossaries exist and should be updated as terms get resolved:
+`CONTEXT-MAP.md`, `packages/eql-mapper/CONTEXT.md`, `packages/cipherstash-proxy/CONTEXT.md`.
+
+---
+
+## 2. Where the branch is
+
+Five commits, unpushed beyond #415's first. In order:
+
+| Commit | What |
+|---|---|
+| `3d33c8ed` | Agent skills config (issue tracker, domain docs) |
+| `74b63721` | Domain glossaries for Proxy and EQL Mapper |
+| `64c658f2` | Deps: cipherstash-client `0.34.1-alpha.4` → `0.42.0`, EQL `2.3.0-pre.3` → `3.0.1` |
+| `b3f293d7` | Encrypt path moved to `encrypt_eql_v3`; v2 retired |
+| `a10b60cd` | v3 decrypt for scalar + SteVec |
+| `387ca790` | Adopted the 0.42.0 representation; workspace compiles |
+
+**State:** the workspace compiles, `cargo fmt` and `cargo clippy --all-targets` are clean.
+**Nothing has been run.** Compiling is not working — `eql-mapper` still emits `eql_v2_encrypted`
+casts and `eql_v2.*` calls into every rewritten statement, so nothing works end to end.
+229 `eql_v2` references remain repo-wide.
+
+The vendored `stack-auth` CIP-3159 patch was dropped (0.42.0 requires `stack-auth ^0.42.0`,
+which carries the CancelGuard fix upstream). `vendor/stack-auth/` is still on disk, unreferenced.
+
+---
+
+## 3. The EQL v3 model
+
+EQL 3.0 removes the `eql_v2` schema entirely. The single opaque `eql_v2_encrypted`
+**composite** type is replaced by **53 typed domains over jsonb**, two-dimensional:
+
+**Token type** × **capability suffix**
+
+- Tokens: `integer`, `smallint`, `bigint`, `date`, `timestamp`, `numeric`, `text`,
+  `boolean`, `real`, `double`, `json`
+- Suffixes: *(none)*, `_eq`, `_ord`, `_ord_ope`, `_ord_ore`, `_match`, `_search`, `_search_ore`
+
+Column domains live in `public` (`public.eql_v3_integer_ord`); query-operand twins live in
+`eql_v3` (`eql_v3.query_integer_ord`). 39 query twins, enumerated separately.
+
+Capability is a property of the **type**, and the domain's CHECK enforces that the payload
+actually carries the required terms — so a missing term fails on insert, not later at query time.
+
+### SEM terms (the storage beneath a capability)
+
+| Suffix | Operators | Term |
+|---|---|---|
+| *(none)* | — (storage only) | `c` |
+| `_eq` | `=` `<>` | `hm` (HMAC-256) |
+| `_ord` | `=` `<>` `<` `<=` `>` `>=`, MIN/MAX | `op` (CLLW-OPE) |
+| `_ord_ope` | as `_ord` | `op` |
+| `_ord_ore` | as `_ord` | `ob` (block-ORE) |
+| `_match` | `@@` | `bf` (bloom filter) |
+| `_search` | all | `hm` + `op` + `bf` |
+| `_search_ore` | all | `hm` + `ob` + `bf` |
+
+Text is the exception: `text_ord*` carries `hm` **as well as** the ordering term, because
+lexicographic ORE/OPE over text is not equality-lossless.
+
+> **Upstream doc bug.** `eql-bindings` `src/v3/mod.rs:26` claims "`ob` for `_ord`/`_ord_ore`,
+> `op` for `_ord_ope`". The generated code disagrees — `IntegerOrd` requires `op`,
+> `IntegerOrdOre` requires `ob`. Trust `term_json_keys_static()`, not that module doc.
+
+### Vocabulary
+
+`EqlTrait` is a **capability**; a **SEM term** (searchable encrypted metadata) is the storage
+that satisfies it. Many-to-one. Neither is an "index" — that word is reserved for a PostgreSQL
+index. The EQL config JSON and `cipherstash_client`'s `ColumnConfig` still spell SEM terms
+`indexes`/`IndexType`; that is a shared wire format and not ours to rename.
+
+---
+
+## 4. Upstream facts worth knowing
+
+**`eql-bindings` 3.0.1** (crates.io) is generated from `eql-domains::CATALOG` by `eql-codegen` —
+the same catalog that generates the SQL. Light deps (serde, serde_json, schemars, ts-rs).
+
+The useful part for us:
+
+```rust
+IntegerOrd::sql_domain_static()      // "public.eql_v3_integer_ord"
+IntegerOrd::term_json_keys_static()  // Some(&["op"])
+```
+
+`v3::all()` enumerates the 53 stored domains, `all_query()` the 39 query twins. Inverting
+`all()` gives a **typname → (token type, required SEM terms)** map straight from the catalog,
+which cannot drift from the SQL. `sql.rs` also embeds `INSTALL_SQL`/`UNINSTALL_SQL` as consts,
+which could replace the `curl` in `mise.toml`'s `eql:download`.
+
+**Containment is gone.** `@>`/`<@` survive only as internal blockers that raise (CIP-3517).
+Fuzzy match is `@@` via `eql_v3.matches`.
+
+**`boolean` is storage-only by design** — no `_eq`, no `_ord`, every operator blocked, because
+a two-value column leaks its distribution under any index.
+
+### The 0.41.1 / 0.42.0 SteVec split — UNRESOLVED
+
+cipherstash-client changed the v3 SteVec wire format and nothing else followed:
+
+| | 0.41.1 (protect-ffi, eql-bindings 3.0.1) | 0.42.0 (what Proxy now pins) |
+|---|---|---|
+| Document | `{v,k,i,sv}` | `{v,k,i,**h**,sv}` |
+| Entry `c` | self-describing mp_base85 record | raw base85 AEAD bytes |
+| Key material | per entry | once, in `h` |
+| Nonce / AAD | data key IV | `selector[..12]` / all 16 selector bytes |
+
+EQL 3.0.1's SQL CHECK accepts **both** (it never forbids extra keys), so the database will not
+catch a mismatch. ProtectJS and Proxy writing encrypted jsonb to the same table would produce
+mutually undecryptable documents. Either Proxy pins back to 0.41.1 or protect-ffi and
+eql-bindings move forward. Not Proxy's call alone. **This is orthogonal to the type checker
+work but blocks shipping.**
+
+### CLLW-ORE data is stranded
+
+`from_v2` returns `UnconvertibleOreTerm` for `oc` SteVec entries — re-encryption is the only
+path. `cipherstash-config` now models this: `IndexType::SteVec { mode }` where
+`SteVecMode::Compat` (CLLW-OPE, `op`) is the default and v3-compatible, and `SteVecMode::Standard`
+(CLLW-ORE, `oc`) is documented upstream as "the legacy v2 protocol, still used by Proxy".
+This is CIP-3233 made explicit in the config model.
+
+---
+
+## 5. Impact map — the type system
+
+Three parallel agents surveyed `eql-mapper`. Findings, with the conflicts resolved.
+
+### Where encrypted types come from
+
+**Only two production sites** construct an `EqlValue` from schema data:
+
+- `inference/unifier/types.rs:508-517` — `Projection::new_from_schema_table`
+- `inference/infer_type_impls/insert_statement.rs:40-49` — INSERT target columns
+
+Both produce `EqlTerm::Full`. Everything else clones. Upstream of both:
+`packages/cipherstash-proxy/src/proxy/schema/manager.rs:142-148`, which matches the single
+string `"eql_v2_encrypted"` and hardcodes `EqlTraits::all()`. **That one match arm is where the
+53-domain mapping has to go.**
+
+### The shapes that must widen
+
+- `EqlValue(TableColumn, EqlTraits)` — `unifier/types.rs:274`
+- `ColumnKind::{Native, Eql(EqlTraits)}` — `model/schema.rs:41-45`
+- `Column::eql(name, features)` — `model/schema.rs:48`
+- `SchemaTableColumn` — `model/schema.rs:63`
+
+There is **no field anywhere in eql-mapper holding a plaintext scalar type for an encrypted
+column.** The `_ord` half of `eql_v3_integer_ord` is derivable from `EqlTraits`; the `integer`
+half is derivable from nothing in the package.
+
+### Two authorities on the scalar type, no reconciliation
+
+The scalar type already exists in the system as `ColumnType`, sourced from the **encrypt config**
+and consumed at `cipherstash-proxy/src/postgresql/data/from_sql.rs:123-292` and
+`context/column.rs:68-86`. Under v3 the **Postgres type name** also encodes it. A config/schema
+disagreement is currently undetectable.
+
+### Encrypted columns never unify with each other
+
+`unifier/types.rs:121` — *"An encrypted column never shares a type with another encrypted column."*
+`unify_types.rs:84-121`: two EQL terms unify iff their `EqlValue`s are `==`, so `TableColumn`
+identity dominates. `users.email = orders.email` is already a type error.
+
+**Therefore a token type is redundant for `Full`/`Full` unification.** Same column → same token
+type, always.
+
+### Literals are inference sinks — CORRECTED FINDING
+
+Two agents disagreed here; resolved by reading the code.
+
+`infer_type_impls/value.rs:19` — a non-placeholder literal unifies with `self.fresh_tvar()`,
+an **unbound variable**, not `Native`. And `(Eql, Native)` is a hard error
+(`unify_types.rs:68-70`).
+
+So `WHERE encrypted_col = 'literal'` works because the literal has no type of its own and
+**absorbs the column's**. Consequence: adding a token type to `EqlValue` buys **zero** literal
+checking — there is nothing for `eql_v3_integer_ord = 'abc'` to contradict. Getting that check
+would require literals to carry a syntactic type they deliberately do not have.
+
+This is not the same as "Native satisfies all bounds". That escape hatch
+(`unifier/eql_traits.rs:279`) is about **bound satisfaction**, not cross-kind unification.
+
+### Bound checking is dead code today
+
+`Unifier::satisfy_bounds` (`unifier/mod.rs:235-248`) and `Type::must_implement`
+(`unifier/types.rs:451-460`) can never fail in production, because:
+
+- every column gets `EqlTraits::all()` (`manager.rs:146`)
+- `Native` ⇒ `ALL_TRAITS` (`eql_traits.rs:279`)
+- `Type::Var` short-circuits to `Ok(())` (`mod.rs:236`)
+
+**Two latent bugs will become user-visible the moment these go live:**
+
+1. `EqlTraits::difference` (`eql_traits.rs:223-231`) is implemented as **XOR**, not set
+   difference. `UnsatisfiedBounds` will report the symmetric difference — listing traits the
+   type *has* but the bound never required.
+2. `must_implement` (`types.rs:456`) passes its operands **reversed** relative to
+   `satisfy_bounds` (`mod.rs:245`). Harmless only because XOR is commutative.
+
+Fix both before making bounds reachable.
+
+### Associated types
+
+`AssociatedTypeSelector { eql_trait, type_name }` (`types.rs:236`) is keyed on
+`(EqlTrait, &'static str)` only. Resolution (`eql_traits.rs:56-115`) maps
+`Eq::Only`/`Ord::Only`/`Contain::Only` → `Partial`, `TokenMatch::Tokenized` → `Tokenized`,
+`JsonLike::{Path,Accessor}` → `JsonPath`/`JsonAccessor`.
+
+**If the token type lives inside `EqlValue`, this machinery needs no change** — every arm does
+`eql_col.clone()`, so it propagates free. Do **not** add a field to `AssociatedTypeSelector`:
+it would break the `lhs.selector == rhs.selector` equality at `unify_types.rs:160` for a
+dimension already determined by `impl_ty`.
+
+---
+
+## 6. Impact map — the SQL surface
+
+### The entire v2 SQL surface is three call sites
+
+Six rules, composed at `type_checked_statement.rs:153-160`. Only three emit SQL.
+
+**`helpers.rs:6-27`** — `cast_as_encrypted`. The single source of every
+`::JSONB::eql_v2_encrypted` cast. Takes **only** an `ast::Value` — no `EqlTerm`, no
+`TableColumn`, no traits. The cast target is a hardcoded `Ident::new("eql_v2_encrypted")`
+at line 17. **This is the one place the v3 domain name would be chosen.**
+
+**`cast_params_as_encrypted.rs:51`** — emits `$1::JSONB::eql_v2_encrypted`. Its gate at line 67
+matches `Some(Type::Value(Value::Eql(_)))` — **the `EqlTerm` is available and discarded by the
+`_`, one line before use.** That is the hook for selecting a `query_<name>` twin.
+
+**`cast_literals_as_encrypted.rs:33`** — emits `'<ciphertext>'::JSONB::eql_v2_encrypted`. Gated
+on map membership, not type. Holds **no `node_types` field at all** (line 13), so it cannot see
+type info even in principle. Needs plumbing, not just a pattern change.
+
+**`rewrite_standard_sql_fns_on_eql_types.rs:59-61`** — blindly prepends `eql_v2` to any
+`pg_catalog.*` name. Emits `eql_v2.{count,min,max,jsonb_path_query,jsonb_path_query_first,
+jsonb_path_exists,jsonb_array_length,jsonb_array_elements,jsonb_array_elements_text}`.
+Note it emits `eql_v2.count`, which **is not in the declaration table** — a name the type
+registry cannot round-trip.
+
+**`rewrite_containment_ops.rs:54-57,86-87`** — `@>` → `eql_v2.jsonb_contains`,
+`<@` → `eql_v2.jsonb_contained_by`. Motivated by GIN index usage, not just type dispatch.
+
+`preserve_effective_aliases.rs` and `fail_on_placeholder_change.rs` emit nothing.
+
+### Rules that exist only because v2 had one opaque type
+
+`RewriteStandardSqlFnsOnEqlTypes` — PG cannot dispatch `min`/`max`/`jsonb_*` on one opaque
+jsonb-backed type, so they are shadowed by hand-written `eql_v2.` overloads. Under v3, PG
+resolves overloads by argument type natively — **but only if v3 ships operator/function
+overloads bound to those domains.** Redundant *conditional on* that, and that is overload
+resolution, not capability-in-the-type. Different mechanisms; verify before assuming.
+
+`RewriteContainmentOps` — same root cause: `@>` cannot be defined on a bare opaque type
+without conflicting with jsonb's own operator.
+
+**Not in this category:** the two cast rules (still needed, only the target changes),
+`PreserveEffectiveAliases` (projection naming, orthogonal), `FailOnPlaceholderChange` (assertion).
+
+### Discipline to preserve
+
+`rewrite_containment_ops.rs:92-99` uses `mem::replace` against a throwaway `Value::Null` rather
+than cloning, specifically so operand `NodeKey` identity survives for the cast rules that run
+after it. **Clone there and literal encryption inside containment expressions silently breaks.**
+
+---
+
+## 7. Impact map — declarations and macros
+
+### Operator → EqlTrait, in full (`inference/sql_types/sql_decls.rs:16-31`)
+
+| Operator | Signature | Trait |
+|---|---|---|
+| `=` `<>` | `<T>(T op T) -> Native` | `Eq` |
+| `<` `<=` `>` `>=` | `<T>(T op T) -> Native` | `Ord` |
+| `->` `->>` | `<T>(T op <T as JsonLike>::Accessor) -> T` | `JsonLike` |
+| `@>` `<@` | `<T>(T op T) -> Native` | `Contain` |
+| `~~` `!~~` `~~*` `!~~*` | `<T>(T op <T as TokenMatch>::Tokenized) -> Native` | `TokenMatch` |
+
+No `@@` is declared. Anything unlisted falls to `Fallback`, which forces lhs, rhs and result
+to `Type::native()` (`sql_binary_operator_types.rs:40-44`).
+
+Functions at `sql_decls.rs:58-79`: `min`/`max` require `Ord`; the `jsonb_*` family requires
+`JsonLike`; `jsonb_array`/`jsonb_contains`/`jsonb_contained_by` require `Contain`; **`count`
+has no bound at all** and accepts any `T` including EQL.
+
+### The macro grammar is capability-only by construction
+
+`eql-mapper-macros/src/parse_type_decl.rs:11-25` — the entire custom-keyword vocabulary is
+`Accessor, Contain, EQL, Eq, Full, JsonLike, Native, Only, Ord, Partial, Path, SetOf, TokenMatch`.
+Every one is a trait name, an associated-type name, or a type constructor. **Not one names a
+data type.**
+
+`EQL(customer.age: Ord)` is expressible. "Encrypted integer with Ord" is not — not in the
+keyword table, not in the grammar, not in the generated `EqlValue`. A v3 port needs a new
+lexical class, new productions in `EqlTerm` (`:289-331`) and `VarDecl` (`:70-91`), and a
+widened payload. Work is concentrated in that one file.
+
+`@@` will not parse today: `token::At` at `:480` unconditionally expects a following `Gt`.
+
+### Things that become ambiguous with a token type
+
+1. **`<T>(T = T)` — the core ambiguity.** One tvar currently conflates *same column*, *same
+   token type*, and *any encrypted*. Indistinguishable today because encrypted identity **is**
+   the column.
+2. **`EqlTerm::Partial`'s union-on-unify** (`unify_types.rs:91`) accumulates capabilities
+   monotonically. If capability is fixed by the domain, you cannot union your way into a
+   capability the column does not have.
+3. **The payload-less variants** — `JsonAccessor`, `JsonPath`, `Tokenized` all return
+   `EqlTraits::none()` (`eql_traits.rs:320-322`). "A tokenized *what*" needs answering.
+4. **`Native` ⇒ `ALL_TRAITS`** and **`Type::Var` ⇒ `Ok(())`** are two independent wildcards in
+   the bound checker.
+
+### Pre-existing gaps this work will expose
+
+- **`Expr::Like`/`ILike` bypass the trait system entirely.** `infer_type_impls/expr.rs:115-131`
+  only unifies the result with `Native` — never requires `TokenMatch`, never produces a
+  `Tokenized` term. The `~~` declarations fire only on the operator form. LIKE on an encrypted
+  column is currently unchecked.
+- **`schema_delta.rs:447,479,529` uses `EqlTraits::default()`** (all false) while the loader uses
+  `all()` (all true). The two paths disagree. Invisible while bounds are dead.
+- **Empty projections** return `EqlTraits::none()` (`eql_traits.rs:310`) while the
+  `satisfy_bounds` doc (`mod.rs:220`) says they satisfy all bounds. Doc and code disagree.
+- `EqlTrait` parse error string (`parse_type_decl.rs:172`) is stale — omits `Contain`.
+
+### Removing `Contain` touches
+
+Keyword table (`parse_type_decl.rs:13`), enum (`eql_traits.rs:23`), assoc types (`:39`),
+resolution (`:73`, `:101-105`), `ALL_TRAITS` (`:154`), struct field (`:145`), `add_mut` (`:200`),
+`to_eql_trait_impls!` (`schema.rs:225-227`), two operators (`sql_decls.rs:25-26`), three
+functions (`sql_decls.rs:76-78`).
+
+---
+
+## 8. Open design questions — the grill agenda
+
+**The framing question.** The research says the token type's job is **naming a v3 domain at
+cast time**, not type checking: it is redundant for unification (§5), and it buys no literal
+checking (§5). So — does it belong in the type lattice at all, or should the transformation
+rules look the domain up from the schema by `TableColumn` at emit time and leave the lattice
+alone? The second is materially cheaper and nothing found so far rules it out. **Settle this
+before anything else; most other answers follow from it.**
+
+Then:
+
+1. If it does go in the lattice: inside `EqlValue` (associated types come free, all six
+   unification arms come free) or on `EqlTerm` (six explicit merges)?
+2. `_ord` vs `_ord_ope` vs `_ord_ore` — identical operators, different SEM terms. Does the type
+   checker distinguish them, or is that purely a cast-target concern?
+3. `integer_eq` and `bigint_eq` are byte-identical on the wire but different domains. Type error
+   to compare? (Note: already a type error via `TableColumn` identity — is that enough?)
+4. What replaces `Contain`? `@>`/`<@` are **directional**; `@@`/`eql_v3.matches` is **symmetric**.
+   `<@` has nowhere to go. Delete the trait, or repoint at `@@` and lose direction?
+5. Do bounds go live? Real errors for `ORDER BY` on an `_eq` column — but the domain CHECK
+   catches it anyway, and `sql_decls.rs:49` states the existing philosophy is *"let the database
+   do its job."* Does v3 change that stance?
+6. Params must cast to `eql_v3.query_<name>` twins, not the stored domain. Does the mapper need
+   the query inventory too, or can the twin name be derived by prefixing?
+7. Which authority owns an encrypted column's scalar type — `pg_type` or the encrypt config?
+   Should the other be cross-checked?
+8. Does `eql-bindings` become a dependency of `eql-mapper` (inverting `all()` into a
+   typname → capability map), or does the mapper keep its own table?
+
+### Prerequisites, whatever the design
+
+- Fix `EqlTraits::difference` XOR bug and the reversed `must_implement` operands **before**
+  bounds become reachable.
+- Reconcile `schema_delta.rs`'s `default()` with the loader's `all()`.
+- Verify whether EQL 3 ships operator/function overloads bound to the domains — that alone
+  decides whether `RewriteStandardSqlFnsOnEqlTypes` retires.
+
+---
+
+## 9. Related memory
+
+`~/.claude/projects/-Users-jamessadler-cipherstash-proxy/memory/`:
+`eql-3-upgrade-in-flight.md`, `cip-3233-client-038-ore-cllw-break.md`,
+`proxy-222-stackauth-15min-auth-bug.md`.

--- a/packages/cipherstash-proxy/Cargo.toml
+++ b/packages/cipherstash-proxy/Cargo.toml
@@ -21,6 +21,7 @@ config = { version = "0.15", features = [
     "toml",
 ], default-features = false }
 cts-common = { workspace = true }
+eql-bindings = { workspace = true }
 eql-mapper = { path = "../eql-mapper" }
 exitcode = "1.1.2"
 hex = "0.4.3"

--- a/packages/cipherstash-proxy/src/postgresql/messages/data_row.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/data_row.rs
@@ -240,85 +240,26 @@ mod tests {
         vec![None, column_config(column)]
     }
 
-    // NOTE: the four `to_ciphertext_*` tests below are pinned to captured
-    // PostgreSQL wire payloads that predate EQL v3. The v3 representation
-    // adopted on this branch parses a column as a v3 `EqlCiphertextV3` (jsonb:
-    // a MessagePack-Base85 record `c`, plus a real SteVec document for jsonb
-    // columns), which these v2 composite/rowtype fixtures do not satisfy —
-    // `as_ciphertext` deserialises them to `None` and the assertions fail.
-    // Valid v3 fixtures cannot be hand-authored; they have to be captured from
-    // a real encrypt round-trip against a live ZeroKMS / EQL-v3 database.
-    // Ignored until those payloads are regenerated (tracked separately).
+    // The four `to_ciphertext_*` fixtures below are REAL EQL v3 wire captures
+    // taken from Postgres -> Proxy `DataRow` messages for the `encrypted` test
+    // table (regenerated via a live encrypt round-trip against ZeroKMS + EQL
+    // v3.0.2). They exercise `DataRow::try_from` + `as_ciphertext` across the
+    // binary (jsonb `0x01` version header) and text (bare JSON) wire encodings,
+    // and NULL columns.
     #[test]
-    #[ignore = "stale EQL v2 wire fixture; needs a real v3 payload regenerated against a live encrypt path — see note above"]
     pub fn to_ciphertext_with_binary_encoding() {
         log::init(LogConfig::with_level(LogLevel::Debug));
 
-        //  Binary
-        // SELECT id, encrypted_text FROM encrypted WHERE id = $1
-        let bytes = to_message(b"D\0\0\nR\0\x02\0\0\0\x08w\xaam\xf8Y$\x9dI\0\0\n<\0\0\0\x01\0\0\x0e\xda\0\0\n0\x01{\"b\": null, \"c\": \"mBbLbP2ww9ymEpm_yfj>@=^)JCqtLxcewai)Ilzx#HbC2p3F;dB`XP9af|s-igMjdMWLYPqYWAB#2|%<Q?A|Izg<&Cs4$4MtatzDN{_NWZFbsdA0=?)lF+VYZewzJaCBv4Uvy=7bie\", \"i\": {\"c\": \"encrypted_text\", \"t\": \"encrypted\"}, \"m\": [71, 1624, 929, 1339, 1764, 1380, 1256, 2018, 575, 470, 1792, 1684, 205, 894, 1365, 272, 814, 1333, 1971, 1942, 1335, 404, 1204, 638, 18, 1147, 1098, 1448, 403, 234, 647, 1982, 279, 1606, 826, 113, 652, 1287, 986, 1239, 1988, 358, 1589, 1775, 1997, 633, 369, 1744, 1700, 1149, 1641, 609, 1506, 1915, 630, 1045, 141, 815, 445, 145, 1758, 1772, 1162, 1761, 1619, 1328, 901, 1090, 637, 1529, 1181, 527, 388, 2015, 1317, 1019, 1369, 1340, 176, 936, 1716, 515, 1101, 656, 1737, 1858, 1633, 1849, 512, 1347, 1389, 700, 1336, 1253, 1396, 381, 35, 586, 581, 1877, 1226, 1273, 80, 1499, 433, 1649, 573, 1150, 1572, 1533, 1077], \"o\": [\"faa1f63cb6d36094d1aa50db6c0217eb447a987071119bb127f677b6a7ee0b4fe40eed7cd84e96e8a11bbe3ea14331f3ec4c8f149ce9d2b0253b4676c86557fcec4a5f8ca4e1ee081c66bf0a3cb594c6b5739f77f62fc5e76991869c23a97f01816cde3dfc24b2ca2fbb12b50fde324f18aa51718d681772bf9caf3c059a6748cbcaf4dd1c4fa026e47f4be75ce9046de508041645c0d48cddef735db92b4495a783b2a0f54d6723c959f74aae6fab62202f0d1f2cc2336ced18df80d12b4c6b5e504d2f6e21e12e2cc8ae620b9c714b8becbed3ed8d2b4ece3f0c911eeee4cba805098becdb041966faf06546cb48037153c3285f3d53f750c7cb7b1b6a985de296d0592b0bcb71687a09cd38d53979c5399245a85f9c8c5db68d14a2c2521795b8d670700e1ff324e0f46fe5338f63074adeba5a8a7d81b2693413ed97aa827b5a16ce9fa33ff9c2870465d992e367dfca76d957cbfb1062433825b83941f40b4d47cd65522c8634f4440b058dae20ec940eecaad70f46a81599ebec6c90735a51170f5456685307e9bdb5d9b94665c6b86985dcd95125\", \"b41d89a196a35252a965ce3c330eac369ead56e9f06e2016da4d6971fe0b8d6e677e1018e7a1bd2fa0b2c1faaa12650d678352ecc81f6be879213fe78b8004b87dd7dcadec59df4dcafdb3c9aa55dcb2cc2bcf2193574b201c9a1c14764d69716f63b0c1aa30a2846696f2a1c790ca2cb26370d7e20904a8748ea98a95ee3cbb95c5f342de4e71bb080b6e5cfcb730ba4c094304c759fe520fd59fa20eb1381bf9cb07b3a952a9cd0994ba49085475b605c67df0f5fb970fe20c343bdb6e4e90037656787cfd58622aa6f77026c57b66b95390f7560ed7dc640553e6219dea4015b3484e835241090d1bae888cbf946dc114680e36119a3aa95f64fb13c88dd6e9636898d423d82964dddec5311ec94a30b71eab561988be6cd07e6b7c18df9b4f0fffcc53cec5e883830ab868ee626d7c9bf6bbf8612eb2e0b472e223a06ddf920988630809e02cacf525e7533406f08ec7b192f2d78cb9d4acda1cd8e0d35898ff15b0b6c00d5dc4fa9e45f0666319e32a54d41da63b34cd83b2ccbb70db48ab3d3a959f2e24e40b899e334b8458430376cb7e28c8e673\"], \"s\": null, \"u\": \"962d77dfaf892b596b3255c022359e54f3e8dc8b21c3d1b32ebd05555f433192\", \"v\": 1, \"sv\": null, \"ocf\": null, \"ocv\": null}");
+        // `SELECT encrypted_text FROM encrypted WHERE id = $1` (extended/binary):
+        // the jsonb column arrives as `0x01` + the v3 EqlCiphertextV3 JSON.
+        let bytes = to_message(b"D\x00\x00\x03\x16\x00\x01\x00\x00\x03\x0c\x01{\"c\": \"mBbL3gJuL?E})+>NeOq5<7N279rs9aRhBwjz3>wOdg{d64myql`6cXIurM_?B|pR<+M8(SeOLoLt~axenSv%=hCOb&m`FC5F;fS-ykq76u4Qgxa(QrcWn^D;Wq5SN5EJ90LtnW_NroxKJj=JLK>\", \"i\": {\"c\": \"encrypted_text\", \"t\": \"encrypted\"}, \"v\": 3, \"bf\": [1512, 1681, 836, 288, 1837, 1131, 415, 1430, 60, 812, 1990, 1211, 1368, 343, 1473, 1980, 598, 1549, 457, 1389, 1557, 941, 494, 1009, 1604, 1033, 2046, 222, 2012, 671, 7, 1525, 265, 901, 743, 543, 1771, 1149, 890, 755, 1974, 1960, 387, 1947, 1298, 130, 1758, 1060, 268, 844, 1375, 746, 1251, 2040], \"hm\": \"96aeaf9852416229d6b33ceb018d9abc90d70cbe7632539d69ef1462c9aa86a0\", \"op\": \"00bf0281ccb68cc6fe496bb1c8277e3484f6392517d5b8425536af7ec00ad7cc40e17e6336568ac4ed98dd659f7581f8a113fe5669b89833d9dd8eadc587a8950b6bd94f872e7f4205a6859e071df47134d3cccf1e53295417\"}");
         let mut data_row = DataRow::try_from(&bytes).unwrap();
 
-        let column_config = column_config_with_id("encrypted_text");
-        let encrypted = data_row.as_ciphertext(&column_config);
-
-        assert_eq!(encrypted.len(), 2);
-
-        // Two rows
-        assert!(encrypted[0].is_none());
-        assert!(encrypted[1].is_some());
-
-        assert_eq!(
-            &column_config[1].as_ref().unwrap().identifier,
-            encrypted[1].as_ref().unwrap().identifier()
-        );
-    }
-
-    #[test]
-    #[ignore = "stale EQL v2 wire fixture; needs a real v3 payload regenerated against a live encrypt path — see note above"]
-    pub fn to_ciphertext_with_binary_encoding_and_null() {
-        log::init(LogConfig::with_level(LogLevel::Debug));
-
-        // Binary
-        // encrypted_text IS NULL
-        // SELECT id, encrypted_text FROM encrypted WHERE id = $1
-
-        // let bytes = to_message(b"D\0\0\0\"\0\x02\0\0\0\x089\"\x88A\xe59\xb0\x13\0\0\0\x0c\0\0\0\x01\0\0\x0e\xda\xff\xff\xff\xff");
-        let bytes = to_message(b"D\0\0\0\"\0\x02\0\0\0\x08>\xe6=<Yk\0\r\0\0\0\x0c\0\0\0\x01\0\0\x0e\xda\xff\xff\xff\xff");
-        let mut data_row = DataRow::try_from(&bytes).unwrap();
-
-        assert!(data_row.columns[1].bytes.is_some());
-
-        let column_config = column_config_with_id("encrypted_text");
-        let encrypted = data_row.as_ciphertext(&column_config);
-
-        assert_eq!(encrypted.len(), 2);
-
-        // Two rows
-        assert!(encrypted[0].is_none());
-        assert!(encrypted[1].is_none());
-
-        // DataColumn has been NULLIFIED
-        assert!(data_row.columns[1].bytes.is_none());
-    }
-
-    #[test]
-    #[ignore = "stale EQL v2 wire fixture; needs a real v3 payload regenerated against a live encrypt path — see note above"]
-    pub fn to_ciphertext_with_text_encoding() {
-        log::init(LogConfig::with_level(LogLevel::Debug));
-
-        // SELECT encrypted_jsonb FROM encrypted LIMIT 1
-        let bytes = to_message(b"D\0\0\x03\xba\0\x01\0\0\x03\xb0(\"{\"\"b\"\": null, \"\"c\"\": \"\"mBbLR(BvRN1BF^PAFs!B^`U;mA>uOUiFLgDpZXhU#s#%c4wyi&Z7`(d0IxUty-cI#Yp%o~QFF39^sRf>4*EG{zlk;}ArEQ}NQHa9@;T73aPOSTpuh\"\", \"\"i\"\": {\"\"c\"\": \"\"encrypted_jsonb\"\", \"\"t\"\": \"\"encrypted\"\"}, \"\"m\"\": null, \"\"o\"\": null, \"\"s\"\": null, \"\"u\"\": null, \"\"v\"\": 1, \"\"sv\"\": [{\"\"b\"\": \"\"8067db44a848ab32c3056a3dbe4edf16\"\", \"\"c\"\": \"\"mBbLR(BvRN1BF^PAFs!B^`U;mA>uOUiFLgDpZXhU#s#%c4wyi&Z7`(d0IxUty-cI#Yp%o~QFF39^sRf>4*EG{zlk;}ArEQ}NQHa9@;T73aPOSTpuh\"\", \"\"m\"\": null, \"\"o\"\": null, \"\"s\"\": \"\"9493d6010fe7845d52149b697729c745\"\", \"\"u\"\": null, \"\"sv\"\": null, \"\"ocf\"\": null, \"\"ocv\"\": null}, {\"\"b\"\": null, \"\"c\"\": \"\"mBbLR(BvRN1BF^PAFs!B^`U;m8QkTKr|h>Q`^NbW(CC|>SD}UM=o%mz(Fw#LQFF39^sRf>4*EG{zlk;}ArEQ}NQHa9@;T73aPOSTpuh\"\", \"\"m\"\": null, \"\"o\"\": null, \"\"s\"\": \"\"b1f0e4bb3855bc33936ef1fddf532765\"\", \"\"u\"\": null, \"\"sv\"\": null, \"\"ocf\"\": null, \"\"ocv\"\": \"\"fbc7a11fc81f2a31c904c5b05572b054824e3b5f5ece78f1b711f93175f0a4a9726157cea247e107\"\"}], \"\"ocf\"\": null, \"\"ocv\"\": null}\")");
-        let mut data_row = DataRow::try_from(&bytes).unwrap();
-
-        assert!(data_row.columns[0].bytes.is_some());
-
-        let column_config = vec![column_config("encrypted_jsonb")];
+        let column_config = vec![column_config("encrypted_text")];
         let encrypted = data_row.as_ciphertext(&column_config);
 
         assert_eq!(encrypted.len(), 1);
         assert!(encrypted[0].is_some());
-
         assert_eq!(
             &column_config[0].as_ref().unwrap().identifier,
             encrypted[0].as_ref().unwrap().identifier()
@@ -326,45 +267,63 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "stale EQL v2 wire fixture; needs a real v3 payload regenerated against a live encrypt path — see note above"]
+    pub fn to_ciphertext_with_binary_encoding_and_null() {
+        log::init(LogConfig::with_level(LogLevel::Debug));
+
+        // `SELECT encrypted_text, encrypted_bool FROM encrypted WHERE id = $1`
+        // (binary), encrypted_text set, encrypted_bool NULL.
+        let bytes = to_message(b"D\x00\x00\x03\x1a\x00\x02\x00\x00\x03\x0c\x01{\"c\": \"mBbL3gJuL?E})+>NeOq5<7N279rs9aRhBwjz3>wOdg{d64myql`6cXIurM_?B|pR<+M8(SeOLoLt~axenSv%=hCOb&m`FC5F;fS-ykq76u4Qgxa(QrcWn^D;Wq5SN5EJ90LtnW_NroxKJj=JLK>\", \"i\": {\"c\": \"encrypted_text\", \"t\": \"encrypted\"}, \"v\": 3, \"bf\": [1512, 1681, 836, 288, 1837, 1131, 415, 1430, 60, 812, 1990, 1211, 1368, 343, 1473, 1980, 598, 1549, 457, 1389, 1557, 941, 494, 1009, 1604, 1033, 2046, 222, 2012, 671, 7, 1525, 265, 901, 743, 543, 1771, 1149, 890, 755, 1974, 1960, 387, 1947, 1298, 130, 1758, 1060, 268, 844, 1375, 746, 1251, 2040], \"hm\": \"96aeaf9852416229d6b33ceb018d9abc90d70cbe7632539d69ef1462c9aa86a0\", \"op\": \"00bf0281ccb68cc6fe496bb1c8277e3484f6392517d5b8425536af7ec00ad7cc40e17e6336568ac4ed98dd659f7581f8a113fe5669b89833d9dd8eadc587a8950b6bd94f872e7f4205a6859e071df47134d3cccf1e53295417\"}\xff\xff\xff\xff");
+        let mut data_row = DataRow::try_from(&bytes).unwrap();
+
+        let column_config = vec![
+            column_config("encrypted_text"),
+            column_config("encrypted_bool"),
+        ];
+        let encrypted = data_row.as_ciphertext(&column_config);
+
+        assert_eq!(encrypted.len(), 2);
+        assert!(encrypted[0].is_some());
+        assert!(encrypted[1].is_none());
+    }
+
+    #[test]
+    pub fn to_ciphertext_with_text_encoding() {
+        log::init(LogConfig::with_level(LogLevel::Debug));
+
+        // `SELECT encrypted_jsonb FROM encrypted WHERE id = 2` (simple/text): the
+        // jsonb column arrives as bare JSON text, no version header.
+        let bytes = to_message(b"D\x00\x00\x027\x00\x01\x00\x00\x02-{\"h\": \"l*AC8+7wO)sD**%APm>F3Bc9FAg#FNCmyISKh%bW{NbL}o`gZpBwFD}ye0IoZJ}<8La$|RV{&<LbY)~;YIARHV#E*=<D)}gxkyQdDaAa?x2iz\", \"i\": {\"c\": \"encrypted_jsonb\", \"t\": \"encrypted\"}, \"k\": \"sv\", \"v\": 3, \"sv\": [{\"c\": \"=)|^uOwqW#H)TqK3PNbj|0;X%JkdzdG4-n\", \"s\": \"4aea36922168767cc743f65936aca693\"}, {\"c\": \"x%zSLSuK0+1GBi+xNdO9%dFT^^Z\", \"s\": \"956c1af474fb873d521afac3f1fed11e\", \"op\": \"00edcfafe10ba38a5a106d2f12d2f7f57238\"}, {\"c\": \"b#r<7aRQs|X-ca_T!nIL<t}C\", \"s\": \"86bc88ee9ebbf7a7bdf1ca2f5289b175\"}, {\"c\": \"`v9`QIuYF_El2G2gz+I}vEv8\", \"s\": \"38e70163b339d6b3bb126618a630d624\"}]}");
+        let mut data_row = DataRow::try_from(&bytes).unwrap();
+
+        let column_config = vec![column_config("encrypted_jsonb")];
+        let encrypted = data_row.as_ciphertext(&column_config);
+
+        assert_eq!(encrypted.len(), 1);
+        assert!(encrypted[0].is_some());
+        assert_eq!(
+            &column_config[0].as_ref().unwrap().identifier,
+            encrypted[0].as_ref().unwrap().identifier()
+        );
+    }
+
+    #[test]
     pub fn to_ciphertext_with_text_encoding_and_null() {
         log::init(LogConfig::with_level(LogLevel::Debug));
 
-        // SELECT * FROM encrypted WHERE id = $1;
-        // Only encrypted_text is NOT NULL
-        let bytes = to_message(b"D\0\0\n\x91\0\n\0\0\0\n1297231342\xff\xff\xff\xff\0\0\nY(\"{\"\"b\"\": null, \"\"c\"\": \"\"mBbJ;S^xMu<v?;UyTSS~VfK;4C(U~uOiKbWSK*!hB3vi!C$luW$k`K6>@++(U20{lxK;qYYaDYF#30N~x;wyOUMoFOB9K!>A_9g9j@+M6V3wENqu#H8gDb9OZewzJaCBv4Uvy=7bie\"\", \"\"i\"\": {\"\"c\"\": \"\"encrypted_text\"\", \"\"t\"\": \"\"encrypted\"\"}, \"\"m\"\": [369, 381, 1758, 403, 35, 609, 1181, 1098, 1347, 1633, 1150, 815, 1997, 234, 1858, 656, 1335, 936, 1204, 630, 1764, 1328, 1649, 1396, 113, 1149, 1499, 1147, 586, 1942, 901, 1256, 1226, 1045, 637, 279, 1162, 1077, 1340, 1336, 1448, 700, 176, 1849, 1915, 1389, 71, 515, 633, 388, 1877, 1339, 1239, 638, 1365, 1380, 1273, 581, 1792, 1716, 145, 512, 814, 272, 1333, 1775, 1572, 1744, 2018, 433, 1641, 1529, 647, 1317, 652, 1606, 1737, 470, 826, 80, 929, 1700, 1619, 1253, 358, 1589, 1971, 1019, 1533, 1624, 573, 1684, 1287, 575, 1761, 527, 404, 1369, 894, 18, 1101, 986, 1772, 1090, 1506, 2015, 1988, 205, 141, 445, 1982], \"\"o\"\": [\"\"faa1f63cb6d36094d1aa50db6c0217eb447a987071119bb127f677b6a7ee0b4fe40eed7cd84e96e8a11bbe3ea14331f3ec4c8f149ce9d2b0253b4676c86557fcec4a5f8ca4e1ee081c66bf0a3cb594c6b5739f77f62fc5e76991869c23a97f01816cde3dfc24b2ca2fbb12b50fde324f18aa51718d681772bf9caf3c059a6748cbcaf4dd1c4fa02645d74699d7d265faf938c339f6cc8f57db9bd4cff8e03cae9e5d21a651b33525e86e335dff61520e8f23d7002f05fa186075a335fb7b2c740133b5a72760ccd216127d69983aa31a090a3b6ca56a48b6372cab60c979465d84dc94e5452c92517b643882fa82c22a26b4feaaa1b0ae8fcb989b10d0351fb3c9c5e56e719f820442612a67fff334438f3f5d35ff6db1b5f7a50670c7fec014f6fc19c352eb011911faf62a230e10c2d16f6c84b46cf9ee7eb1afb9c61a523891e31da2a18b445769d75c11873566dc8196d77e985423226bd1db10e4ce9eb10c2f69db7ce57d47281401617978d2bcfca23b9015b9e705615b8bf773daa87a18417f86e5338a7929fa4f10c6864af09870bfd9ddfb7848\"\", \"\"b41d89a196a35252a965ce3c330eac369ead56e9f06e2016da4d6971fe0b8d6e677e1018e7a1bd2fa0b2c1faaa12650d678352ecc81f6be879213fe78b8004b87dd7dcadec59df4dcafdb3c9aa55dcb2cc2bcf2193574b201c9a1c14764d69716f63b0c1aa30a2846696f2a1c790ca2cb26370d7e20904a8748ea98a95ee3cbb95c5f342de4e71bbf0262e84d59188ea72fe4449a16e7c73f88ed06b9cb724902a85d063c03e9b1a63dd18b9604625ca3cb8110d9c8f93e1771525c51b6ee092d554e84d61df5b557994f32191bb2b6801d9727fb707d5287e6c83d6b16763a6e66526baf80765a58d36df744be7872d2750eb28a86a519a21ee710f618c09cb2bd45f21e805ae4e11eb2987d7be31c32164d4f828fc35c389d516d0d6a54e25041985cffcb6124b4d3fa5b0ba91e19d60e3102370e9c1c768df1b427c682304a1dfdea2d3e514db22057f43d8121b8daf7c434831e5b618bbca9f4e198741927bdc168e4703fb1f703957f7b70491e06bec4adee19d29ef5e938695e1d49ef50ceef0a9c3e46bd8fe309e013e5ea0d35c5ebf3dddd97573\"\"], \"\"s\"\": null, \"\"u\"\": \"\"962d77dfaf892b596b3255c022359e54f3e8dc8b21c3d1b32ebd05555f433192\"\", \"\"v\"\": 1, \"\"sv\"\": null, \"\"ocf\"\": null, \"\"ocv\"\": null}\")\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff");
-
+        // `SELECT encrypted_text, encrypted_bool FROM encrypted WHERE id = 1`
+        // (text), encrypted_text set, encrypted_bool NULL.
+        let bytes = to_message(b"D\x00\x00\x03\x19\x00\x02\x00\x00\x03\x0b{\"c\": \"mBbL3gJuL?E})+>NeOq5<7N279rs9aRhBwjz3>wOdg{d64myql`6cXIurM_?B|pR<+M8(SeOLoLt~axenSv%=hCOb&m`FC5F;fS-ykq76u4Qgxa(QrcWn^D;Wq5SN5EJ90LtnW_NroxKJj=JLK>\", \"i\": {\"c\": \"encrypted_text\", \"t\": \"encrypted\"}, \"v\": 3, \"bf\": [1512, 1681, 836, 288, 1837, 1131, 415, 1430, 60, 812, 1990, 1211, 1368, 343, 1473, 1980, 598, 1549, 457, 1389, 1557, 941, 494, 1009, 1604, 1033, 2046, 222, 2012, 671, 7, 1525, 265, 901, 743, 543, 1771, 1149, 890, 755, 1974, 1960, 387, 1947, 1298, 130, 1758, 1060, 268, 844, 1375, 746, 1251, 2040], \"hm\": \"96aeaf9852416229d6b33ceb018d9abc90d70cbe7632539d69ef1462c9aa86a0\", \"op\": \"00bf0281ccb68cc6fe496bb1c8277e3484f6392517d5b8425536af7ec00ad7cc40e17e6336568ac4ed98dd659f7581f8a113fe5669b89833d9dd8eadc587a8950b6bd94f872e7f4205a6859e071df47134d3cccf1e53295417\"}\xff\xff\xff\xff");
         let mut data_row = DataRow::try_from(&bytes).unwrap();
 
-        assert!(data_row.columns[0].bytes.is_some());
-
         let column_config = vec![
-            None,
-            None,
             column_config("encrypted_text"),
             column_config("encrypted_bool"),
-            column_config("encrypted_int2"),
-            column_config("encrypted_int4"),
-            column_config("encrypted_int8"),
-            column_config("encrypted_float8"),
-            column_config("encrypted_date"),
-            column_config("encrypted_jsonb"),
         ];
-
         let encrypted = data_row.as_ciphertext(&column_config);
 
-        assert_eq!(encrypted.len(), 10);
-
-        assert!(encrypted[0].is_none());
+        assert_eq!(encrypted.len(), 2);
+        assert!(encrypted[0].is_some());
         assert!(encrypted[1].is_none());
-        assert!(encrypted[2].is_some()); // <-- Some
-        assert!(encrypted[3].is_none());
-        // etc
-
-        assert_eq!(
-            &column_config[2].as_ref().unwrap().identifier,
-            encrypted[2].as_ref().unwrap().identifier()
-        );
     }
 
     #[test]

--- a/packages/cipherstash-proxy/src/proxy/schema/eql_domains.rs
+++ b/packages/cipherstash-proxy/src/proxy/schema/eql_domains.rs
@@ -1,0 +1,229 @@
+//! Resolves EQL v3 Postgres domain typnames to the inert domain identity and
+//! capabilities the type checker needs (ADR-0002).
+//!
+//! The mapping is inverted from the `eql-bindings` v3 catalog (`v3::all()`),
+//! which is generated from the same source as the installed SQL domains, so it
+//! cannot drift from them. `eql-mapper` stays wire-format-agnostic — this
+//! `eql-bindings` dependency lives only in the proxy's schema loader.
+//!
+//! Term → capability mapping (from `eql-bindings` `v3::terms`):
+//! - `hm` (HMAC-256)  → `Eq`
+//! - `op` (CLLW-OPE)  → `Ord`
+//! - `ob` (block-ORE) → `Ord`
+//! - `bf` (bloom)     → `TokenMatch`
+//! - `c` / empty      → storage-only (no capabilities)
+//!
+//! `term_json_keys() == None` marks the JSON SteVec domains
+//! (`eql_v3_json_search`, `eql_v3_json_entry`), whose searchable terms live
+//! per-entry rather than on the domain. Those are mapped to `JsonLike`.
+//!
+//! NOTE (CIP-3598): the precise capability set for the JSON SteVec domains was
+//! not pinned down by the v3 type-checker ADRs; `JsonLike` is a provisional
+//! choice pending that decision.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use eql_bindings::v3;
+use eql_mapper::{DomainIdentity, EqlTrait, EqlTraits, TokenType};
+use sqltk::parser::ast::Ident;
+
+/// The `eql_v3_` typname prefix every public-schema column domain carries.
+const DOMAIN_PREFIX: &str = "eql_v3_";
+
+/// `typname` (e.g. `eql_v3_integer_ord`) → (token type, capabilities), inverted
+/// once from the `eql-bindings` catalog.
+fn catalog() -> &'static HashMap<String, (TokenType, EqlTraits)> {
+    static MAP: OnceLock<HashMap<String, (TokenType, EqlTraits)>> = OnceLock::new();
+    MAP.get_or_init(|| {
+        let mut map = HashMap::new();
+        for domain in v3::all() {
+            // `sql_domain()` is schema-qualified, e.g. `public.eql_v3_integer_ord`.
+            let qualified = domain.sql_domain();
+            let typname = qualified.rsplit('.').next().unwrap_or(qualified);
+
+            if let Some(token) = token_type(typname) {
+                let traits = traits_from_terms(domain.term_json_keys());
+                map.insert(typname.to_string(), (token, traits));
+            }
+        }
+        map
+    })
+}
+
+/// Resolve a Postgres domain typname to its inert v3 domain identity and
+/// capabilities, or `None` if it is not a recognised v3 EQL domain.
+pub(crate) fn resolve(typname: &str) -> Option<(DomainIdentity, EqlTraits)> {
+    let (token, traits) = catalog().get(typname).copied()?;
+    let identity = DomainIdentity {
+        token,
+        domain: Ident::new(typname),
+    };
+    Some((identity, traits))
+}
+
+/// The token type is the first segment after the `eql_v3_` prefix; every token
+/// type is a single underscore-free word, so the capability suffix (which may
+/// itself contain underscores, e.g. `ord_ore`) never interferes.
+fn token_type(typname: &str) -> Option<TokenType> {
+    let rest = typname.strip_prefix(DOMAIN_PREFIX)?;
+    let token = rest.split('_').next()?;
+    Some(match token {
+        "smallint" => TokenType::SmallInt,
+        "integer" => TokenType::Integer,
+        "bigint" => TokenType::BigInt,
+        "real" => TokenType::Real,
+        "double" => TokenType::Double,
+        "numeric" => TokenType::Numeric,
+        "text" => TokenType::Text,
+        "boolean" => TokenType::Boolean,
+        "date" => TokenType::Date,
+        "timestamp" => TokenType::Timestamp,
+        "json" => TokenType::Json,
+        _ => return None,
+    })
+}
+
+fn traits_from_terms(term_keys: Option<&[&str]>) -> EqlTraits {
+    match term_keys {
+        // JSON SteVec domains carry their terms per entry, not on the domain.
+        None => EqlTraits::from(EqlTrait::JsonLike),
+        Some(terms) => terms
+            .iter()
+            .filter_map(|term| match *term {
+                "hm" => Some(EqlTrait::Eq),
+                "op" | "ob" => Some(EqlTrait::Ord),
+                "bf" => Some(EqlTrait::TokenMatch),
+                // `c` is the storage-only source-ciphertext term; anything else
+                // is unknown and contributes no capability.
+                _ => None,
+            })
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn traits(typname: &str) -> EqlTraits {
+        resolve(typname)
+            .unwrap_or_else(|| panic!("{typname} did not resolve"))
+            .1
+    }
+
+    fn token(typname: &str) -> TokenType {
+        resolve(typname).unwrap().0.token
+    }
+
+    #[test]
+    fn storage_only_domain_has_no_capabilities() {
+        assert_eq!(traits("eql_v3_integer"), EqlTraits::none());
+        assert_eq!(traits("eql_v3_text"), EqlTraits::none());
+        // boolean is storage-only by design (a two-value column leaks its
+        // distribution under any index).
+        assert_eq!(traits("eql_v3_boolean"), EqlTraits::none());
+    }
+
+    #[test]
+    fn eq_domain_implements_eq_only() {
+        assert_eq!(traits("eql_v3_integer_eq"), EqlTraits::from(EqlTrait::Eq));
+    }
+
+    #[test]
+    fn ord_domains_imply_eq() {
+        // `op` and `ob` both back Ord; Ord implies Eq.
+        let ord = EqlTraits::from(EqlTrait::Ord);
+        assert_eq!(traits("eql_v3_integer_ord"), ord); // op
+        assert_eq!(traits("eql_v3_integer_ord_ope"), ord); // op
+        assert_eq!(traits("eql_v3_integer_ord_ore"), ord); // ob
+        assert!(traits("eql_v3_integer_ord").eq); // Ord ⇒ Eq
+    }
+
+    #[test]
+    fn match_domain_implements_token_match() {
+        assert_eq!(
+            traits("eql_v3_text_match"),
+            EqlTraits::from(EqlTrait::TokenMatch)
+        );
+    }
+
+    #[test]
+    fn text_ord_carries_the_hm_equality_exception() {
+        // Lexicographic ORE/OPE over text is not equality-lossless, so text_ord*
+        // stores `hm` alongside its ordering term — Eq is explicit, not merely
+        // implied.
+        let eq_ord: EqlTraits = [EqlTrait::Eq, EqlTrait::Ord].into_iter().collect();
+        assert_eq!(traits("eql_v3_text_ord"), eq_ord); // [hm, op]
+        assert_eq!(traits("eql_v3_text_ord_ore"), eq_ord); // [hm, ob]
+    }
+
+    #[test]
+    fn search_domains_implement_eq_ord_and_match() {
+        let all_three: EqlTraits = [EqlTrait::Eq, EqlTrait::Ord, EqlTrait::TokenMatch]
+            .into_iter()
+            .collect();
+        assert_eq!(traits("eql_v3_text_search"), all_three); // [hm, op, bf]
+        assert_eq!(traits("eql_v3_text_search_ore"), all_three); // [hm, ob, bf]
+    }
+
+    #[test]
+    fn json_search_domain_is_json_like() {
+        assert_eq!(
+            traits("eql_v3_json_search"),
+            EqlTraits::from(EqlTrait::JsonLike)
+        );
+    }
+
+    #[test]
+    fn token_type_is_parsed_across_suffixes() {
+        assert_eq!(token("eql_v3_integer_ord_ore"), TokenType::Integer);
+        assert_eq!(token("eql_v3_bigint_eq"), TokenType::BigInt);
+        assert_eq!(token("eql_v3_text_search"), TokenType::Text);
+        assert_eq!(token("eql_v3_timestamp_ord"), TokenType::Timestamp);
+        assert_eq!(token("eql_v3_json_search"), TokenType::Json);
+    }
+
+    #[test]
+    fn domain_identity_carries_the_typname() {
+        let (identity, _) = resolve("eql_v3_integer_ord").unwrap();
+        assert_eq!(identity.domain.value, "eql_v3_integer_ord");
+        assert_eq!(identity.token, TokenType::Integer);
+    }
+
+    #[test]
+    fn non_eql_domain_names_do_not_resolve() {
+        assert!(resolve("jsonb").is_none());
+        assert!(resolve("text").is_none());
+        assert!(resolve("eql_v2_encrypted").is_none());
+        assert!(resolve("").is_none());
+    }
+
+    #[test]
+    fn every_public_column_domain_resolves_to_a_known_token_type() {
+        // Guards against a new token type being added upstream that this loader
+        // silently drops. Only `public.eql_v3_*` column domains are user-facing
+        // column types; the `eql_v3.query_*` operand twins that `all()` also
+        // yields (e.g. `eql_v3.query_json`) are deliberately not resolved.
+        let mut checked = 0;
+        for domain in v3::all() {
+            let qualified = domain.sql_domain();
+            if let Some(typname) = qualified.strip_prefix("public.") {
+                assert!(
+                    resolve(typname).is_some(),
+                    "public column domain {typname} did not resolve to a token type"
+                );
+                checked += 1;
+            }
+        }
+        assert!(checked > 0, "no public column domains found in the catalog");
+    }
+
+    #[test]
+    fn query_operand_twins_are_not_resolved_as_column_domains() {
+        // `all()` yields at least one `eql_v3.query_*` twin; those are operands,
+        // never column types, so they must not resolve here.
+        assert!(resolve("query_json").is_none());
+        assert!(resolve("query_integer_eq").is_none());
+    }
+}

--- a/packages/cipherstash-proxy/src/proxy/schema/eql_domains.rs
+++ b/packages/cipherstash-proxy/src/proxy/schema/eql_domains.rs
@@ -15,26 +15,24 @@
 //!
 //! `term_json_keys() == None` marks the JSON SteVec domains
 //! (`eql_v3_json_search`, `eql_v3_json_entry`), whose searchable terms live
-//! per-entry rather than on the domain. Those are mapped to `JsonLike`.
-//!
-//! NOTE (CIP-3598): the precise capability set for the JSON SteVec domains was
-//! not pinned down by the v3 type-checker ADRs; `JsonLike` is a provisional
-//! choice pending that decision.
+//! per-entry rather than on the domain. Verified against the installed v3 SQL
+//! (`cipherstash-encrypt.sql`), an encrypted JSON column supports `->`/`->>`
+//! (JsonLike) **and** `@>`/`<@` containment (Contain) — the latter are real
+//! implementations, not the raise-stubs the other jsonb operators get. So JSON
+//! domains map to `JsonLike + Contain`. (Note: `@>`/`<@` are removed only on
+//! *scalar* encrypted columns; on JSON they are the primary query surface.)
 
 use std::collections::HashMap;
 use std::sync::OnceLock;
 
 use eql_bindings::v3;
 use eql_mapper::{DomainIdentity, EqlTrait, EqlTraits, TokenType};
-use sqltk::parser::ast::Ident;
 
-/// The `eql_v3_` typname prefix every public-schema column domain carries.
-const DOMAIN_PREFIX: &str = "eql_v3_";
-
-/// `typname` (e.g. `eql_v3_integer_ord`) → (token type, capabilities), inverted
-/// once from the `eql-bindings` catalog.
-fn catalog() -> &'static HashMap<String, (TokenType, EqlTraits)> {
-    static MAP: OnceLock<HashMap<String, (TokenType, EqlTraits)>> = OnceLock::new();
+/// `typname` (e.g. `eql_v3_integer_ord`) → capabilities, inverted once from the
+/// `eql-bindings` catalog. Keyed only by the public column domains; the token
+/// type is recovered from the typname via [`DomainIdentity::from_domain_name`].
+fn catalog() -> &'static HashMap<String, EqlTraits> {
+    static MAP: OnceLock<HashMap<String, EqlTraits>> = OnceLock::new();
     MAP.get_or_init(|| {
         let mut map = HashMap::new();
         for domain in v3::all() {
@@ -42,9 +40,13 @@ fn catalog() -> &'static HashMap<String, (TokenType, EqlTraits)> {
             let qualified = domain.sql_domain();
             let typname = qualified.rsplit('.').next().unwrap_or(qualified);
 
-            if let Some(token) = token_type(typname) {
-                let traits = traits_from_terms(domain.term_json_keys());
-                map.insert(typname.to_string(), (token, traits));
+            // Only public column domains have a parseable token type; this skips
+            // the `eql_v3.query_*` operand twins that `all()` also yields.
+            if TokenType::from_domain_name(typname).is_some() {
+                map.insert(
+                    typname.to_string(),
+                    traits_from_terms(domain.term_json_keys()),
+                );
             }
         }
         map
@@ -54,40 +56,19 @@ fn catalog() -> &'static HashMap<String, (TokenType, EqlTraits)> {
 /// Resolve a Postgres domain typname to its inert v3 domain identity and
 /// capabilities, or `None` if it is not a recognised v3 EQL domain.
 pub(crate) fn resolve(typname: &str) -> Option<(DomainIdentity, EqlTraits)> {
-    let (token, traits) = catalog().get(typname).copied()?;
-    let identity = DomainIdentity {
-        token,
-        domain: Ident::new(typname),
-    };
+    let traits = *catalog().get(typname)?;
+    let identity = DomainIdentity::from_domain_name(typname)?;
     Some((identity, traits))
-}
-
-/// The token type is the first segment after the `eql_v3_` prefix; every token
-/// type is a single underscore-free word, so the capability suffix (which may
-/// itself contain underscores, e.g. `ord_ore`) never interferes.
-fn token_type(typname: &str) -> Option<TokenType> {
-    let rest = typname.strip_prefix(DOMAIN_PREFIX)?;
-    let token = rest.split('_').next()?;
-    Some(match token {
-        "smallint" => TokenType::SmallInt,
-        "integer" => TokenType::Integer,
-        "bigint" => TokenType::BigInt,
-        "real" => TokenType::Real,
-        "double" => TokenType::Double,
-        "numeric" => TokenType::Numeric,
-        "text" => TokenType::Text,
-        "boolean" => TokenType::Boolean,
-        "date" => TokenType::Date,
-        "timestamp" => TokenType::Timestamp,
-        "json" => TokenType::Json,
-        _ => return None,
-    })
 }
 
 fn traits_from_terms(term_keys: Option<&[&str]>) -> EqlTraits {
     match term_keys {
-        // JSON SteVec domains carry their terms per entry, not on the domain.
-        None => EqlTraits::from(EqlTrait::JsonLike),
+        // JSON SteVec domains: `->`/`->>` (JsonLike) plus `@>`/`<@` containment
+        // (Contain), per the installed v3 SQL. The per-entry terms (hm/op) are
+        // not column-level capabilities.
+        None => [EqlTrait::JsonLike, EqlTrait::Contain]
+            .into_iter()
+            .collect(),
         Some(terms) => terms
             .iter()
             .filter_map(|term| match *term {
@@ -168,11 +149,13 @@ mod test {
     }
 
     #[test]
-    fn json_search_domain_is_json_like() {
-        assert_eq!(
-            traits("eql_v3_json_search"),
-            EqlTraits::from(EqlTrait::JsonLike)
-        );
+    fn json_search_domain_is_json_like_and_contain() {
+        // Verified against cipherstash-encrypt.sql: -> / ->> (JsonLike) and
+        // @> / <@ (Contain) are real operators on eql_v3_json_search.
+        let json_caps: EqlTraits = [EqlTrait::JsonLike, EqlTrait::Contain]
+            .into_iter()
+            .collect();
+        assert_eq!(traits("eql_v3_json_search"), json_caps);
     }
 
     #[test]

--- a/packages/cipherstash-proxy/src/proxy/schema/eql_domains.rs
+++ b/packages/cipherstash-proxy/src/proxy/schema/eql_domains.rs
@@ -28,6 +28,20 @@ use std::sync::OnceLock;
 use eql_bindings::v3;
 use eql_mapper::{DomainIdentity, EqlTrait, EqlTraits, TokenType};
 
+/// SteVec sub-structural domains that live in the `public` schema but are NOT
+/// user-declarable column types, so they must never resolve to a column
+/// capability set.
+///
+/// `eql_v3_json_entry` is the element a `->` traversal returns (one `sv` array
+/// entry); its per-entry terms are `hm` XOR `op` (equality/ordering), not the
+/// `JsonLike + Contain` that a `term_json_keys() == None` JSON *document* domain
+/// (`eql_v3_json_search`) carries. Left in the catalog it would type-check a
+/// column mistakenly declared with that type as supporting `->`/`@>` but not
+/// `=`/`<` — inverted. Excluding it makes that misclassification impossible
+/// rather than merely latent: a column so declared falls through to a native
+/// (plaintext) column instead. See PR #424 review.
+const NON_COLUMN_DOMAINS: &[&str] = &["eql_v3_json_entry"];
+
 /// `typname` (e.g. `eql_v3_integer_ord`) → capabilities, inverted once from the
 /// `eql-bindings` catalog. Keyed only by the public column domains; the token
 /// type is recovered from the typname via [`DomainIdentity::from_domain_name`].
@@ -41,8 +55,12 @@ fn catalog() -> &'static HashMap<String, EqlTraits> {
             let typname = qualified.rsplit('.').next().unwrap_or(qualified);
 
             // Only public column domains have a parseable token type; this skips
-            // the `eql_v3.query_*` operand twins that `all()` also yields.
-            if TokenType::from_domain_name(typname).is_some() {
+            // the `eql_v3.query_*` operand twins that `all()` also yields. The
+            // `public` SteVec sub-structural domains (`eql_v3_json_entry`) parse
+            // but are not column types, so exclude them explicitly.
+            if TokenType::from_domain_name(typname).is_some()
+                && !NON_COLUMN_DOMAINS.contains(&typname)
+            {
                 map.insert(
                     typname.to_string(),
                     traits_from_terms(domain.term_json_keys()),
@@ -192,6 +210,11 @@ mod test {
         for domain in v3::all() {
             let qualified = domain.sql_domain();
             if let Some(typname) = qualified.strip_prefix("public.") {
+                // SteVec sub-structural domains are `public` but not column
+                // types (see NON_COLUMN_DOMAINS), so they are excluded by design.
+                if NON_COLUMN_DOMAINS.contains(&typname) {
+                    continue;
+                }
                 assert!(
                     resolve(typname).is_some(),
                     "public column domain {typname} did not resolve to a token type"
@@ -200,6 +223,24 @@ mod test {
             }
         }
         assert!(checked > 0, "no public column domains found in the catalog");
+    }
+
+    #[test]
+    fn json_entry_operand_domain_is_not_a_column_type() {
+        // `eql_v3_json_entry` is the element `->` returns, not a declarable
+        // column type; its per-entry terms are `hm` XOR `op`, so resolving it to
+        // JsonLike+Contain (as `term_json_keys() == None` otherwise would) is
+        // inverted. It must not resolve as a column domain — a column mistakenly
+        // declared with it then falls through to a native column. (#424)
+        assert!(resolve("eql_v3_json_entry").is_none());
+        // The real JSON column domains still resolve.
+        assert!(resolve("eql_v3_json").is_some()); // storage-only
+        assert_eq!(
+            traits("eql_v3_json_search"),
+            [EqlTrait::JsonLike, EqlTrait::Contain]
+                .into_iter()
+                .collect()
+        );
     }
 
     #[test]

--- a/packages/cipherstash-proxy/src/proxy/schema/manager.rs
+++ b/packages/cipherstash-proxy/src/proxy/schema/manager.rs
@@ -163,8 +163,14 @@ pub async fn load_schema(config: &DatabaseConfig) -> Result<Schema, Error> {
                         // type) have no v3 domain identity and are unsupported on
                         // this v3-only build — warn rather than silently treating
                         // them as encrypted or plaintext.
+                        //
+                        // The column is served as a native passthrough: Proxy runs
+                        // no encrypt/decrypt on it, so new writes are stored as-is
+                        // (in plaintext) and existing values are returned as-is.
+                        // This is a data-at-rest exposure on the write path, so the
+                        // warning must be impossible to miss in ops.
                         if column_type_name.as_deref() == Some("eql_v2_encrypted") {
-                            warn!(target: SCHEMA, msg = "ignoring unsupported eql_v2_encrypted column on a v3 build", table = table_name, column = col);
+                            warn!(target: SCHEMA, msg = "eql_v2_encrypted column is unsupported on this EQL v3 build and is being served as a PLAINTEXT (native) column: Proxy performs no encryption on writes or decryption on reads. Migrate the column to an EQL v3 domain before writing to it.", table = table_name, column = col);
                         }
                         Column::native(ident)
                     }

--- a/packages/cipherstash-proxy/src/proxy/schema/manager.rs
+++ b/packages/cipherstash-proxy/src/proxy/schema/manager.rs
@@ -4,7 +4,6 @@ use crate::error::Error;
 use crate::proxy::{AGGREGATE_QUERY, SCHEMA_QUERY};
 use crate::{connect, log::SCHEMA};
 use arc_swap::ArcSwap;
-use eql_mapper::{self, EqlTraits};
 use eql_mapper::{Column, Schema, Table};
 use sqltk::parser::ast::Ident;
 use std::sync::Arc;
@@ -154,18 +153,21 @@ pub async fn load_schema(config: &DatabaseConfig) -> Result<Schema, Error> {
                     .as_deref()
                     .and_then(eql_domains::resolve);
 
-                let column = match (v3, column_type_name.as_deref()) {
-                    (Some((identity, eql_traits)), _) => {
+                let column = match v3 {
+                    Some((identity, eql_traits)) => {
                         debug!(target: SCHEMA, msg = "eql_v3 column", table = table_name, column = col, domain = %identity.domain.value, traits = %eql_traits);
-                        Column::eql_with_identity(ident, eql_traits, Some(identity))
+                        Column::eql(ident, eql_traits, identity)
                     }
-                    // Legacy EQL v2 columns are a composite type, reported by
-                    // `udt_name`. Retained for reading pre-v3 schemas.
-                    (None, Some("eql_v2_encrypted")) => {
-                        debug!(target: SCHEMA, msg = "eql_v2_encrypted column", table = table_name, column = col);
-                        Column::eql(ident, EqlTraits::all())
+                    None => {
+                        // Legacy EQL v2 columns (the `eql_v2_encrypted` composite
+                        // type) have no v3 domain identity and are unsupported on
+                        // this v3-only build — warn rather than silently treating
+                        // them as encrypted or plaintext.
+                        if column_type_name.as_deref() == Some("eql_v2_encrypted") {
+                            warn!(target: SCHEMA, msg = "ignoring unsupported eql_v2_encrypted column on a v3 build", table = table_name, column = col);
+                        }
+                        Column::native(ident)
                     }
-                    _ => Column::native(ident),
                 };
 
                 table.add_column(Arc::new(column));

--- a/packages/cipherstash-proxy/src/proxy/schema/manager.rs
+++ b/packages/cipherstash-proxy/src/proxy/schema/manager.rs
@@ -1,3 +1,4 @@
+use super::eql_domains;
 use crate::config::DatabaseConfig;
 use crate::error::Error;
 use crate::proxy::{AGGREGATE_QUERY, SCHEMA_QUERY};
@@ -133,24 +134,42 @@ pub async fn load_schema(config: &DatabaseConfig) -> Result<Schema, Error> {
         let table_name: String = table.get("table_name");
         let columns: Vec<String> = table.get("columns");
         let column_type_names: Vec<Option<String>> = table.get("column_type_names");
+        let column_domain_names: Vec<Option<String>> = table.get("column_domain_names");
 
         let mut table = Table::new(Ident::new(&table_name));
 
-        columns.iter().zip(column_type_names).for_each(|(col, column_type_name)| {
-            let ident = Ident::with_quote('"', col);
+        columns
+            .iter()
+            .zip(column_type_names)
+            .zip(column_domain_names)
+            .for_each(|((col, column_type_name), column_domain_name)| {
+                let ident = Ident::with_quote('"', col);
 
-            let column = match column_type_name.as_deref() {
-                Some("eql_v2_encrypted") => {
-                    debug!(target: SCHEMA, msg = "eql_v2_encrypted column", table = table_name, column = col);
+                // Prefer the v3 domain: encrypted columns are jsonb-backed
+                // DOMAINs whose typname encodes the token type and capabilities.
+                // The domain identity and traits are read from the eql-bindings
+                // catalog (ADR-0002); a domain we do not recognise is treated as
+                // a plaintext column.
+                let v3 = column_domain_name
+                    .as_deref()
+                    .and_then(eql_domains::resolve);
 
-                    let eql_traits =  EqlTraits::all();
-                    Column::eql(ident, eql_traits)
-                }
-                _ => Column::native(ident),
-            };
+                let column = match (v3, column_type_name.as_deref()) {
+                    (Some((identity, eql_traits)), _) => {
+                        debug!(target: SCHEMA, msg = "eql_v3 column", table = table_name, column = col, domain = %identity.domain.value, traits = %eql_traits);
+                        Column::eql_with_identity(ident, eql_traits, Some(identity))
+                    }
+                    // Legacy EQL v2 columns are a composite type, reported by
+                    // `udt_name`. Retained for reading pre-v3 schemas.
+                    (None, Some("eql_v2_encrypted")) => {
+                        debug!(target: SCHEMA, msg = "eql_v2_encrypted column", table = table_name, column = col);
+                        Column::eql(ident, EqlTraits::all())
+                    }
+                    _ => Column::native(ident),
+                };
 
-            table.add_column(Arc::new(column));
-        });
+                table.add_column(Arc::new(column));
+            });
 
         schema.add_table(table);
     }

--- a/packages/cipherstash-proxy/src/proxy/schema/mod.rs
+++ b/packages/cipherstash-proxy/src/proxy/schema/mod.rs
@@ -1,3 +1,4 @@
+mod eql_domains;
 mod manager;
 
 pub use manager::SchemaManager;

--- a/packages/cipherstash-proxy/src/proxy/sql/select_table_schemas.sql
+++ b/packages/cipherstash-proxy/src/proxy/sql/select_table_schemas.sql
@@ -2,7 +2,11 @@ SELECT
     t.table_schema,
     t.table_name,
     array_agg(c.column_name)::text[] AS columns,
-    array_agg(c.udt_name)::text[] AS column_type_names
+    array_agg(c.udt_name)::text[] AS column_type_names,
+    -- EQL v3 encrypted columns are jsonb-backed DOMAINs, so `udt_name` reports
+    -- the base type (`jsonb`); the domain typname (e.g. `eql_v3_integer_ord`)
+    -- is only available via `domain_name`. NULL for non-domain columns.
+    array_agg(c.domain_name)::text[] AS column_domain_names
 FROM
     information_schema.tables t
 LEFT JOIN

--- a/packages/eql-mapper-macros/src/parse_type_decl.rs
+++ b/packages/eql-mapper-macros/src/parse_type_decl.rs
@@ -305,12 +305,11 @@ impl Parse for EqlTerm {
 
             Ok(Self(quote! {
                 crate::inference::unifier::EqlTerm::Full(
-                    crate::inference::unifier::EqlValue(
+                    crate::inference::unifier::EqlValue::with_canonical_identity(
                         crate::inference::unifier::TableColumn {
                             table: #table.into(),
                             column: #column.into(),
                         },
-                        None,
                         #bounds,
                     ),
                 )
@@ -318,12 +317,11 @@ impl Parse for EqlTerm {
         } else {
             Ok(Self(quote! {
                 crate::inference::unifier::EqlTerm::Full(
-                    crate::inference::unifier::EqlValue(
+                    crate::inference::unifier::EqlValue::with_canonical_identity(
                         crate::inference::unifier::TableColumn {
                             table: #table.into(),
                             column: #column.into(),
                         },
-                        None,
                         crate::inference::unifier::EqlTraits::none(),
                     ),
                 )

--- a/packages/eql-mapper-macros/src/parse_type_decl.rs
+++ b/packages/eql-mapper-macros/src/parse_type_decl.rs
@@ -310,6 +310,7 @@ impl Parse for EqlTerm {
                             table: #table.into(),
                             column: #column.into(),
                         },
+                        None,
                         #bounds,
                     ),
                 )
@@ -319,11 +320,12 @@ impl Parse for EqlTerm {
                 crate::inference::unifier::EqlTerm::Full(
                     crate::inference::unifier::EqlValue(
                         crate::inference::unifier::TableColumn {
-                            table: #table,
-                            column: #column
+                            table: #table.into(),
+                            column: #column.into(),
                         },
+                        None,
+                        crate::inference::unifier::EqlTraits::none(),
                     ),
-                    crate::inference::unifier::EqlTraits::none(),
                 )
             }))
         }

--- a/packages/eql-mapper/CONTEXT.md
+++ b/packages/eql-mapper/CONTEXT.md
@@ -53,8 +53,13 @@ A **capability**, not a storage structure — several SEM terms can satisfy one 
 is **coarse** by design: `Ord` says "ordering is allowed" without distinguishing OPE from
 ORE, because that variant lives in the domain identity. See the shared vocabulary in
 `CONTEXT-MAP.md`.
-_Avoid_: index, index type (those name the storage, not the capability); `Contain` (the
-v2 containment trait — removed in v3, where `@>`/`<@` on encrypted values raise).
+_Avoid_: index, index type (those name the storage, not the capability).
+
+**`Contain`** is **retained** in v3, scoped to encrypted **JSON** columns
+(`eql_v3_json_search`): `@>`/`<@` are real, supported operators there. On **scalar**
+encrypted columns `@>`/`<@` raise — so `Contain` is a JSON-only capability, not a
+general one. (An earlier note here claimed `Contain` was removed entirely in v3; that was
+verified wrong against the installed `cipherstash-encrypt.sql`.)
 
 **EqlTraits**:
 A set of `EqlTrait`s. Read in two opposite directions depending on position: as

--- a/packages/eql-mapper/CONTEXT.md
+++ b/packages/eql-mapper/CONTEXT.md
@@ -1,8 +1,14 @@
 # EQL Mapper
 
 Parses SQL, infers a type for every node, and rewrites statements that touch encrypted
-columns into their EQL v2 equivalents. It knows nothing about the PostgreSQL wire
+columns into their EQL v3 equivalents. It knows nothing about the PostgreSQL wire
 protocol, ZeroKMS, or ciphertext — it reasons about types and rewrites syntax.
+
+> **Migration in flight.** The code still emits the EQL v2 surface
+> (`eql_v2_encrypted` casts, `eql_v2.*` calls); the vocabulary below is the **v3
+> target** the type-checker extension is being designed against. See
+> [`docs/adr/`](./docs/adr/) for the load-bearing decisions and
+> `docs/plans/2026-07-20-eql-v3-type-checker-handoff.md` for the impact maps.
 
 ## Language
 
@@ -25,14 +31,30 @@ bound — that is a deliberate escape hatch for the type checker, not a claim ab
 database.
 
 **EqlValue**:
-The identity of an encrypted column paired with the capabilities configured for it —
-a `TableColumn` plus `EqlTraits`.
+The identity of an encrypted column: a `TableColumn`, its **domain identity**, and its
+`EqlTraits`. Two encrypted columns never share a type, so the `TableColumn` alone settles
+unification — the domain identity and traits ride along for rewriting, not for checking.
+
+**Domain identity**:
+The inert `(token type, v3 domain)` an encrypted column carries — e.g. `text` /
+`eql_v3_text_ord_ore`. Populated by the schema loader from the Postgres domain name,
+never a checked dimension of unification. It does two jobs at rewrite time: names the
+cast target and selects the **term-extraction function** variant (`ord_term` vs
+`ord_term_ore`). It is the home of every v3 specific — token type, OPE-vs-ORE — that the
+coarse `EqlTrait` deliberately does not carry.
+
+**Token type**:
+The plaintext scalar half of a v3 domain — `integer`, `text`, `timestamp`, … The
+capability half (`_eq`, `_ord`, …) is the `EqlTraits`; together they name the domain.
 
 **EqlTrait**:
-A class of operation an encrypted value supports: `Eq`, `Ord`, `TokenMatch`, `JsonLike`,
-`Contain`. A **capability**, not a storage structure — several SEM terms can satisfy one
-trait. See the shared vocabulary in `CONTEXT-MAP.md`.
-_Avoid_: index, index type (those name the storage, not the capability).
+A class of operation an encrypted value supports: `Eq`, `Ord`, `TokenMatch`, `JsonLike`.
+A **capability**, not a storage structure — several SEM terms can satisfy one trait. It
+is **coarse** by design: `Ord` says "ordering is allowed" without distinguishing OPE from
+ORE, because that variant lives in the domain identity. See the shared vocabulary in
+`CONTEXT-MAP.md`.
+_Avoid_: index, index type (those name the storage, not the capability); `Contain` (the
+v2 containment trait — removed in v3, where `@>`/`<@` on encrypted values raise).
 
 **EqlTraits**:
 A set of `EqlTrait`s. Read in two opposite directions depending on position: as
@@ -83,7 +105,7 @@ The result of type checking — the projection, params, literals and node types,
 entry point that applies transformations.
 
 **TransformationRule**:
-A composable mutation of the typed AST that rewrites plaintext SQL into EQL v2
+A composable mutation of the typed AST that rewrites plaintext SQL into EQL v3
 operations. Tuples of rules are themselves rules.
 _Avoid_: using "rule" for a typing rule; those are operator/function signature
 declarations.
@@ -92,11 +114,40 @@ declarations.
 A `$N` placeholder position in the statement. Its PostgreSQL type OID is Proxy's
 concern, not this crate's.
 
-## Known model gap
+### EQL v3 rewriting
+
+**Term-extraction function**:
+An `eql_v3.*` function that pulls one SEM term out of an encrypted value into a natively
+comparable scalar: `eq_term` → HMAC, `ord_term` → CLLW-OPE, `ord_term_ore` → block-ORE,
+`match_term` → bloom filter. These are the target of rewriting, and the thing a functional
+index is built on.
+
+**Functional-index rewrite**:
+The core v3 transformation: `col <op> x` becomes `term_fn(col) <op> term_fn(x)`, where
+`term_fn` is chosen by the capability the operator exercises. It is the only form portable
+to managed Postgres (Supabase forbids `CREATE OPERATOR`), and it lets a functional index
+`CREATE INDEX ON t (eql_v3.ord_term(col))` engage via the term type's native opclass.
+Selecting the term function *is* the capability check — a column whose domain provides no
+such term is a capability error, not a fallback.
+_Avoid_: describing this as "rewriting to operators"; v3 dispatches through functions.
+
+**Query operand** (query twin):
+The term-only payload used as the right-hand side of a rewritten predicate —
+`{v, i, <terms>}`, the envelope minus the record ciphertext `c`. It inhabits the
+`eql_v3.query_<name>` domains (the `query_<name>` twins), distinct from the `public`
+column domains. A stored value is a full column domain; an operand is a query twin.
+
+## Design decisions in flight
 
 The trait-bounds machinery here is complete — `satisfy_bounds` and `UnsatisfiedBounds`
-exist and work — but Proxy currently feeds every encrypted column `EqlTraits::all()`
-(`packages/cipherstash-proxy/src/proxy/schema/manager.rs:146`) rather than the traits its
-configured SEM terms actually provide. So bound violations cannot be caught at type-check
-time in production today. Treat `EqlTraits` on an `EqlValue` as *intended* capability,
-not observed capability, until that join exists.
+exist and work — but is **dead code today** because Proxy feeds every encrypted column
+`EqlTraits::all()` (`packages/cipherstash-proxy/src/proxy/schema/manager.rs:146`).
+
+The v3 type-checker extension closes this: the loader will source real per-column
+`(token, capability)` from the Postgres domain name, making capability **observed**, not
+intended, and turning bound-checking live. See the ADRs:
+
+- [ADR-0001](./docs/adr/0001-functional-index-rewrite.md) — rewrite through
+  term-extraction functions rather than native operators.
+- [ADR-0002](./docs/adr/0002-token-type-as-inert-identity.md) — the token type is inert
+  identity data, not a checked type dimension.

--- a/packages/eql-mapper/docs/adr/0001-functional-index-rewrite.md
+++ b/packages/eql-mapper/docs/adr/0001-functional-index-rewrite.md
@@ -1,0 +1,33 @@
+---
+status: accepted
+---
+
+# Rewrite encrypted operators through term-extraction functions, not native operators
+
+EQL v3 ships native operators (`CREATE OPERATOR public.=`, btree opclasses) bound to its
+53 domain types, which makes it tempting to leave comparisons untouched and let Postgres
+dispatch them. We will **not** do that. The mapper rewrites every operator on an encrypted
+column into the functional form `eql_v3.<cap>_term(lhs) <native-op> eql_v3.<cap>_term(rhs)`
+— `eq_term` (→ HMAC), `ord_term` / `ord_term_ore` (→ CLLW-OPE / block-ORE), `match_term`
+(→ bloom filter) — with the term function chosen by the capability the operator exercises.
+
+**Why:** our primary deployment target is Supabase and other managed Postgres, where
+`CREATE OPERATOR` DDL is unavailable to non-superusers, so the native-operator path simply
+does not exist there. The functional form is the only surface portable across every
+install, it engages functional indexes (`CREATE INDEX ON t (eql_v3.ord_term(col))`) via
+the term type's native opclass, and we have tested that Postgres's query planner handles
+it well. This also collapses two concerns into one: **selecting the term function is the
+capability check** — a column whose domain provides no matching term (e.g. `ORDER BY` on an
+`eql_v3_text_eq` column, or any operator on storage-only `eql_v3_boolean` / `eql_v3_json`)
+has no valid rewrite target, which is exactly the type error we raise.
+
+## Consequences
+
+- The v2 transformation layer does **not** evaporate under v3 — it is retargeted from the
+  `eql_v2.*` opaque-type functions to the `eql_v3.*_term()` functional-index surface. This
+  is close to the v2 structure, not a rewrite from scratch.
+- The `_ord` vs `_ord_ore` distinction (OPE `op` vs block-ORE `ob`) becomes load-bearing:
+  the mapper must emit `ord_term` vs `ord_term_ore` per the column's domain. That variant
+  is read from the domain identity (see ADR-0002), not from the coarse `Ord` trait.
+- Native `@>`/`<@`/operators on **plaintext** columns are untouched; only encrypted
+  operands are rewritten.

--- a/packages/eql-mapper/docs/adr/0001-functional-index-rewrite.md
+++ b/packages/eql-mapper/docs/adr/0001-functional-index-rewrite.md
@@ -31,3 +31,8 @@ has no valid rewrite target, which is exactly the type error we raise.
   is read from the domain identity (see ADR-0002), not from the coarse `Ord` trait.
 - Native `@>`/`<@`/operators on **plaintext** columns are untouched; only encrypted
   operands are rewritten.
+- **Containment is not gone.** `@>`/`<@` raise on *scalar* encrypted columns, but on
+  encrypted **JSON** columns (`eql_v3_json_search`) they are real, supported operators
+  (verified against the installed `cipherstash-encrypt.sql`). The `Contain` trait is
+  therefore retained as a JSON-only capability, and its rewrite targets the SteVec
+  containment surface — it is not deleted.

--- a/packages/eql-mapper/docs/adr/0002-token-type-as-inert-identity.md
+++ b/packages/eql-mapper/docs/adr/0002-token-type-as-inert-identity.md
@@ -1,0 +1,34 @@
+---
+status: accepted
+---
+
+# The v3 token type is inert identity data, not a checked type dimension
+
+EQL v3 encrypted columns are two-dimensional — a token type (`integer`, `text`, …) crossed
+with a capability (`_eq`, `_ord`, …) — where v2 had one opaque `eql_v2_encrypted`. We carry
+the token type (and full domain) inside `EqlValue` as **inert identity data**: populated by
+the schema loader from the Postgres domain name, read only at rewrite time to name the cast
+target and select the term-extraction-function variant, and **not** a dimension the unifier
+checks.
+
+**Why not make it a checked dimension:** it would buy no safety. Two encrypted columns
+never unify with each other — `TableColumn` identity already settles it (`unify_types.rs`),
+so `users.email = orders.email` is already a type error regardless of token type. And a
+plaintext literal is an inference sink: it starts as an unbound variable and *absorbs* the
+column's type (`value.rs`), so there is nothing for `eql_v3_integer_ord = 'abc'` to
+contradict at the literal. A checked token dimension would force the macro grammar, all six
+unification arms, and the bound logic to learn a new axis for zero return. Capability
+(`EqlTraits`) stays the only checked axis; the token type and the OPE-vs-ORE variant ride
+in the identity and surface only during code generation.
+
+## Consequences
+
+- `EqlValue` becomes `(TableColumn, domain identity, EqlTraits)`; the identity threads
+  through the associated-type machinery and unification arms for free because it is never
+  inspected there.
+- The source of truth for the identity is the Postgres domain name, parsed in
+  `cipherstash-proxy`'s `SchemaManager` via the `eql-bindings` inventory; the encrypt
+  config is demoted to a cross-check. `eql-mapper` stays wire-format-agnostic and takes no
+  dependency on `eql-bindings`.
+- If a future capability genuinely needs cross-column token-type checking (none does
+  today), this decision is the thing to revisit.

--- a/packages/eql-mapper/docs/adr/0002-token-type-as-inert-identity.md
+++ b/packages/eql-mapper/docs/adr/0002-token-type-as-inert-identity.md
@@ -27,8 +27,22 @@ in the identity and surface only during code generation.
   through the associated-type machinery and unification arms for free because it is never
   inspected there.
 - The source of truth for the identity is the Postgres domain name, parsed in
-  `cipherstash-proxy`'s `SchemaManager` via the `eql-bindings` inventory; the encrypt
-  config is demoted to a cross-check. `eql-mapper` stays wire-format-agnostic and takes no
-  dependency on `eql-bindings`.
+  `cipherstash-proxy`'s `SchemaManager` via the `eql-bindings` inventory. The domain name
+  is the **sole** authority for a column's capability; the encrypt config is **not**
+  consulted (a mismatch cross-check was considered and dropped — see the amendment below).
+  `eql-mapper` stays wire-format-agnostic and takes no dependency on `eql-bindings`.
 - If a future capability genuinely needs cross-column token-type checking (none does
   today), this decision is the thing to revisit.
+
+## Amendment (2026-07-22)
+
+Two points confirmed during implementation:
+
+- **Domain identity is non-optional.** `EqlValue` carries a `DomainIdentity`, not an
+  `Option<DomainIdentity>`. A migration-time `Option` was tried and rejected: the loader
+  always supplies the real identity, and a legacy `eql_v2_encrypted` column — which has no
+  v3 domain — is dropped (loaded as `Native` with a warning) rather than given a fabricated
+  identity, since v2 is retired on this build.
+- **No config cross-check.** The domain name is the sole authority; the encrypt config is
+  not cross-checked against it. The drift diagnostic was considered and dropped to avoid
+  coupling `SchemaManager` to `EncryptConfigManager` for a non-correctness check.

--- a/packages/eql-mapper/src/inference/infer_type_impls/insert_statement.rs
+++ b/packages/eql-mapper/src/inference/infer_type_impls/insert_statement.rs
@@ -44,9 +44,9 @@ impl<'ast> InferType<'ast, Insert> for TypeInferencer<'ast> {
 
                         let value_ty = match &stc.kind {
                             ColumnKind::Native => Value::Native(NativeValue(Some(tc.clone()))),
-                            ColumnKind::Eql(features) => {
-                                Value::Eql(EqlTerm::Full(EqlValue(tc.clone(), *features)))
-                            }
+                            ColumnKind::Eql(features, identity) => Value::Eql(EqlTerm::Full(
+                                EqlValue(tc.clone(), identity.clone(), *features),
+                            )),
                         };
 
                         (Arc::new(Type::Value(value_ty)), Some(tc.column.clone()))

--- a/packages/eql-mapper/src/inference/unifier/eql_traits.rs
+++ b/packages/eql-mapper/src/inference/unifier/eql_traits.rs
@@ -456,6 +456,7 @@ mod test {
                 table: Ident::new("t"),
                 column: Ident::new("c"),
             },
+            None,
             EqlTraits {
                 token_match: true,
                 ..EqlTraits::none()

--- a/packages/eql-mapper/src/inference/unifier/eql_traits.rs
+++ b/packages/eql-mapper/src/inference/unifier/eql_traits.rs
@@ -220,13 +220,19 @@ impl EqlTraits {
         }
     }
 
+    /// The set of traits in `self` that are not in `other` (set difference,
+    /// `self ∧ ¬other`).
+    ///
+    /// Used to report the bounds a type is *missing*: `required.difference(&implemented)`.
+    /// Not symmetric — do not swap the operands (see [`Type::must_implement`] and
+    /// [`Unifier::satisfy_bounds`], which must call it the same way around).
     pub(crate) fn difference(&self, other: &Self) -> Self {
         EqlTraits {
-            eq: self.eq ^ other.eq,
-            ord: self.ord ^ other.ord,
-            token_match: self.token_match ^ other.token_match,
-            json_like: self.json_like ^ other.json_like,
-            contain: self.contain ^ other.contain,
+            eq: self.eq && !other.eq,
+            ord: self.ord && !other.ord,
+            token_match: self.token_match && !other.token_match,
+            json_like: self.json_like && !other.json_like,
+            contain: self.contain && !other.contain,
         }
     }
 }
@@ -408,3 +414,73 @@ impl EqlValue {
        ILIKE { expr: Self, pattern: Self::Tokenized, .. } -> Native;
    }
 */
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::unifier::TableColumn;
+    use sqltk::parser::ast::Ident;
+
+    #[test]
+    fn difference_is_asymmetric_set_difference() {
+        let eq = EqlTraits {
+            eq: true,
+            ..EqlTraits::none()
+        };
+        let eq_ord = EqlTraits {
+            eq: true,
+            ord: true,
+            ..EqlTraits::none()
+        };
+        let ord_only = EqlTraits {
+            ord: true,
+            ..EqlTraits::none()
+        };
+
+        // `A.difference(B)` is `A ∧ ¬B` — elements in A but not in B.
+        assert_eq!(eq_ord.difference(&eq), ord_only);
+
+        // The discriminator against the old XOR (symmetric-difference) impl,
+        // which returned `{ord}` here instead of the empty set.
+        assert_eq!(eq.difference(&eq_ord), EqlTraits::none());
+
+        // Difference with self is always empty.
+        assert_eq!(eq_ord.difference(&eq_ord), EqlTraits::none());
+    }
+
+    #[test]
+    fn must_implement_reports_only_the_missing_bounds() {
+        // A column that implements TokenMatch but not Eq.
+        let ty = Type::Value(Value::Eql(EqlTerm::Full(EqlValue(
+            TableColumn {
+                table: Ident::new("t"),
+                column: Ident::new("c"),
+            },
+            EqlTraits {
+                token_match: true,
+                ..EqlTraits::none()
+            },
+        ))));
+
+        let eq = EqlTraits {
+            eq: true,
+            ..EqlTraits::none()
+        };
+
+        // Requiring a bound the type already has succeeds.
+        assert!(ty
+            .must_implement(&EqlTraits {
+                token_match: true,
+                ..EqlTraits::none()
+            })
+            .is_ok());
+
+        // Requiring Eq fails, and the reported set is exactly the missing bound
+        // (`{eq}`). The old reversed-operand + XOR bug reported `{eq, token_match}`
+        // — i.e. it listed a trait the type *has* but the bound never required.
+        match ty.must_implement(&eq) {
+            Err(TypeError::UnsatisfiedBounds(_, missing)) => assert_eq!(missing, eq),
+            other => panic!("expected UnsatisfiedBounds, got {other:?}"),
+        }
+    }
+}

--- a/packages/eql-mapper/src/inference/unifier/eql_traits.rs
+++ b/packages/eql-mapper/src/inference/unifier/eql_traits.rs
@@ -451,17 +451,18 @@ mod test {
     #[test]
     fn must_implement_reports_only_the_missing_bounds() {
         // A column that implements TokenMatch but not Eq.
-        let ty = Type::Value(Value::Eql(EqlTerm::Full(EqlValue(
-            TableColumn {
-                table: Ident::new("t"),
-                column: Ident::new("c"),
-            },
-            None,
-            EqlTraits {
-                token_match: true,
-                ..EqlTraits::none()
-            },
-        ))));
+        let ty = Type::Value(Value::Eql(EqlTerm::Full(
+            EqlValue::with_canonical_identity(
+                TableColumn {
+                    table: Ident::new("t"),
+                    column: Ident::new("c"),
+                },
+                EqlTraits {
+                    token_match: true,
+                    ..EqlTraits::none()
+                },
+            ),
+        )));
 
         let eq = EqlTraits {
             eq: true,

--- a/packages/eql-mapper/src/inference/unifier/type_env.rs
+++ b/packages/eql-mapper/src/inference/unifier/type_env.rs
@@ -266,14 +266,15 @@ mod test {
         if let Type::Associated(associated) = &*instance.get_type(&tvar!(A))? {
             assert_eq!(
                 associated.resolve_selector_target(&mut unifier)?.as_deref(),
-                Some(&Type::Value(Value::Eql(EqlTerm::JsonAccessor(EqlValue(
-                    TableColumn {
-                        table: "customer".into(),
-                        column: "name".into()
-                    },
-                    None,
-                    EqlTraits::from(EqlTrait::JsonLike)
-                ),))))
+                Some(&Type::Value(Value::Eql(EqlTerm::JsonAccessor(
+                    EqlValue::with_canonical_identity(
+                        TableColumn {
+                            table: "customer".into(),
+                            column: "name".into()
+                        },
+                        EqlTraits::from(EqlTrait::JsonLike)
+                    ),
+                ))))
             );
         } else {
             panic!("expected associated type");

--- a/packages/eql-mapper/src/inference/unifier/type_env.rs
+++ b/packages/eql-mapper/src/inference/unifier/type_env.rs
@@ -271,6 +271,7 @@ mod test {
                         table: "customer".into(),
                         column: "name".into()
                     },
+                    None,
                     EqlTraits::from(EqlTrait::JsonLike)
                 ),))))
             );

--- a/packages/eql-mapper/src/inference/unifier/types.rs
+++ b/packages/eql-mapper/src/inference/unifier/types.rs
@@ -454,7 +454,10 @@ impl Type {
         } else {
             Err(TypeError::UnsatisfiedBounds(
                 Arc::new(self.clone()),
-                self.effective_bounds().difference(bounds),
+                // Report the *missing* bounds: required (`bounds`) minus implemented
+                // (`self.effective_bounds()`). Operand order must match
+                // `Unifier::satisfy_bounds`.
+                bounds.difference(&self.effective_bounds()),
             ))
         }
     }

--- a/packages/eql-mapper/src/inference/unifier/types.rs
+++ b/packages/eql-mapper/src/inference/unifier/types.rs
@@ -359,8 +359,17 @@ impl DomainIdentity {
     /// **test/fixture convenience** for constructing identities where no live
     /// schema loader supplies the real domain name — production identities always
     /// come from [`Self::from_domain_name`] via the loader. The synthesised domain
-    /// name is deterministic so both sides of a test assertion agree; it is not
-    /// guaranteed to equal the exact catalog typname.
+    /// name is deterministic so both sides of a test assertion agree.
+    ///
+    /// The synthesised name is NOT authoritative and must never be treated as the
+    /// column's real catalog domain: it may not only diverge from the real typname
+    /// but actively **collide with an unrelated real domain that means something
+    /// else**. For example `canonical(Text, {json_like})` produces
+    /// `eql_v3_text_search` — a real catalog domain whose terms are `[hm, op, bf]`
+    /// (Eq + Ord + TokenMatch), nothing to do with JSON — and it can equally emit
+    /// genuinely non-catalog names (`Eq + TokenMatch` → `eql_v3_text_eq_match`,
+    /// `Contain` → `eql_v3_text_contain`). Only [`Self::from_domain_name`] yields a
+    /// real domain identity.
     pub fn canonical(token: TokenType, traits: EqlTraits) -> Self {
         let mut parts: Vec<&str> = Vec::new();
         if traits.json_like {

--- a/packages/eql-mapper/src/inference/unifier/types.rs
+++ b/packages/eql-mapper/src/inference/unifier/types.rs
@@ -269,9 +269,51 @@ pub struct TableColumn {
     pub column: Ident,
 }
 
+/// The plaintext scalar half of a v3 domain — the "token type".
+///
+/// Crossed with a capability suffix (`_eq`, `_ord`, …) it names a v3 domain,
+/// e.g. `text` + `_ord_ore` ⇒ `eql_v3_text_ord_ore`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
+pub enum TokenType {
+    SmallInt,
+    Integer,
+    BigInt,
+    Real,
+    Double,
+    Numeric,
+    Text,
+    Boolean,
+    Date,
+    Timestamp,
+    Json,
+}
+
+/// The inert `(token type, v3 domain)` an encrypted column carries (ADR-0002).
+///
+/// Populated by the schema loader from the Postgres domain name; **never** a
+/// checked dimension of unification. It is read only at rewrite time — to name
+/// the cast target and to select the term-extraction-function variant
+/// (`ord_term` vs `ord_term_ore`) — so it threads through unification and the
+/// associated-type machinery untouched.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
+#[display("{}", domain)]
+pub struct DomainIdentity {
+    pub token: TokenType,
+    /// The v3 domain typname, e.g. `eql_v3_text_ord_ore`.
+    pub domain: Ident,
+}
+
+/// The identity of an encrypted column: its `TableColumn`, its inert
+/// [`DomainIdentity`] (see ADR-0002), and its [`EqlTraits`] capabilities.
+///
+/// The domain identity is `None` while the mapper still emits the EQL v2
+/// surface; the v3 schema loader (CIP-3598) populates it. It is deliberately
+/// not part of `PartialEq`/`Ord`-driven unification — two encrypted columns
+/// never share a type because their `TableColumn`s differ, so the identity
+/// never decides unification even though it is compared here.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Display, Hash)]
 #[display("EQL({})", _0)]
-pub struct EqlValue(pub TableColumn, pub EqlTraits);
+pub struct EqlValue(pub TableColumn, pub Option<DomainIdentity>, pub EqlTraits);
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Display, Hash)]
 #[display("{}", _0.as_ref().map(|tc| format!("Native({tc})")).unwrap_or(String::from("Native")))]
@@ -468,8 +510,14 @@ impl EqlValue {
         &self.0
     }
 
+    /// The inert v3 domain identity, if the schema loader has populated it.
+    /// `None` while the mapper still emits the EQL v2 surface.
+    pub fn domain_identity(&self) -> Option<&DomainIdentity> {
+        self.1.as_ref()
+    }
+
     pub fn trait_impls(&self) -> EqlTraits {
-        self.1
+        self.2
     }
 }
 
@@ -515,9 +563,9 @@ impl Projection {
 
                     let value_ty = match &col.kind {
                         ColumnKind::Native => Type::Value(Value::Native(NativeValue(Some(tc)))),
-                        ColumnKind::Eql(features) => {
-                            Type::Value(Value::Eql(EqlTerm::Full(EqlValue(tc, *features))))
-                        }
+                        ColumnKind::Eql(features, identity) => Type::Value(Value::Eql(
+                            EqlTerm::Full(EqlValue(tc, identity.clone(), *features)),
+                        )),
                     };
 
                     ProjectionColumn::new(value_ty, Some(col.name.clone()))

--- a/packages/eql-mapper/src/inference/unifier/types.rs
+++ b/packages/eql-mapper/src/inference/unifier/types.rs
@@ -288,6 +288,47 @@ pub enum TokenType {
     Json,
 }
 
+impl TokenType {
+    /// The token type's spelling inside a v3 domain typname
+    /// (`eql_v3_<token>_<suffix>`).
+    pub fn as_domain_str(&self) -> &'static str {
+        match self {
+            TokenType::SmallInt => "smallint",
+            TokenType::Integer => "integer",
+            TokenType::BigInt => "bigint",
+            TokenType::Real => "real",
+            TokenType::Double => "double",
+            TokenType::Numeric => "numeric",
+            TokenType::Text => "text",
+            TokenType::Boolean => "boolean",
+            TokenType::Date => "date",
+            TokenType::Timestamp => "timestamp",
+            TokenType::Json => "json",
+        }
+    }
+
+    /// Parse the token type from a v3 domain typname. The token type is the
+    /// first segment after the `eql_v3_` prefix; every token type is a single
+    /// underscore-free word, so a multi-part capability suffix never interferes.
+    pub fn from_domain_name(domain: &str) -> Option<Self> {
+        let rest = domain.strip_prefix("eql_v3_")?;
+        Some(match rest.split('_').next()? {
+            "smallint" => TokenType::SmallInt,
+            "integer" => TokenType::Integer,
+            "bigint" => TokenType::BigInt,
+            "real" => TokenType::Real,
+            "double" => TokenType::Double,
+            "numeric" => TokenType::Numeric,
+            "text" => TokenType::Text,
+            "boolean" => TokenType::Boolean,
+            "date" => TokenType::Date,
+            "timestamp" => TokenType::Timestamp,
+            "json" => TokenType::Json,
+            _ => return None,
+        })
+    }
+}
+
 /// The inert `(token type, v3 domain)` an encrypted column carries (ADR-0002).
 ///
 /// Populated by the schema loader from the Postgres domain name; **never** a
@@ -303,17 +344,63 @@ pub struct DomainIdentity {
     pub domain: Ident,
 }
 
+impl DomainIdentity {
+    /// Build an identity from a v3 domain typname, parsing the token type from
+    /// the name. The domain name is the authority (the schema loader passes the
+    /// real typname); returns `None` for a name that is not a v3 EQL domain.
+    pub fn from_domain_name(domain: &str) -> Option<Self> {
+        Some(Self {
+            token: TokenType::from_domain_name(domain)?,
+            domain: Ident::new(domain),
+        })
+    }
+
+    /// A canonical identity for a `(token, capabilities)` pair. This is a
+    /// **test/fixture convenience** for constructing identities where no live
+    /// schema loader supplies the real domain name — production identities always
+    /// come from [`Self::from_domain_name`] via the loader. The synthesised domain
+    /// name is deterministic so both sides of a test assertion agree; it is not
+    /// guaranteed to equal the exact catalog typname.
+    pub fn canonical(token: TokenType, traits: EqlTraits) -> Self {
+        let mut parts: Vec<&str> = Vec::new();
+        if traits.json_like {
+            parts.push("search");
+        } else {
+            if traits.ord {
+                parts.push("ord");
+            } else if traits.eq {
+                parts.push("eq");
+            }
+            if traits.token_match {
+                parts.push("match");
+            }
+            if traits.contain {
+                parts.push("contain");
+            }
+        }
+        let suffix = if parts.is_empty() {
+            String::new()
+        } else {
+            format!("_{}", parts.join("_"))
+        };
+        let domain = format!("eql_v3_{}{}", token.as_domain_str(), suffix);
+        Self {
+            token,
+            domain: Ident::new(domain),
+        }
+    }
+}
+
 /// The identity of an encrypted column: its `TableColumn`, its inert
 /// [`DomainIdentity`] (see ADR-0002), and its [`EqlTraits`] capabilities.
 ///
-/// The domain identity is `None` while the mapper still emits the EQL v2
-/// surface; the v3 schema loader (CIP-3598) populates it. It is deliberately
-/// not part of `PartialEq`/`Ord`-driven unification — two encrypted columns
-/// never share a type because their `TableColumn`s differ, so the identity
-/// never decides unification even though it is compared here.
+/// The domain identity is deliberately not part of `PartialEq`/`Ord`-driven
+/// unification — two encrypted columns never share a type because their
+/// `TableColumn`s differ, so the identity never decides unification even though
+/// it is compared here.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Display, Hash)]
 #[display("EQL({})", _0)]
-pub struct EqlValue(pub TableColumn, pub Option<DomainIdentity>, pub EqlTraits);
+pub struct EqlValue(pub TableColumn, pub DomainIdentity, pub EqlTraits);
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Display, Hash)]
 #[display("{}", _0.as_ref().map(|tc| format!("Native({tc})")).unwrap_or(String::from("Native")))]
@@ -510,10 +597,21 @@ impl EqlValue {
         &self.0
     }
 
-    /// The inert v3 domain identity, if the schema loader has populated it.
-    /// `None` while the mapper still emits the EQL v2 surface.
-    pub fn domain_identity(&self) -> Option<&DomainIdentity> {
-        self.1.as_ref()
+    /// The inert v3 domain identity — names the cast target and selects the
+    /// term-extraction-function variant at rewrite time (ADR-0002).
+    pub fn domain_identity(&self) -> &DomainIdentity {
+        &self.1
+    }
+
+    /// Test/fixture constructor: builds the value with the canonical `text`-token
+    /// [`DomainIdentity`] for `traits`. Production values come from the schema
+    /// loader with the real domain identity, never this.
+    pub fn with_canonical_identity(table_column: TableColumn, traits: EqlTraits) -> Self {
+        Self(
+            table_column,
+            DomainIdentity::canonical(TokenType::Text, traits),
+            traits,
+        )
     }
 
     pub fn trait_impls(&self) -> EqlTraits {

--- a/packages/eql-mapper/src/lib.rs
+++ b/packages/eql-mapper/src/lib.rs
@@ -105,12 +105,11 @@ mod test {
                 assert_eq!(
                     typed.literals,
                     vec![(
-                        EqlTerm::Full(EqlValue(
+                        EqlTerm::Full(EqlValue::with_canonical_identity(
                             TableColumn {
                                 table: id("users"),
                                 column: id("email"),
                             },
-                            None,
                             EqlTraits::from(EqlTrait::Eq)
                         ),),
                         &ast::Value::SingleQuotedString("hello@cipherstash.com".into()),
@@ -139,12 +138,11 @@ mod test {
         match type_check(schema, &statement) {
             Ok(typed) => {
                 assert!(typed.literals.contains(&(
-                    EqlTerm::Full(EqlValue(
+                    EqlTerm::Full(EqlValue::with_canonical_identity(
                         TableColumn {
                             table: id("users"),
                             column: id("email")
                         },
-                        None,
                         EqlTraits::default()
                     )),
                     &ast::Value::SingleQuotedString("hello@cipherstash.com".into()),
@@ -172,12 +170,11 @@ mod test {
         match type_check(schema, &statement) {
             Ok(typed) => {
                 assert!(typed.literals.contains(&(
-                    EqlTerm::Full(EqlValue(
+                    EqlTerm::Full(EqlValue::with_canonical_identity(
                         TableColumn {
                             table: id("users"),
                             column: id("email")
                         },
-                        None,
                         EqlTraits::default()
                     )),
                     &ast::Value::SingleQuotedString("hello@cipherstash.com".into()),
@@ -206,12 +203,11 @@ mod test {
         match type_check(schema, &statement) {
             Ok(typed) => {
                 assert!(typed.literals.contains(&(
-                    EqlTerm::Full(EqlValue(
+                    EqlTerm::Full(EqlValue::with_canonical_identity(
                         TableColumn {
                             table: id("users"),
                             column: id("email")
                         },
-                        None,
                         EqlTraits::default()
                     )),
                     &ast::Value::SingleQuotedString("hello@cipherstash.com".into()),
@@ -548,21 +544,19 @@ mod test {
 
         match type_check(schema, &statement) {
             Ok(typed) => {
-                let a = Value::Eql(EqlTerm::Full(EqlValue(
+                let a = Value::Eql(EqlTerm::Full(EqlValue::with_canonical_identity(
                     TableColumn {
                         table: id("users"),
                         column: id("email"),
                     },
-                    None,
                     EqlTraits::default(),
                 )));
 
-                let b = Value::Eql(EqlTerm::Full(EqlValue(
+                let b = Value::Eql(EqlTerm::Full(EqlValue::with_canonical_identity(
                     TableColumn {
                         table: id("users"),
                         column: id("first_name"),
                     },
-                    None,
                     EqlTraits::default(),
                 )));
 
@@ -598,21 +592,19 @@ mod test {
 
         match type_check(schema, &statement) {
             Ok(typed) => {
-                let a = Value::Eql(EqlTerm::Full(EqlValue(
+                let a = Value::Eql(EqlTerm::Full(EqlValue::with_canonical_identity(
                     TableColumn {
                         table: id("users"),
                         column: id("salary"),
                     },
-                    None,
                     EqlTraits::from(EqlTrait::Ord),
                 )));
 
-                let b = Value::Eql(EqlTerm::Full(EqlValue(
+                let b = Value::Eql(EqlTerm::Full(EqlValue::with_canonical_identity(
                     TableColumn {
                         table: id("users"),
                         column: id("age"),
                     },
-                    None,
                     EqlTraits::from(EqlTrait::Ord),
                 )));
 
@@ -1121,12 +1113,11 @@ mod test {
         assert_eq!(
             typed.literals,
             vec![(
-                EqlTerm::Full(EqlValue(
+                EqlTerm::Full(EqlValue::with_canonical_identity(
                     TableColumn {
                         table: id("employees"),
                         column: id("salary")
                     },
-                    None,
                     EqlTraits::from(EqlTrait::Ord)
                 ),),
                 &ast::Value::Number(200000.into(), false),
@@ -1172,12 +1163,11 @@ mod test {
         assert_eq!(
             typed.literals,
             vec![(
-                EqlTerm::Full(EqlValue(
+                EqlTerm::Full(EqlValue::with_canonical_identity(
                     TableColumn {
                         table: id("employees"),
                         column: id("salary")
                     },
-                    None,
                     EqlTraits::default()
                 )),
                 &ast::Value::Number(20000.into(), false)

--- a/packages/eql-mapper/src/lib.rs
+++ b/packages/eql-mapper/src/lib.rs
@@ -110,6 +110,7 @@ mod test {
                                 table: id("users"),
                                 column: id("email"),
                             },
+                            None,
                             EqlTraits::from(EqlTrait::Eq)
                         ),),
                         &ast::Value::SingleQuotedString("hello@cipherstash.com".into()),
@@ -143,6 +144,7 @@ mod test {
                             table: id("users"),
                             column: id("email")
                         },
+                        None,
                         EqlTraits::default()
                     )),
                     &ast::Value::SingleQuotedString("hello@cipherstash.com".into()),
@@ -175,6 +177,7 @@ mod test {
                             table: id("users"),
                             column: id("email")
                         },
+                        None,
                         EqlTraits::default()
                     )),
                     &ast::Value::SingleQuotedString("hello@cipherstash.com".into()),
@@ -208,6 +211,7 @@ mod test {
                             table: id("users"),
                             column: id("email")
                         },
+                        None,
                         EqlTraits::default()
                     )),
                     &ast::Value::SingleQuotedString("hello@cipherstash.com".into()),
@@ -549,6 +553,7 @@ mod test {
                         table: id("users"),
                         column: id("email"),
                     },
+                    None,
                     EqlTraits::default(),
                 )));
 
@@ -557,6 +562,7 @@ mod test {
                         table: id("users"),
                         column: id("first_name"),
                     },
+                    None,
                     EqlTraits::default(),
                 )));
 
@@ -597,6 +603,7 @@ mod test {
                         table: id("users"),
                         column: id("salary"),
                     },
+                    None,
                     EqlTraits::from(EqlTrait::Ord),
                 )));
 
@@ -605,6 +612,7 @@ mod test {
                         table: id("users"),
                         column: id("age"),
                     },
+                    None,
                     EqlTraits::from(EqlTrait::Ord),
                 )));
 
@@ -1118,6 +1126,7 @@ mod test {
                         table: id("employees"),
                         column: id("salary")
                     },
+                    None,
                     EqlTraits::from(EqlTrait::Ord)
                 ),),
                 &ast::Value::Number(200000.into(), false),
@@ -1168,6 +1177,7 @@ mod test {
                         table: id("employees"),
                         column: id("salary")
                     },
+                    None,
                     EqlTraits::default()
                 )),
                 &ast::Value::Number(20000.into(), false)

--- a/packages/eql-mapper/src/lib.rs
+++ b/packages/eql-mapper/src/lib.rs
@@ -21,8 +21,8 @@ pub use model::*;
 pub use param::*;
 pub use type_checked_statement::*;
 pub use unifier::{
-    Array, AssociatedType, EqlTerm, EqlTermVariant, EqlTrait, EqlTraits, EqlValue, NativeValue,
-    Projection, ProjectionColumn, SetOf, TableColumn, Type, Value,
+    Array, AssociatedType, DomainIdentity, EqlTerm, EqlTermVariant, EqlTrait, EqlTraits, EqlValue,
+    NativeValue, Projection, ProjectionColumn, SetOf, TableColumn, TokenType, Type, Value,
 };
 
 pub(crate) use dep::*;

--- a/packages/eql-mapper/src/model/schema.rs
+++ b/packages/eql-mapper/src/model/schema.rs
@@ -3,7 +3,10 @@
 //! Column type information is unused currently.
 
 use super::ident_case::*;
-use crate::{iterator_ext::IteratorExt, unifier::EqlTraits};
+use crate::{
+    iterator_ext::IteratorExt,
+    unifier::{DomainIdentity, EqlTraits},
+};
 use core::fmt::Debug;
 use derive_more::Display;
 use sqltk::parser::ast::{Ident, ObjectName, ObjectNamePart};
@@ -38,17 +41,30 @@ pub struct Column {
     pub kind: ColumnKind,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Display, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Display, Hash)]
 pub enum ColumnKind {
+    #[display("Native")]
     Native,
-    Eql(EqlTraits),
+    /// An encrypted column: its capabilities, plus the inert v3 domain identity
+    /// (see ADR-0002). The identity is `None` while the mapper still emits the
+    /// EQL v2 surface; the v3 schema loader (CIP-3598) populates it.
+    #[display("Eql({})", _0)]
+    Eql(EqlTraits, Option<DomainIdentity>),
 }
 
 impl Column {
     pub fn eql(name: Ident, features: EqlTraits) -> Self {
+        Self::eql_with_identity(name, features, None)
+    }
+
+    pub fn eql_with_identity(
+        name: Ident,
+        features: EqlTraits,
+        identity: Option<DomainIdentity>,
+    ) -> Self {
         Self {
             name,
-            kind: ColumnKind::Eql(features),
+            kind: ColumnKind::Eql(features, identity),
         }
     }
 
@@ -123,7 +139,7 @@ impl Schema {
             .map(|col| SchemaTableColumn {
                 table: table.name.clone(),
                 column: col.name.clone(),
-                kind: col.kind,
+                kind: col.kind.clone(),
             })
             .collect())
     }
@@ -143,7 +159,7 @@ impl Schema {
                     Ok(column) => Ok(SchemaTableColumn {
                         table: table.name.clone(),
                         column: column.name.clone(),
-                        kind: column.kind,
+                        kind: column.kind.clone(),
                     }),
                     Err(_) => Err(SchemaError::ColumnNotFound(
                         table_name.to_string(),

--- a/packages/eql-mapper/src/model/schema.rs
+++ b/packages/eql-mapper/src/model/schema.rs
@@ -46,22 +46,14 @@ pub enum ColumnKind {
     #[display("Native")]
     Native,
     /// An encrypted column: its capabilities, plus the inert v3 domain identity
-    /// (see ADR-0002). The identity is `None` while the mapper still emits the
-    /// EQL v2 surface; the v3 schema loader (CIP-3598) populates it.
+    /// (see ADR-0002), which the v3 schema loader populates from the Postgres
+    /// domain name.
     #[display("Eql({})", _0)]
-    Eql(EqlTraits, Option<DomainIdentity>),
+    Eql(EqlTraits, DomainIdentity),
 }
 
 impl Column {
-    pub fn eql(name: Ident, features: EqlTraits) -> Self {
-        Self::eql_with_identity(name, features, None)
-    }
-
-    pub fn eql_with_identity(
-        name: Ident,
-        features: EqlTraits,
-        identity: Option<DomainIdentity>,
-    ) -> Self {
+    pub fn eql(name: Ident, features: EqlTraits, identity: DomainIdentity) -> Self {
         Self {
             name,
             kind: ColumnKind::Eql(features, identity),
@@ -289,11 +281,32 @@ macro_rules! schema {
     (@add_columns $table:ident $( $column_name:ident $(($($options:tt)+))? , )* ) => {
         $( schema!(@add_column $table $column_name $(($($options)*))? ); )*
     };
+    // Explicit v3 domain typname, e.g. `col (EQL("eql_v3_integer_ord_ore"): Ord)`.
+    // The token type is parsed from the domain name; use this when a test cares
+    // about the token type or the OPE-vs-ORE variant.
+    (@add_column $table:ident $column_name:ident (EQL($domain:literal) $(: $trait_:ident $(+ $trait_rest:ident)*)?) ) => {
+        {
+            let __traits = $crate::to_eql_trait_impls!($($trait_ $($trait_rest)*)?);
+            $table.add_column(std::sync::Arc::new($crate::model::Column::eql(
+                ::sqltk::parser::ast::Ident::new(stringify!($column_name)),
+                __traits,
+                $crate::unifier::DomainIdentity::from_domain_name($domain)
+                    .expect("EQL(<domain>) must be a valid v3 domain typname"),
+            )));
+        }
+    };
+    // Default: no explicit domain — synthesise a canonical `text`-token identity
+    // for the given capabilities (fine for the many tests that don't exercise the
+    // token type).
     (@add_column $table:ident $column_name:ident (EQL $(: $trait_:ident $(+ $trait_rest:ident)*)?) ) => {
-        $table.add_column(std::sync::Arc::new($crate::model::Column::eql(
-            ::sqltk::parser::ast::Ident::new(stringify!($column_name)),
-            $crate::to_eql_trait_impls!($($trait_ $($trait_rest)*)?)
-        )));
+        {
+            let __traits = $crate::to_eql_trait_impls!($($trait_ $($trait_rest)*)?);
+            $table.add_column(std::sync::Arc::new($crate::model::Column::eql(
+                ::sqltk::parser::ast::Ident::new(stringify!($column_name)),
+                __traits,
+                $crate::unifier::DomainIdentity::canonical($crate::unifier::TokenType::Text, __traits),
+            )));
+        }
     };
     (@add_column $table:ident $column_name:ident (PK) ) => {
         $table.add_column(

--- a/packages/eql-mapper/src/model/schema_delta.rs
+++ b/packages/eql-mapper/src/model/schema_delta.rs
@@ -363,7 +363,7 @@ mod test {
     use crate::{
         schema,
         test_helpers::{id, object_name, parse},
-        unifier::EqlTraits,
+        unifier::{DomainIdentity, EqlTraits, TokenType},
         ColumnKind, SchemaError, SchemaTableColumn, TableResolver,
     };
 
@@ -444,7 +444,10 @@ mod test {
             Ok(SchemaTableColumn {
                 table: id("users"),
                 column: id("primary_email"),
-                kind: ColumnKind::Eql(EqlTraits::default(), None)
+                kind: ColumnKind::Eql(
+                    EqlTraits::default(),
+                    DomainIdentity::canonical(TokenType::Text, EqlTraits::default())
+                )
             })
         )
     }
@@ -476,7 +479,10 @@ mod test {
             Ok(SchemaTableColumn {
                 table: id("app_users"),
                 column: id("email"),
-                kind: ColumnKind::Eql(EqlTraits::default(), None)
+                kind: ColumnKind::Eql(
+                    EqlTraits::default(),
+                    DomainIdentity::canonical(TokenType::Text, EqlTraits::default())
+                )
             })
         )
     }
@@ -526,7 +532,10 @@ mod test {
             Ok(SchemaTableColumn {
                 table: id("users"),
                 column: id("email"),
-                kind: ColumnKind::Eql(EqlTraits::default(), None)
+                kind: ColumnKind::Eql(
+                    EqlTraits::default(),
+                    DomainIdentity::canonical(TokenType::Text, EqlTraits::default())
+                )
             })
         );
 

--- a/packages/eql-mapper/src/model/schema_delta.rs
+++ b/packages/eql-mapper/src/model/schema_delta.rs
@@ -78,7 +78,7 @@ impl SchemaWithEdits {
             .map(|col| SchemaTableColumn {
                 table: table.name.clone(),
                 column: col.name.clone(),
-                kind: col.kind,
+                kind: col.kind.clone(),
             })
             .collect())
     }
@@ -100,7 +100,7 @@ impl SchemaWithEdits {
                 Ok(SchemaTableColumn {
                     table: table_name.clone(),
                     column: column_name.clone(),
-                    kind: col.kind,
+                    kind: col.kind.clone(),
                 })
             }
             None => Err(SchemaError::ColumnNotFound(
@@ -444,7 +444,7 @@ mod test {
             Ok(SchemaTableColumn {
                 table: id("users"),
                 column: id("primary_email"),
-                kind: ColumnKind::Eql(EqlTraits::default())
+                kind: ColumnKind::Eql(EqlTraits::default(), None)
             })
         )
     }
@@ -476,7 +476,7 @@ mod test {
             Ok(SchemaTableColumn {
                 table: id("app_users"),
                 column: id("email"),
-                kind: ColumnKind::Eql(EqlTraits::default())
+                kind: ColumnKind::Eql(EqlTraits::default(), None)
             })
         )
     }
@@ -526,7 +526,7 @@ mod test {
             Ok(SchemaTableColumn {
                 table: id("users"),
                 column: id("email"),
-                kind: ColumnKind::Eql(EqlTraits::default())
+                kind: ColumnKind::Eql(EqlTraits::default(), None)
             })
         );
 

--- a/packages/eql-mapper/src/test_helpers.rs
+++ b/packages/eql-mapper/src/test_helpers.rs
@@ -145,7 +145,7 @@ macro_rules! col {
             ty: Arc::new(Type::Value(Value::Eql(EqlTerm::Full(EqlValue(TableColumn {
                 table: id(stringify!($table)),
                 column: id(stringify!($column)),
-            }, $crate::to_eql_traits!($($($eql_traits)*)?)))))),
+            }, None, $crate::to_eql_traits!($($($eql_traits)*)?)))))),
             alias: None,
         }
     };
@@ -155,7 +155,7 @@ macro_rules! col {
             ty: Arc::new(Type::Value(Value::Eql(EqlTerm::Full(EqlValue(TableColumn {
                 table: id(stringify!($table)),
                 column: id(stringify!($column)),
-            }, $crate::to_eql_traits!($($($eql_traits)*)?)))))),
+            }, None, $crate::to_eql_traits!($($($eql_traits)*)?)))))),
             alias: Some(id(stringify!($alias))),
         }
     };

--- a/packages/eql-mapper/src/test_helpers.rs
+++ b/packages/eql-mapper/src/test_helpers.rs
@@ -142,20 +142,20 @@ macro_rules! col {
 
     ((EQL($table:ident . $column:ident $(: $($eql_traits:ident)*)?))) => {
         ProjectionColumn {
-            ty: Arc::new(Type::Value(Value::Eql(EqlTerm::Full(EqlValue(TableColumn {
+            ty: Arc::new(Type::Value(Value::Eql(EqlTerm::Full(EqlValue::with_canonical_identity(TableColumn {
                 table: id(stringify!($table)),
                 column: id(stringify!($column)),
-            }, None, $crate::to_eql_traits!($($($eql_traits)*)?)))))),
+            }, $crate::to_eql_traits!($($($eql_traits)*)?)))))),
             alias: None,
         }
     };
 
     ((EQL($table:ident . $column:ident $(: $($eql_traits:ident)*)?) as $alias:ident)) => {
         ProjectionColumn {
-            ty: Arc::new(Type::Value(Value::Eql(EqlTerm::Full(EqlValue(TableColumn {
+            ty: Arc::new(Type::Value(Value::Eql(EqlTerm::Full(EqlValue::with_canonical_identity(TableColumn {
                 table: id(stringify!($table)),
                 column: id(stringify!($column)),
-            }, None, $crate::to_eql_traits!($($($eql_traits)*)?)))))),
+            }, $crate::to_eql_traits!($($($eql_traits)*)?)))))),
             alias: Some(id(stringify!($alias))),
         }
     };


### PR DESCRIPTION
<!-- git-queue:begin -->
### 📚 eql-v3 PR &nbsp;·&nbsp; 2 of 6

Part of a queue. The PRs merge in FIFO order — the numbered order below, #1 first. Merging one supersedes the PRs after it until the author runs `git queue sync` (rebases the rest onto the merged base) and `git queue submit` (retargets their PRs).

✅🟢 [#423 `queue/eql-v3/upgrade-deps`](https://github.com/cipherstash/proxy/pull/423) → `main`
♻️🟢 **[#424 `queue/eql-v3/typecheck`](https://github.com/cipherstash/proxy/pull/424) → `queue/eql-v3/upgrade-deps`** &nbsp;👈 **this PR**
✅🟢 [#428 `queue/eql-v3/transform`](https://github.com/cipherstash/proxy/pull/428) → `queue/eql-v3/typecheck`
✅🟢 [#426 `queue/eql-v3/showcase`](https://github.com/cipherstash/proxy/pull/426) → `queue/eql-v3/transform`
⏳🟢 [#427 `queue/eql-v3/integration`](https://github.com/cipherstash/proxy/pull/427) → `queue/eql-v3/showcase`
⏳🟢 [#430 `feat/eql-v3-jsonb-composite-selectors`](https://github.com/cipherstash/proxy/pull/430) → `queue/eql-v3/integration`

<sub>✅ approved · ♻️ changes requested · ⏳ review pending &nbsp;|&nbsp; 🟣 merged · 🟢 open · ⚫ closed &nbsp;—&nbsp; status as of the last `git queue submit`.</sub>
<sub>🥞 Managed by git-queue — do not edit this list by hand.</sub>

# About this queue

Migrates CipherStash Proxy from EQL v2 to EQL v3 (cipherstash-client 0.34.1-alpha.4 → 0.42.0, EQL 2.3.0-pre.3 → 3.0.2), replacing the opaque eql_v2_encrypted composite type with 53 typed jsonb domains that encode both scalar type and searchable capability in the column type itself.

# About this branch

Type checker for v3 domains — extends EQL Mapper to emit `eql_v3_<token>_<capability>` domains instead of eql_v2_encrypted
(designed, not yet built; the step that makes the migration actually work).
<!-- git-queue:end -->