### PR TITLE
ci(test): run the Test workflow on PRs to any base branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,10 @@
 name: Test
 on:
+  # No `branches` filter: run on pull requests targeting ANY base branch, not
+  # just `main`. Stacked/queued PRs target intermediate branches (e.g.
+  # `queue/<name>/...`), so a `branches: [main]` filter skipped CI on every PR
+  # in a stack except the front one.
   pull_request:
-    branches:
-      - main
     paths-ignore:
      - '.github/workflows/release.yml' # ignore unrelated workflow
      - '.github/workflows/benchmark.yml' # ignore unrelated workflow


### PR DESCRIPTION
The `Test` workflow's `pull_request` trigger had `branches: [main]`, so it only ran for PRs whose **base** is `main`. Stacked / queued PRs target intermediate branches (e.g. `queue/<name>/...`), so CI was skipped on every PR in a stack except the front one.

This drops the `branches` filter from the `pull_request` trigger so the workflow runs on pull requests **regardless of base branch**. The `push` trigger stays scoped to `main` (post-merge), and `paths-ignore` / `workflow_dispatch` are unchanged.

Separate, standalone change off `main` (not part of the EQL v3 queue).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Continuous integration checks now run for pull requests targeting any branch, including intermediate branches in stacked or queued workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->