### PR TITLE
chore(deps): upgrade EQL and eql-bindings to 3.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- **EQL v3 (searchable encryption)**: Proxy now targets EQL v3. Encrypted columns are declared with self-configuring, typed `jsonb` domains (for example `eql_v3_text_search`, `eql_v3_integer_ord`, `eql_v3_json_search`) that encode both the scalar type and the column's searchable capabilities in the column type itself, replacing EQL v2's opaque `eql_v2_encrypted` composite type and its separate `eql_v2_configuration` table. The bundled `cipherstash-client` is upgraded to 0.42.0 and EQL to 3.0.3. Existing v2-encrypted data and schemas must be migrated to v3.
+- **EQL v3 (searchable encryption)**: Proxy now targets EQL v3. Encrypted columns are declared with self-configuring, typed `jsonb` domains (for example `eql_v3_text_search`, `eql_v3_integer_ord`, `eql_v3_json_search`) that encode both the scalar type and the column's searchable capabilities in the column type itself, replacing EQL v2's opaque `eql_v2_encrypted` composite type and its separate `eql_v2_configuration` table. The bundled `cipherstash-client` is upgraded to 0.42.0 and EQL to 3.0.4. Existing v2-encrypted data and schemas must be migrated to v3.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "eql-bindings"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a898feed3aca4f05856ff897cb08ea470da40bf6ae079712891155425fe19c"
+checksum = "4192d35cf5bed8b5c9b10f67e845665776e87f41ce8551e9e9f96d8650578fd0"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ cts-common = { version = "=0.42.0" }
 # EQL v3 domain catalog: maps Postgres domain names to (token type, SEM terms).
 # The authoritative source for a column's domain identity (ADR-0002); only the
 # SchemaManager depends on it, keeping eql-mapper wire-format-agnostic.
-eql-bindings = { version = "=3.0.3" }
+eql-bindings = { version = "=3.0.4" }
 
 thiserror = "2.0.9"
 tokio = { version = "1.44.2", features = ["full"] }

--- a/mise.local.example.toml
+++ b/mise.local.example.toml
@@ -15,7 +15,7 @@ CS_CLIENT_KEY = "client-key"
 CS_CLIENT_ID = "client-id"
 
 # The release of EQL that the proxy tests will use and releases will be built with
-CS_EQL_VERSION = "eql-3.0.3"
+CS_EQL_VERSION = "eql-3.0.4"
 
 # TLS variables are required for providing TLS to Proxy's clients.
 # CS_TLS__TYPE can be either "Path" or "Pem" (case-sensitive).

--- a/mise.toml
+++ b/mise.toml
@@ -34,7 +34,7 @@ CS_PROXY__HOST = "host.docker.internal"
 # Misc
 DOCKER_CLI_HINTS = "false" # Please don't show us What's Next.
 
-CS_EQL_VERSION = "eql-3.0.3"
+CS_EQL_VERSION = "eql-3.0.4"
 
 
 [tools]

--- a/packages/eql-mapper/src/transformation_rules/rewrite_eql_group_by.rs
+++ b/packages/eql-mapper/src/transformation_rules/rewrite_eql_group_by.rs
@@ -42,8 +42,8 @@ use super::TransformationRule;
 /// preserved, so clients selecting by name are unaffected.
 ///
 /// Requires an EQL release carrying `eql_v3.grouped_value` (CIP-3657, EQL PR
-/// 423) — later than the 3.0.2 currently pinned in `mise.toml`. Only the
-/// projection case needs it; grouping without selecting the column does not.
+/// 423), which the pinned 3.0.4 does. Only the projection case needs it;
+/// grouping without selecting the column does not.
 #[derive(Debug)]
 pub struct RewriteEqlGroupBy<'ast> {
     node_types: Arc<HashMap<NodeKey<'ast>, Type>>,


### PR DESCRIPTION
The 3.0.3 → 3.0.4 delta is inert: `eql-bindings`' `src/` is byte-identical between the two releases, and the SQL differs only in doc-comment markup (`@example` → `@code{.sql}`) plus the two version strings `eql_v3.version()` and the schema COMMENT report.

Also drops the stale caveat on `RewriteEqlGroupBy`, which still claimed `eql_v3.grouped_value` needed a release later than the pinned one — it named 3.0.2 while `mise.toml` had moved to 3.0.3, and the function is present in the 3.0.4 SQL the pin now installs.

<!-- Please provide a summary of what's being changed -->

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the bundled EQL searchable-encryption release to version 3.0.4.
  - Updated setup and development configurations to use the same EQL version.
  - Improved compatibility for grouped search results using `grouped_value`.
- **Documentation**
  - Updated release notes and technical guidance to reflect the EQL 3.0.4 baseline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->