### PR TITLE
test(integration): take the suite's ports from the environment

### DIFF
--- a/packages/cipherstash-proxy-integration/src/common.rs
+++ b/packages/cipherstash-proxy-integration/src/common.rs
@@ -68,7 +68,10 @@ fn port_from_env(var: &str, default: u16) -> u16 {
         Ok(value) => value
             .parse()
             .unwrap_or_else(|_| panic!("{var} must be a port number, got: {value:?}")),
-        Err(_) => default,
+        Err(std::env::VarError::NotPresent) => default,
+        Err(std::env::VarError::NotUnicode(value)) => {
+            panic!("{var} must be a port number, got non-unicode value: {value:?}")
+        }
     }
 }
 

--- a/packages/cipherstash-proxy-integration/src/common.rs
+++ b/packages/cipherstash-proxy-integration/src/common.rs
@@ -14,7 +14,7 @@
 //! ```rust
 //! #[tokio::test]
 //! async fn my_test() {
-//!     let client = connect_with_tls(PROXY).await;
+//!     let client = connect_with_tls(*PROXY).await;
 //!     clear_with_client(&client).await;
 //!     insert_with_client(sql, params, &client).await;
 //!     query_by_with_client(sql, param, &client).await;
@@ -41,26 +41,36 @@ use rustls::{
     pki_types::CertificateDer, ClientConfig,
 };
 use serde_json::Value;
-use std::sync::{Arc, Once};
+use std::sync::{Arc, LazyLock, Once};
 use tokio_postgres::{types::ToSql, Client, NoTls, Row, SimpleQueryMessage};
 use tracing::info;
 use tracing_subscriber::{filter::Directive, EnvFilter, FmtSubscriber};
 
-pub const PROXY: u16 = 6432;
-
-/// Proxy port for tests: `CS_PROXY__PORT` if set, otherwise [`PROXY`].
+/// The ports the suite connects to, defaulting to the standard dev ports.
 ///
-/// Lets a local run target a proxy on a non-default port without patching the
-/// test source (mirrors [`get_database_port`] for `CS_DATABASE__PORT`).
-pub fn proxy_port() -> u16 {
-    std::env::var("CS_PROXY__PORT")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(PROXY)
+/// Each is overridable by environment variable so that several copies of this
+/// suite can run at once, each against its own Proxy and PostgreSQL. Set these
+/// to match the `CS_SERVER__PORT` and `CS_DATABASE__PORT` the Proxy under test
+/// was started with — nothing here starts anything, it only decides where to
+/// connect.
+pub static PROXY: LazyLock<u16> = LazyLock::new(|| port_from_env("CS_TEST_PROXY_PORT", 6432));
+pub static PROXY_METRICS_PORT: LazyLock<u16> =
+    LazyLock::new(|| port_from_env("CS_TEST_PROXY_METRICS_PORT", 9930));
+pub static PG_PORT: LazyLock<u16> = LazyLock::new(|| port_from_env("CS_TEST_PG_PORT", 5532));
+pub static PG_TLS_PORT: LazyLock<u16> =
+    LazyLock::new(|| port_from_env("CS_TEST_PG_TLS_PORT", 5617));
+
+/// Panics rather than falling back to the default: a typo'd port would
+/// otherwise send the whole suite at whatever is already listening on 6432,
+/// which is the one outcome that looks like a pass and isn't.
+fn port_from_env(var: &str, default: u16) -> u16 {
+    match std::env::var(var) {
+        Ok(value) => value
+            .parse()
+            .unwrap_or_else(|_| panic!("{var} must be a port number, got: {value:?}")),
+        Err(_) => default,
+    }
 }
-pub const PROXY_METRICS_PORT: u16 = 9930;
-pub const PG_PORT: u16 = 5532;
-pub const PG_TLS_PORT: u16 = 5617;
 
 pub const TEST_SCHEMA_SQL: &str = include_str!(concat!("../../../tests/sql/schema.sql"));
 
@@ -88,7 +98,7 @@ pub fn random_string() -> String {
 }
 
 pub async fn clear() {
-    clear_with_client(&connect_with_tls(PROXY).await).await;
+    clear_with_client(&connect_with_tls(*PROXY).await).await;
 }
 
 pub async fn clear_with_client(client: &Client) {
@@ -108,13 +118,13 @@ pub async fn clear_table_with_client(client: &Client, table: &str) {
 }
 
 pub async fn clear_table(table: &str) {
-    clear_table_with_client(&connect_with_tls(PROXY).await, table).await;
+    clear_table_with_client(&connect_with_tls(*PROXY).await, table).await;
 }
 
 pub async fn reset_schema() {
     let port = std::env::var("CS_DATABASE__PORT")
         .map(|s| s.parse().unwrap())
-        .unwrap_or(PG_PORT);
+        .unwrap_or(*PG_PORT);
 
     let client = connect_with_tls(port).await;
     client.simple_query(TEST_SCHEMA_SQL).await.unwrap();
@@ -123,7 +133,7 @@ pub async fn reset_schema() {
 pub async fn reset_schema_to(schema: &'static str) {
     let port = std::env::var("CS_DATABASE__PORT")
         .map(|s| s.parse().unwrap())
-        .unwrap_or(PG_PORT);
+        .unwrap_or(*PG_PORT);
 
     let client = connect_with_tls(port).await;
     client.simple_query(schema).await.unwrap();
@@ -143,7 +153,7 @@ pub async fn table_exists(table: &str) -> bool {
 
     let port = std::env::var("CS_DATABASE__PORT")
         .map(|s| s.parse().unwrap())
-        .unwrap_or(PG_PORT);
+        .unwrap_or(*PG_PORT);
 
     let client = connect_with_tls(port).await;
     let messages = client.simple_query(&query).await.unwrap();
@@ -226,19 +236,19 @@ pub async fn connect(port: u16) -> Client {
 }
 
 pub async fn execute_query(sql: &str, params: &[&(dyn ToSql + Sync)]) {
-    let client = connect_with_tls(PROXY).await;
+    let client = connect_with_tls(*PROXY).await;
     client.query(sql, params).await.unwrap();
 }
 
 pub async fn execute_simple_query(sql: &str) {
-    let client = connect_with_tls(PROXY).await;
+    let client = connect_with_tls(*PROXY).await;
     client.simple_query(sql).await.unwrap();
 }
 
 pub async fn query<T: for<'a> tokio_postgres::types::FromSql<'a> + Send + Sync>(
     sql: &str,
 ) -> Vec<T> {
-    let client = connect_with_tls(PROXY).await;
+    let client = connect_with_tls(*PROXY).await;
     query_with_client(sql, &client).await
 }
 
@@ -278,7 +288,7 @@ pub async fn query_by_params<T>(sql: &str, params: &[&(dyn ToSql + Sync)]) -> Ve
 where
     T: for<'a> tokio_postgres::types::FromSql<'a> + Send + Sync,
 {
-    let client = connect_with_tls(PROXY).await;
+    let client = connect_with_tls(*PROXY).await;
     query_by_params_with_client(sql, params, &client).await
 }
 
@@ -299,7 +309,7 @@ pub fn get_database_port() -> u16 {
     std::env::var("CS_DATABASE__PORT")
         .ok()
         .and_then(|s| s.parse().ok())
-        .unwrap_or(PG_PORT)
+        .unwrap_or(*PG_PORT)
 }
 
 pub async fn query_direct_by<T>(sql: &str, param: &(dyn ToSql + Sync)) -> Vec<T>
@@ -318,7 +328,7 @@ pub async fn simple_query<T: std::str::FromStr>(sql: &str) -> Vec<T>
 where
     <T as std::str::FromStr>::Err: std::fmt::Debug,
 {
-    let client = connect_with_tls(PROXY).await;
+    let client = connect_with_tls(*PROXY).await;
     simple_query_with_client(sql, &client).await
 }
 
@@ -352,7 +362,7 @@ where
 // Returns a vector of `Option<String>` for each row in the result set.
 // Nulls are represented as `None`, and non-null values are converted to `Some(String)`.
 pub async fn simple_query_with_null(sql: &str) -> Vec<Option<String>> {
-    let client = connect_with_tls(PROXY).await;
+    let client = connect_with_tls(*PROXY).await;
     let rows = client.simple_query(sql).await.unwrap();
     rows.iter()
         .filter_map(|row| {
@@ -366,7 +376,7 @@ pub async fn simple_query_with_null(sql: &str) -> Vec<Option<String>> {
 }
 
 pub async fn insert(sql: &str, params: &[&(dyn ToSql + Sync)]) {
-    let client = connect_with_tls(PROXY).await;
+    let client = connect_with_tls(*PROXY).await;
     insert_with_client(sql, params, &client).await;
 }
 
@@ -375,7 +385,7 @@ pub async fn insert_with_client(sql: &str, params: &[&(dyn ToSql + Sync)], clien
 }
 
 pub async fn insert_jsonb() -> Value {
-    let client = connect_with_tls(PROXY).await;
+    let client = connect_with_tls(*PROXY).await;
     insert_jsonb_with_client(&client).await
 }
 

--- a/packages/cipherstash-proxy-integration/src/connection_resilience.rs
+++ b/packages/cipherstash-proxy-integration/src/connection_resilience.rs
@@ -21,8 +21,8 @@ mod tests {
     #[tokio::test]
     async fn slow_query_does_not_block_other_connections() {
         let result = timeout(Duration::from_secs(30), async {
-            let client_a = connect_with_tls(PROXY).await;
-            let client_b = connect_with_tls(PROXY).await;
+            let client_a = connect_with_tls(*PROXY).await;
+            let client_b = connect_with_tls(*PROXY).await;
 
             // Connection A: run a slow query
             let a_handle = tokio::spawn(async move {
@@ -56,7 +56,7 @@ mod tests {
         let result = timeout(Duration::from_secs(10), async {
             // First connection: query, then drop
             {
-                let client = connect_with_tls(PROXY).await;
+                let client = connect_with_tls(*PROXY).await;
                 let rows = client.simple_query("SELECT 1").await.unwrap();
                 assert!(!rows.is_empty());
             }
@@ -66,7 +66,7 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(100)).await;
 
             // Second connection: should work fine
-            let client = connect_with_tls(PROXY).await;
+            let client = connect_with_tls(*PROXY).await;
             let rows = client.simple_query("SELECT 1").await.unwrap();
             assert!(!rows.is_empty());
         })
@@ -84,7 +84,7 @@ mod tests {
             // 5 slow connections
             for _ in 0..5 {
                 join_set.spawn(async {
-                    let client = connect_with_tls(PROXY).await;
+                    let client = connect_with_tls(*PROXY).await;
                     client.simple_query("SELECT pg_sleep(3)").await.unwrap();
                 });
             }
@@ -96,7 +96,7 @@ mod tests {
             for _ in 0..5 {
                 join_set.spawn(async {
                     let start = Instant::now();
-                    let client = connect_with_tls(PROXY).await;
+                    let client = connect_with_tls(*PROXY).await;
                     let rows = client.simple_query("SELECT 1").await.unwrap();
                     let elapsed = start.elapsed();
 
@@ -140,7 +140,7 @@ mod tests {
 
             // Connection B: through proxy, attempt to acquire the same lock (will block)
             let b_handle = tokio::spawn(async move {
-                let client_b = connect_with_tls(PROXY).await;
+                let client_b = connect_with_tls(*PROXY).await;
                 // This will block until A releases the lock
                 client_b
                     .simple_query(&b_lock_query)
@@ -173,7 +173,7 @@ mod tests {
 
             // Connection C: through proxy, should complete immediately despite B being blocked
             let start = Instant::now();
-            let client_c = connect_with_tls(PROXY).await;
+            let client_c = connect_with_tls(*PROXY).await;
             let rows = client_c.simple_query("SELECT 1").await.unwrap();
             let elapsed = start.elapsed();
 

--- a/packages/cipherstash-proxy-integration/src/decrypt/insert_returning.rs
+++ b/packages/cipherstash-proxy-integration/src/decrypt/insert_returning.rs
@@ -10,7 +10,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let plaintext = "plaintext";
@@ -59,7 +59,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let plaintext = "plaintext";
@@ -101,7 +101,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let plaintext = "plaintext";

--- a/packages/cipherstash-proxy-integration/src/diagnostics.rs
+++ b/packages/cipherstash-proxy-integration/src/diagnostics.rs
@@ -14,7 +14,7 @@ mod tests {
 
     /// Fetch metrics with retry logic to handle CI timing variability.
     async fn fetch_metrics_with_retry(max_retries: u32, delay_ms: u64) -> String {
-        let url = format!("http://localhost:{}/metrics", PROXY_METRICS_PORT);
+        let url = format!("http://localhost:{}/metrics", *PROXY_METRICS_PORT);
         let mut last_error = None;
 
         for attempt in 0..max_retries {
@@ -40,7 +40,7 @@ mod tests {
 
     #[tokio::test]
     async fn metrics_include_statement_labels() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         clear().await;
 
@@ -80,7 +80,7 @@ mod tests {
 
     #[tokio::test]
     async fn slow_statement_metrics_and_logs() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         clear().await;
 

--- a/packages/cipherstash-proxy-integration/src/disable_mapping.rs
+++ b/packages/cipherstash-proxy-integration/src/disable_mapping.rs
@@ -24,7 +24,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let encrypted_text = "hello".to_string();
@@ -74,7 +74,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
 
@@ -143,7 +143,7 @@ mod tests {
         let sql = "INSERT INTO encrypted (id, encrypted_text) VALUES ($1, $2)";
         execute_query(sql, &[&id, &encrypted_text]).await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let sql = "SET CIPHERSTASH.UNSAFE_DISABLE_MAPPING = true";
         client.query(sql, &[]).await.unwrap();
 
@@ -151,7 +151,7 @@ mod tests {
 
         // Mapping is NOT disabled for these queries
         for _ in 1..5 {
-            let client = connect_with_tls(PROXY).await;
+            let client = connect_with_tls(*PROXY).await;
 
             let actual = query_with_client::<String>(select_sql, &client).await;
 

--- a/packages/cipherstash-proxy-integration/src/empty_result.rs
+++ b/packages/cipherstash-proxy-integration/src/empty_result.rs
@@ -4,7 +4,7 @@ mod tests {
 
     #[tokio::test]
     async fn empty_result_regression() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql = "SELECT ''";
 

--- a/packages/cipherstash-proxy-integration/src/encryption_sanity.rs
+++ b/packages/cipherstash-proxy-integration/src/encryption_sanity.rs
@@ -22,7 +22,7 @@ mod tests {
         let plaintext = "hello world";
 
         // Insert through proxy (should encrypt)
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let sql = "INSERT INTO encrypted (id, encrypted_text) VALUES ($1, $2)";
         client.query(sql, &[&id, &plaintext]).await.unwrap();
 
@@ -49,7 +49,7 @@ mod tests {
         let plaintext_json = serde_json::json!({"key": "value", "number": 42});
 
         // Insert through proxy (should encrypt)
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let sql = "INSERT INTO encrypted (id, encrypted_jsonb) VALUES ($1, $2)";
         client.query(sql, &[&id, &plaintext_json]).await.unwrap();
 
@@ -76,7 +76,7 @@ mod tests {
         let plaintext: f64 = 123.456;
 
         // Insert through proxy (should encrypt)
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let sql = "INSERT INTO encrypted (id, encrypted_float8) VALUES ($1, $2)";
         client.query(sql, &[&id, &plaintext]).await.unwrap();
 
@@ -103,7 +103,7 @@ mod tests {
         let plaintext: bool = true;
 
         // Insert through proxy (should encrypt)
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let sql = "INSERT INTO encrypted (id, encrypted_bool) VALUES ($1, $2)";
         client.query(sql, &[&id, &plaintext]).await.unwrap();
 
@@ -130,7 +130,7 @@ mod tests {
         let plaintext = NaiveDate::from_ymd_opt(2024, 6, 15).unwrap();
 
         // Insert through proxy (should encrypt)
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let sql = "INSERT INTO encrypted (id, encrypted_date) VALUES ($1, $2)";
         client.query(sql, &[&id, &plaintext]).await.unwrap();
 
@@ -157,7 +157,7 @@ mod tests {
         let plaintext: i16 = 42;
 
         // Insert through proxy (should encrypt)
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let sql = "INSERT INTO encrypted (id, encrypted_int2) VALUES ($1, $2)";
         client.query(sql, &[&id, &plaintext]).await.unwrap();
 
@@ -184,7 +184,7 @@ mod tests {
         let plaintext: i32 = 12345;
 
         // Insert through proxy (should encrypt)
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let sql = "INSERT INTO encrypted (id, encrypted_int4) VALUES ($1, $2)";
         client.query(sql, &[&id, &plaintext]).await.unwrap();
 
@@ -211,7 +211,7 @@ mod tests {
         let plaintext: i64 = 9876543210;
 
         // Insert through proxy (should encrypt)
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let sql = "INSERT INTO encrypted (id, encrypted_int8) VALUES ($1, $2)";
         client.query(sql, &[&id, &plaintext]).await.unwrap();
 

--- a/packages/cipherstash-proxy-integration/src/eql_regression.rs
+++ b/packages/cipherstash-proxy-integration/src/eql_regression.rs
@@ -73,7 +73,7 @@ mod tests {
         let id = random_id();
 
         // Insert via proxy (will encrypt)
-        let proxy_client = connect_with_tls(PROXY).await;
+        let proxy_client = connect_with_tls(*PROXY).await;
         let sql = format!("INSERT INTO encrypted (id, {column}) VALUES ($1, $2)");
         proxy_client
             .execute(&sql, &[&id, plaintext])
@@ -117,7 +117,7 @@ mod tests {
     where
         T: for<'a> tokio_postgres::types::FromSql<'a>,
     {
-        let proxy_client = connect_with_tls(PROXY).await;
+        let proxy_client = connect_with_tls(*PROXY).await;
         let sql = format!("SELECT {column} FROM encrypted WHERE id = $1");
         let rows = proxy_client
             .query(&sql, &[&id])
@@ -496,7 +496,7 @@ mod tests {
             insert_encrypted_directly(id, "encrypted_jsonb", &fixture.ciphertext).await;
 
             // Test field access via proxy
-            let proxy_client = connect_with_tls(PROXY).await;
+            let proxy_client = connect_with_tls(*PROXY).await;
 
             // Access string field
             let sql = "SELECT encrypted_jsonb->'string' FROM encrypted WHERE id = $1";
@@ -547,7 +547,7 @@ mod tests {
             let id = random_id();
             insert_encrypted_directly(id, "encrypted_jsonb", &fixture.ciphertext).await;
 
-            let proxy_client = connect_with_tls(PROXY).await;
+            let proxy_client = connect_with_tls(*PROXY).await;
 
             // Access array field
             let sql = "SELECT encrypted_jsonb->'array_number' FROM encrypted WHERE id = $1";

--- a/packages/cipherstash-proxy-integration/src/extended_protocol_error_messages.rs
+++ b/packages/cipherstash-proxy-integration/src/extended_protocol_error_messages.rs
@@ -2,9 +2,7 @@
 mod tests {
     use tracing::{debug, info};
 
-    use crate::common::{
-        clear, connect_with_tls, proxy_port, random_id, reset_schema, trace, PROXY,
-    };
+    use crate::common::{clear, connect_with_tls, random_id, reset_schema, trace, PROXY};
 
     /// A statement that always fails inside the proxy, at Parse, in every
     /// configuration: the proxy's SQL parser rejects it before it reaches the
@@ -40,7 +38,7 @@ mod tests {
 
         let id = random_id();
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let encrypted_text = "hello@cipherstash.com";
 
@@ -76,7 +74,7 @@ mod tests {
 
         reset_schema().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let _reset = Reset;
 
@@ -103,7 +101,7 @@ mod tests {
     async fn mapper_unsupported_parameter_type_with_date() {
         trace();
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         // let encrypted_date = NaiveDate::parse_from_str("2025-01-01", "%Y-%m-%d").unwrap();
@@ -132,7 +130,7 @@ mod tests {
     async fn proxy_error_after_mapped_statement() {
         trace();
 
-        let client = connect_with_tls(proxy_port()).await;
+        let client = connect_with_tls(*PROXY).await;
 
         // Mapped warm-up: an encrypted statement that parses, binds and
         // executes successfully.
@@ -171,7 +169,7 @@ mod tests {
     async fn proxy_error_after_passthrough_statement() {
         trace();
 
-        let client = connect_with_tls(proxy_port()).await;
+        let client = connect_with_tls(*PROXY).await;
 
         // Passthrough warm-up.
         client.query("SELECT 1::int4", &[]).await.unwrap();
@@ -200,7 +198,7 @@ mod tests {
 
         reset_schema().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let _reset = Reset;
 

--- a/packages/cipherstash-proxy-integration/src/insert/insert_domain_type.rs
+++ b/packages/cipherstash-proxy-integration/src/insert/insert_domain_type.rs
@@ -40,7 +40,7 @@ mod tests {
 
         let sql = "INSERT INTO encrypted (id, plaintext_domain, encrypted_text) VALUES ($1, $2, $3) RETURNING id, plaintext_domain, encrypted_text";
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let result = client
             .query(sql, &[&id, &encrypted_domain, &encrypted_text])
             .await

--- a/packages/cipherstash-proxy-integration/src/insert/insert_with_params.rs
+++ b/packages/cipherstash-proxy-integration/src/insert/insert_with_params.rs
@@ -71,7 +71,7 @@ mod tests {
     pub async fn query<T: for<'a> tokio_postgres::types::FromSql<'a> + Send + Sync>(
         sql: &str,
     ) -> Vec<T> {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let rows = client.query(sql, &[]).await.unwrap();
         rows.iter().map(|row| row.get(0)).collect::<Vec<T>>()
     }

--- a/packages/cipherstash-proxy-integration/src/map_concat.rs
+++ b/packages/cipherstash-proxy-integration/src/map_concat.rs
@@ -4,7 +4,7 @@ mod tests {
 
     #[tokio::test]
     async fn map_concat_regression() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         clear().await;
 

--- a/packages/cipherstash-proxy-integration/src/map_literals.rs
+++ b/packages/cipherstash-proxy-integration/src/map_literals.rs
@@ -6,7 +6,7 @@ mod tests {
     async fn map_literal() {
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let encrypted_text = "hello@cipherstash.com";
@@ -26,7 +26,7 @@ mod tests {
     async fn map_literal_with_param() {
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let encrypted_text = "hello@cipherstash.com";
@@ -55,7 +55,7 @@ mod tests {
         trace();
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let encrypted_jsonb = serde_json::json!({"key": "value"});
@@ -94,7 +94,7 @@ mod tests {
         let plaintext_json = serde_json::json!({"key": "value"});
 
         // Insert through proxy (should encrypt)
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let sql = "INSERT INTO encrypted (id, encrypted_jsonb) VALUES ($1, $2)";
         client.query(sql, &[&id, &plaintext_json]).await.unwrap();
 
@@ -136,7 +136,7 @@ mod tests {
     async fn map_repeated_literals_different_columns_regression() {
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
 
@@ -158,7 +158,7 @@ mod tests {
     async fn map_repeated_literals_same_column_regression() {
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql =
             format!("INSERT INTO encrypted (id, encrypted_text) VALUES ({}, 'a'), ({}, 'a') RETURNING encrypted_text", random_id(), random_id());

--- a/packages/cipherstash-proxy-integration/src/map_match_index.rs
+++ b/packages/cipherstash-proxy-integration/src/map_match_index.rs
@@ -8,7 +8,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let encrypted_text = "hello@cipherstash.com";

--- a/packages/cipherstash-proxy-integration/src/map_nulls.rs
+++ b/packages/cipherstash-proxy-integration/src/map_nulls.rs
@@ -7,7 +7,7 @@ mod tests {
     async fn map_insert_null_param() {
         trace();
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let encrypted_text: Option<String> = None;
@@ -30,7 +30,7 @@ mod tests {
     async fn map_update_null_param() {
         trace();
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let encrypted_text = "hello@cipherstash.com";
@@ -68,7 +68,7 @@ mod tests {
     async fn map_insert_encrypted_null_literal() {
         trace();
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
 
@@ -93,7 +93,7 @@ mod tests {
     async fn map_insert_null_literal_with_param() {
         trace();
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let encrypted_int2: i16 = 42;
@@ -125,7 +125,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let plaintext: Option<String> = None;

--- a/packages/cipherstash-proxy-integration/src/map_ope_index_order.rs
+++ b/packages/cipherstash-proxy-integration/src/map_ope_index_order.rs
@@ -66,7 +66,7 @@ mod tests {
     {
         trace();
         clear_table(table).await;
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let insert = format!("INSERT INTO {table} (id, {col_name}) VALUES ($1, $2)");
         for idx in interleaved_indices(values.len()) {
@@ -94,7 +94,7 @@ mod tests {
         trace();
         let table = "encrypted_ope_order_nulls_last";
         clear_table(table).await;
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let null_insert = format!("INSERT INTO {table} (id) VALUES ($1)");
         client.query(&null_insert, &[&random_id()]).await.unwrap();
@@ -121,7 +121,7 @@ mod tests {
         trace();
         let table = "encrypted_ope_order_nulls_first";
         clear_table(table).await;
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let insert = format!("INSERT INTO {table} (id, encrypted_text) VALUES ($1, $2), ($3, $4)");
         client

--- a/packages/cipherstash-proxy-integration/src/map_ope_index_where.rs
+++ b/packages/cipherstash-proxy-integration/src/map_ope_index_where.rs
@@ -63,7 +63,7 @@ mod tests {
 
         clear_table(table).await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         // Insert test data
         let sql = format!("INSERT INTO {table} (id, {col_name}) VALUES ($1, $2)");

--- a/packages/cipherstash-proxy-integration/src/map_ore_index_order.rs
+++ b/packages/cipherstash-proxy-integration/src/map_ore_index_order.rs
@@ -9,7 +9,7 @@ mod tests {
         trace();
         let table = "encrypted_ore_order_text";
         clear_table(table).await;
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         ore_order_helpers::ore_order_text(&client, table).await;
     }
 
@@ -18,7 +18,7 @@ mod tests {
         trace();
         let table = "encrypted_ore_order_text_desc";
         clear_table(table).await;
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         ore_order_helpers::ore_order_text_desc(&client, table).await;
     }
 
@@ -27,7 +27,7 @@ mod tests {
         trace();
         let table = "encrypted_ore_order_nulls_last";
         clear_table(table).await;
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         ore_order_helpers::ore_order_nulls_last_by_default(&client, table).await;
     }
 
@@ -36,7 +36,7 @@ mod tests {
         trace();
         let table = "encrypted_ore_order_nulls_first";
         clear_table(table).await;
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         ore_order_helpers::ore_order_nulls_first(&client, table).await;
     }
 
@@ -45,7 +45,7 @@ mod tests {
         trace();
         let table = "encrypted_ore_order_qualified";
         clear_table(table).await;
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         ore_order_helpers::ore_order_qualified_column(&client, table).await;
     }
 
@@ -54,7 +54,7 @@ mod tests {
         trace();
         let table = "encrypted_ore_order_qualified_alias";
         clear_table(table).await;
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         ore_order_helpers::ore_order_qualified_column_with_alias(&client, table).await;
     }
 
@@ -63,7 +63,7 @@ mod tests {
         trace();
         let table = "encrypted_ore_order_no_select_projection";
         clear_table(table).await;
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         ore_order_helpers::ore_order_no_eql_column_in_select_projection(&client, table).await;
     }
 
@@ -72,7 +72,7 @@ mod tests {
         trace();
         let table = "encrypted_ore_order_plaintext_column";
         clear_table(table).await;
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         ore_order_helpers::ore_order_plaintext_column(&client, table).await;
     }
 
@@ -81,7 +81,7 @@ mod tests {
         trace();
         let table = "encrypted_ore_order_plaintext_and_eql";
         clear_table(table).await;
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         ore_order_helpers::ore_order_plaintext_and_eql_columns(&client, table).await;
     }
 
@@ -90,7 +90,7 @@ mod tests {
         trace();
         let table = "encrypted_ore_order_simple_protocol";
         clear_table(table).await;
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         ore_order_helpers::ore_order_simple_protocol(&client, table).await;
     }
 
@@ -99,7 +99,7 @@ mod tests {
         trace();
         let table = "encrypted_ore_order_int2";
         clear_table(table).await;
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let values: Vec<i16> = vec![-100, -10, -1, 0, 1, 5, 10, 20, 100, 200];
         ore_order_helpers::ore_order_generic(
             &client,
@@ -116,7 +116,7 @@ mod tests {
         trace();
         let table = "encrypted_ore_order_int2_desc";
         clear_table(table).await;
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let values: Vec<i16> = vec![-100, -10, -1, 0, 1, 5, 10, 20, 100, 200];
         ore_order_helpers::ore_order_generic(
             &client,
@@ -133,7 +133,7 @@ mod tests {
         trace();
         let table = "encrypted_ore_order_int4";
         clear_table(table).await;
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let values: Vec<i32> = vec![
             -50_000, -1_000, -1, 0, 1, 42, 1_000, 10_000, 50_000, 100_000,
         ];
@@ -152,7 +152,7 @@ mod tests {
         trace();
         let table = "encrypted_ore_order_int4_desc";
         clear_table(table).await;
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let values: Vec<i32> = vec![
             -50_000, -1_000, -1, 0, 1, 42, 1_000, 10_000, 50_000, 100_000,
         ];
@@ -171,7 +171,7 @@ mod tests {
         trace();
         let table = "encrypted_ore_order_int8";
         clear_table(table).await;
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let values: Vec<i64> = vec![
             -1_000_000, -10_000, -1, 0, 1, 42, 10_000, 100_000, 1_000_000, 9_999_999,
         ];
@@ -190,7 +190,7 @@ mod tests {
         trace();
         let table = "encrypted_ore_order_int8_desc";
         clear_table(table).await;
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let values: Vec<i64> = vec![
             -1_000_000, -10_000, -1, 0, 1, 42, 10_000, 100_000, 1_000_000, 9_999_999,
         ];
@@ -209,7 +209,7 @@ mod tests {
         trace();
         let table = "encrypted_ore_order_float8";
         clear_table(table).await;
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let values: Vec<f64> = vec![
             -99.9, -1.5, -0.001, 0.0, 0.001, 1.5, 3.25, 42.0, 99.9, 1000.5,
         ];
@@ -228,7 +228,7 @@ mod tests {
         trace();
         let table = "encrypted_ore_order_float8_desc";
         clear_table(table).await;
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let values: Vec<f64> = vec![
             -99.9, -1.5, -0.001, 0.0, 0.001, 1.5, 3.25, 42.0, 99.9, 1000.5,
         ];

--- a/packages/cipherstash-proxy-integration/src/map_ore_index_where.rs
+++ b/packages/cipherstash-proxy-integration/src/map_ore_index_where.rs
@@ -63,7 +63,7 @@ mod tests {
 
         clear_table(table).await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         // Insert test data
         let sql = format!("INSERT INTO {table} (id, {col_name}) VALUES ($1, $2)");

--- a/packages/cipherstash-proxy-integration/src/map_params.rs
+++ b/packages/cipherstash-proxy-integration/src/map_params.rs
@@ -8,7 +8,7 @@ mod tests {
 
         reset_schema().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let plaintext = "hello@cipherstash.com";

--- a/packages/cipherstash-proxy-integration/src/map_unique_index.rs
+++ b/packages/cipherstash-proxy-integration/src/map_unique_index.rs
@@ -9,7 +9,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let encrypted_text = "hello@cipherstash.com";
@@ -38,7 +38,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let encrypted_int2: i16 = 42;
@@ -66,7 +66,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let encrypted_int4: i32 = 42;
@@ -94,7 +94,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let encrypted_int8: i64 = 42;
@@ -122,7 +122,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let encrypted_float8: f64 = 42.00;
@@ -150,7 +150,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let encrypted_date = NaiveDate::parse_from_str("2025-01-01", "%Y-%m-%d").unwrap();
@@ -178,7 +178,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let plaintext = "hello@cipherstash.com";
@@ -203,7 +203,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let plaintext = "hello@cipherstash.com";

--- a/packages/cipherstash-proxy-integration/src/migrate/mod.rs
+++ b/packages/cipherstash-proxy-integration/src/migrate/mod.rs
@@ -55,7 +55,7 @@ mod tests {
             }
         };
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         for _ in 1..10 {
             let id = random_id();

--- a/packages/cipherstash-proxy-integration/src/multitenant/contention.rs
+++ b/packages/cipherstash-proxy-integration/src/multitenant/contention.rs
@@ -39,7 +39,7 @@ mod tests {
     /// Establish a connection and set the keyset for a tenant.
     /// Returns the ready-to-use client (connection setup is excluded from timing).
     async fn connect_as_tenant(keyset_id: &str) -> tokio_postgres::Client {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         // SET doesn't support parameterized values; keyset_id is from trusted env vars
         let sql = format!("SET CIPHERSTASH.KEYSET_ID = '{keyset_id}'");
         client.execute(&sql, &[]).await.unwrap();

--- a/packages/cipherstash-proxy-integration/src/multitenant/ore_order.rs
+++ b/packages/cipherstash-proxy-integration/src/multitenant/ore_order.rs
@@ -17,7 +17,7 @@ mod tests {
     async fn connect_as_tenant(keyset_id: &str) -> tokio_postgres::Client {
         uuid::Uuid::parse_str(keyset_id)
             .unwrap_or_else(|_| panic!("invalid UUID for keyset_id: {keyset_id}"));
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let sql = format!("SET CIPHERSTASH.KEYSET_ID = '{keyset_id}'");
         client.execute(&sql, &[]).await.unwrap();
         client

--- a/packages/cipherstash-proxy-integration/src/multitenant/set_keyset_id.rs
+++ b/packages/cipherstash-proxy-integration/src/multitenant/set_keyset_id.rs
@@ -33,7 +33,7 @@ mod tests {
 
         // KEYSET_ID IS SCOPED TO A CONNECTION
         // The same client/connection is used for tests
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         // DEFAULT_KEYSET_ID SHOULD BE DISABLED FOR THIS TEST
         // SET KEYSET IS REQUIRED
@@ -103,7 +103,7 @@ mod tests {
 
         // KEYSET_ID IS SCOPED TO A CONNECTION
         // The same client/connection is used for tests
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         // DEFAULT_KEYSET_ID SHOULD BE DISABLED FOR THIS TEST
         // SET KEYSET IS REQUIRED
@@ -190,8 +190,8 @@ mod tests {
         let tenant_1_text = "TENANT_1".to_string();
         let tenant_2_text = "TENANT_2".to_string();
 
-        let tenant_1_client = connect_with_tls(PROXY).await;
-        let tenant_2_client = connect_with_tls(PROXY).await;
+        let tenant_1_client = connect_with_tls(*PROXY).await;
+        let tenant_2_client = connect_with_tls(*PROXY).await;
 
         // DEFAULT_KEYSET_ID SHOULD BE DISABLED FOR THIS TEST
         // SET KEYSET IS REQUIRED
@@ -262,7 +262,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let tenant_keyset_id_1 = std::env::var("CS_TENANT_KEYSET_ID_1")
             .map(|s| Uuid::parse_str(&s).unwrap())
@@ -308,7 +308,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let tenant_keyset_id_1 = std::env::var("CS_TENANT_KEYSET_ID_1")
             .map(|s| Uuid::parse_str(&s).unwrap())
@@ -346,7 +346,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let tenant_keyset_id_1 = std::env::var("CS_TENANT_KEYSET_ID_1")
             .map(|s| Uuid::parse_str(&s).unwrap())

--- a/packages/cipherstash-proxy-integration/src/multitenant/set_keyset_name.rs
+++ b/packages/cipherstash-proxy-integration/src/multitenant/set_keyset_name.rs
@@ -28,7 +28,7 @@ mod tests {
 
         // KEYSET_NAME IS SCOPED TO A CONNECTION
         // The same client/connection is used for tests
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         // DEFAULT_KEYSET_ID SHOULD BE DISABLED FOR THIS TEST
         // SET KEYSET IS REQUIRED
@@ -93,7 +93,7 @@ mod tests {
 
         // KEYSET_ID IS SCOPED TO A CONNECTION
         // The same client/connection is used for tests
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         // DEFAULT_KEYSET_ID SHOULD BE DISABLED FOR THIS TEST
         // SET KEYSET IS REQUIRED
@@ -181,8 +181,8 @@ mod tests {
         let tenant_1_text = "TENANT_1".to_string();
         let tenant_2_text = "TENANT_2".to_string();
 
-        let tenant_1_client = connect_with_tls(PROXY).await;
-        let tenant_2_client = connect_with_tls(PROXY).await;
+        let tenant_1_client = connect_with_tls(*PROXY).await;
+        let tenant_2_client = connect_with_tls(*PROXY).await;
 
         // DEFAULT_KEYSET_ID SHOULD BE DISABLED FOR THIS TEST
         // SET KEYSET IS REQUIRED
@@ -263,8 +263,8 @@ mod tests {
         let tenant_1_text = "TENANT_1_DATA".to_string();
         let tenant_2_text = "TENANT_2_DATA".to_string();
 
-        let tenant_1_client = connect_with_tls(PROXY).await;
-        let tenant_2_client = connect_with_tls(PROXY).await;
+        let tenant_1_client = connect_with_tls(*PROXY).await;
+        let tenant_2_client = connect_with_tls(*PROXY).await;
 
         // Set tenant keysets for each client
         let sql = format!("SET CIPHERSTASH.KEYSET_NAME = '{tenant_keyset_name_1}'");
@@ -327,7 +327,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let tenant_keyset_name_1 = std::env::var("CS_TENANT_KEYSET_NAME_1").unwrap();
 
@@ -372,7 +372,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let tenant_keyset_name_1 = std::env::var("CS_TENANT_KEYSET_NAME_1").unwrap();
 

--- a/packages/cipherstash-proxy-integration/src/passthrough.rs
+++ b/packages/cipherstash-proxy-integration/src/passthrough.rs
@@ -6,7 +6,7 @@ mod tests {
 
     #[tokio::test]
     async fn passthrough_statement() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         clear().await;
 
@@ -29,7 +29,7 @@ mod tests {
 
     #[tokio::test]
     async fn passthrough_invalid_statement() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         clear().await;
 
@@ -56,7 +56,7 @@ mod tests {
     async fn passthrough_statement_parallel() {
         for _x in 1..100 {
             tokio::spawn(async move {
-                let client = connect_with_tls(PROXY).await;
+                let client = connect_with_tls(*PROXY).await;
 
                 for _x in 1..10 {
                     let id = random_id();
@@ -86,7 +86,7 @@ mod tests {
 
     #[tokio::test]
     async fn passthrough_insert_from_select() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         clear().await;
 
@@ -118,7 +118,7 @@ mod tests {
 
     #[tokio::test]
     async fn passthrough_insert_with_value_from_select() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         clear().await;
 
@@ -149,7 +149,7 @@ mod tests {
 
     #[tokio::test]
     async fn passthrough_insert_with_returning() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         clear().await;
 
@@ -170,7 +170,7 @@ mod tests {
 
     #[tokio::test]
     async fn passthrough_select_with_cardinality() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         clear().await;
 
@@ -198,7 +198,7 @@ mod tests {
 
     #[tokio::test]
     async fn passthrough_delete_with_select() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         clear().await;
 

--- a/packages/cipherstash-proxy-integration/src/pipeline.rs
+++ b/packages/cipherstash-proxy-integration/src/pipeline.rs
@@ -16,7 +16,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let counter = AtomicUsize::new(0);
 

--- a/packages/cipherstash-proxy-integration/src/schema_change.rs
+++ b/packages/cipherstash-proxy-integration/src/schema_change.rs
@@ -4,7 +4,7 @@ mod tests {
 
     #[tokio::test]
     async fn schema_change_reloads_schema() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
 

--- a/packages/cipherstash-proxy-integration/src/select/distinct_order_by.rs
+++ b/packages/cipherstash-proxy-integration/src/select/distinct_order_by.rs
@@ -45,7 +45,7 @@ mod tests {
 
         insert_text(&["cherry", "apple", "date", "banana"]).await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql = "SELECT DISTINCT encrypted_text FROM encrypted ORDER BY encrypted_text ASC";
         let rows = client.query(sql, &[]).await.unwrap();
@@ -78,7 +78,7 @@ mod tests {
         // Six rows, three distinct plaintexts.
         insert_text(&["cherry", "apple", "banana", "apple", "cherry", "apple"]).await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         // Without ORDER BY: deduplicated in place, no subquery wrapping.
         let sql = "SELECT DISTINCT encrypted_text FROM encrypted";
@@ -108,7 +108,7 @@ mod tests {
 
         insert_text(&["cherry", "apple"]).await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql = "SELECT DISTINCT id, encrypted_text FROM encrypted ORDER BY encrypted_text";
         let rows = client.query(sql, &[]).await.unwrap();
@@ -130,7 +130,7 @@ mod tests {
 
         insert_text(&["cherry", "apple"]).await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql = "SELECT DISTINCT encrypted_text AS fruit FROM encrypted ORDER BY encrypted_text";
         let rows = client.query(sql, &[]).await.unwrap();
@@ -166,7 +166,7 @@ mod tests {
             .await;
         }
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql = "SELECT DISTINCT plaintext, encrypted_text FROM encrypted \
                    ORDER BY plaintext, encrypted_text";
@@ -204,7 +204,7 @@ mod tests {
             .await;
         }
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         // `1` is `plaintext`.
         let sql = "SELECT DISTINCT plaintext, encrypted_text FROM encrypted \
@@ -235,7 +235,7 @@ mod tests {
 
         insert_text(&["cherry", "apple", "date", "banana"]).await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql = "SELECT DISTINCT encrypted_text FROM encrypted \
                    ORDER BY encrypted_text ASC LIMIT 2";

--- a/packages/cipherstash-proxy-integration/src/select/indexing.rs
+++ b/packages/cipherstash-proxy-integration/src/select/indexing.rs
@@ -32,7 +32,7 @@ mod tests {
             insert(&sql, &[&id, &encrypted_text]).await;
         }
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql = "CREATE INDEX ON encrypted (eql_v3.ord_term(encrypted_text))";
         let _ = client.simple_query(sql).await;

--- a/packages/cipherstash-proxy-integration/src/select/jsonb_array_elements.rs
+++ b/packages/cipherstash-proxy-integration/src/select/jsonb_array_elements.rs
@@ -27,7 +27,7 @@ mod tests {
     #[tokio::test]
     async fn select_jsonb_array_elements_with_string() {
         trace();
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         clear_with_client(&client).await;
         insert_jsonb_with_client(&client).await;
@@ -39,7 +39,7 @@ mod tests {
     #[tokio::test]
     async fn select_jsonb_array_elements_with_numeric() {
         trace();
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         clear_with_client(&client).await;
         insert_jsonb_with_client(&client).await;
@@ -51,7 +51,7 @@ mod tests {
     #[tokio::test]
     async fn select_jsonb_array_elements_with_unknown_field() {
         trace();
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         clear_with_client(&client).await;
         insert_jsonb_with_client(&client).await;

--- a/packages/cipherstash-proxy-integration/src/select/jsonb_containment_index.rs
+++ b/packages/cipherstash-proxy-integration/src/select/jsonb_containment_index.rs
@@ -203,7 +203,7 @@ mod tests {
                 trace();
                 ensure_fixture_data().await;
 
-                let client = connect_with_tls(PROXY).await;
+                let client = connect_with_tls(*PROXY).await;
                 let test_case = ContainmentTestCase::new(OperandType::$lhs, OperandType::$rhs);
                 let search_value = test_case.search_value();
                 test_case.run(&client, &search_value).await;
@@ -217,7 +217,7 @@ mod tests {
     /// Does NOT call clear() - preserves data from other tests.
     /// Only inserts if the fixture data is missing.
     async fn ensure_fixture_data() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         // Check if fixture data already exists
         let sql = format!(
@@ -303,7 +303,7 @@ mod tests {
         trace();
         ensure_fixture_data().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         // Use extended query protocol with parameterized query
         // Filter by fixture ID range to isolate from other test data

--- a/packages/cipherstash-proxy-integration/src/select/jsonb_fusion_gaps.rs
+++ b/packages/cipherstash-proxy-integration/src/select/jsonb_fusion_gaps.rs
@@ -57,7 +57,7 @@ mod tests {
         clear().await;
         let id = insert_nested().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql = "SELECT id FROM encrypted WHERE encrypted_jsonb -> 'nested' -> 'string' = $1";
         let rows = client
@@ -89,7 +89,7 @@ mod tests {
         clear().await;
         insert_nested().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let selector: Option<String> = None;
         let sql = "SELECT id FROM encrypted WHERE encrypted_jsonb -> $1 = $2";

--- a/packages/cipherstash-proxy-integration/src/select/jsonb_path_query.rs
+++ b/packages/cipherstash-proxy-integration/src/select/jsonb_path_query.rs
@@ -34,7 +34,7 @@ mod tests {
     #[tokio::test]
     async fn select_jsonb_path_query_number() {
         trace();
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         clear_with_client(&client).await;
         insert_jsonb_with_client(&client).await;
@@ -45,7 +45,7 @@ mod tests {
     #[tokio::test]
     async fn select_jsonb_path_query_string() {
         trace();
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         clear_with_client(&client).await;
         insert_jsonb_with_client(&client).await;
@@ -56,7 +56,7 @@ mod tests {
     #[tokio::test]
     async fn select_jsonb_path_query_value() {
         trace();
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         clear_with_client(&client).await;
         insert_jsonb_with_client(&client).await;
@@ -72,7 +72,7 @@ mod tests {
     #[tokio::test]
     async fn select_jsonb_path_query_with_unknown() {
         trace();
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         clear_with_client(&client).await;
         insert_jsonb_with_client(&client).await;
@@ -97,7 +97,7 @@ mod tests {
     #[tokio::test]
     async fn select_jsonb_path_query_with_alias() {
         trace();
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         clear_with_client(&client).await;
         insert_jsonb_with_client(&client).await;

--- a/packages/cipherstash-proxy-integration/src/select/jsonb_selector_param_types.rs
+++ b/packages/cipherstash-proxy-integration/src/select/jsonb_selector_param_types.rs
@@ -22,7 +22,7 @@ mod tests {
         clear().await;
         insert_jsonb().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let selector = JsonPath::new("$.number");
 
         let sql = "SELECT jsonb_path_exists(encrypted_jsonb, $1) FROM encrypted";
@@ -42,7 +42,7 @@ mod tests {
         clear().await;
         insert_jsonb().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let selector = JsonPath::new("$.string");
 
         let sql = "SELECT jsonb_path_query_first(encrypted_jsonb, $1) FROM encrypted";
@@ -61,7 +61,7 @@ mod tests {
         clear().await;
         insert_jsonb().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql = "SELECT encrypted_jsonb -> $1 FROM encrypted";
         let stmt = client

--- a/packages/cipherstash-proxy-integration/src/select/operator_backed_predicates.rs
+++ b/packages/cipherstash-proxy-integration/src/select/operator_backed_predicates.rs
@@ -39,7 +39,7 @@ mod tests {
 
         insert_rows(&[("a", 1), ("b", 2), ("c", 3), ("d", 4), ("e", 5)]).await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql = "SELECT encrypted_int4 FROM encrypted WHERE encrypted_int4 BETWEEN 2 AND 4 \
                    ORDER BY encrypted_int4";
@@ -65,7 +65,7 @@ mod tests {
 
         insert_rows(&[("apple", 1), ("banana", 2), ("cherry", 3)]).await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql =
             "SELECT encrypted_text FROM encrypted WHERE encrypted_text IS DISTINCT FROM 'apple'";

--- a/packages/cipherstash-proxy-integration/src/select/operator_class_shapes.rs
+++ b/packages/cipherstash-proxy-integration/src/select/operator_class_shapes.rs
@@ -62,7 +62,7 @@ mod tests {
         clear().await;
         insert_fixture().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql = "SELECT DISTINCT ON (encrypted_text) encrypted_text FROM encrypted";
         let rows = client.query(sql, &[]).await.unwrap();
@@ -81,7 +81,7 @@ mod tests {
         clear().await;
         insert_fixture().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql = "SELECT encrypted_text FROM encrypted ORDER BY 1";
         let rows = client.query(sql, &[]).await.unwrap();
@@ -97,7 +97,7 @@ mod tests {
         clear().await;
         insert_fixture().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql = "SELECT encrypted_text FROM encrypted GROUP BY 1";
         let rows = client.query(sql, &[]).await.unwrap();
@@ -113,7 +113,7 @@ mod tests {
         clear().await;
         insert_fixture().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         // Two 'apple' rows and two 'banana' rows, so each of those partitions
         // must produce a rank 2. Every rank being 1 means no partitioning.
@@ -140,7 +140,7 @@ mod tests {
         clear().await;
         insert_fixture().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql =
             "SELECT encrypted_text FROM encrypted UNION ALL SELECT encrypted_text FROM encrypted";

--- a/packages/cipherstash-proxy-integration/src/select/pg_catalog.rs
+++ b/packages/cipherstash-proxy-integration/src/select/pg_catalog.rs
@@ -8,7 +8,7 @@ mod tests {
     ///
     #[tokio::test]
     async fn select_from_pg_catalog() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql = "SELECT attname, atttypid FROM pg_catalog.pg_attribute WHERE attrelid IS NOT NULL AND NOT attisdropped AND attnum > 0 ORDER BY attnum";
         let rows = client.query(sql, &[]).await.unwrap();

--- a/packages/cipherstash-proxy-integration/src/select/select_where_in.rs
+++ b/packages/cipherstash-proxy-integration/src/select/select_where_in.rs
@@ -58,7 +58,7 @@ mod tests {
         let sql =
             "SELECT encrypted_text FROM encrypted WHERE encrypted_text IN ('apple', 'banana')";
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let rows = client.query(sql, &[]).await.unwrap();
         let actual: Vec<String> = rows.iter().map(|r| r.get("encrypted_text")).collect();
         assert_eq!(vec!["apple", "banana"], sorted(actual));
@@ -78,7 +78,7 @@ mod tests {
         let sql =
             "SELECT encrypted_text FROM encrypted WHERE encrypted_text NOT IN ('apple', 'banana')";
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let rows = client.query(sql, &[]).await.unwrap();
         let actual: Vec<String> = rows.iter().map(|r| r.get("encrypted_text")).collect();
         assert_eq!(vec!["cherry"], actual);
@@ -96,7 +96,7 @@ mod tests {
 
         insert_text(&["apple", "banana", "cherry"]).await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql = "SELECT encrypted_text FROM encrypted WHERE encrypted_text IN ($1, $2)";
         let rows = client
@@ -127,7 +127,7 @@ mod tests {
 
         let sql = "SELECT encrypted_text FROM encrypted WHERE encrypted_text IN ('durian')";
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let rows = client.query(sql, &[]).await.unwrap();
         assert!(rows.is_empty());
 

--- a/packages/cipherstash-proxy-integration/src/select/select_where_jsonb.rs
+++ b/packages/cipherstash-proxy-integration/src/select/select_where_jsonb.rs
@@ -63,7 +63,7 @@ mod tests {
 
         insert_jsonb().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let selector = "number";
         let value = Value::from(1);

--- a/packages/cipherstash-proxy-integration/src/select/unmappable.rs
+++ b/packages/cipherstash-proxy-integration/src/select/unmappable.rs
@@ -11,7 +11,7 @@ mod tests {
     ///
     #[tokio::test]
     async fn unmappable_table_not_found() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql = "SELECT blah FROM vtha";
         let result = client.query(sql, &[]).await;
@@ -24,7 +24,7 @@ mod tests {
 
     #[tokio::test]
     async fn unmappable_column_not_found() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql = "SELECT blah FROM encrypted";
         let result = client.query(sql, &[]).await;
@@ -37,7 +37,7 @@ mod tests {
 
     #[tokio::test]
     async fn unmappable_native_cannot_be_unified_with_encrypted() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql = "SELECT * FROM encrypted WHERE plaintext = encrypted_text";
         let result = client.query(sql, &[]).await;
@@ -50,7 +50,7 @@ mod tests {
 
     #[tokio::test]
     async fn unmappable_syntax_error() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql = "SELECT *, FROM encrypted";
         let result = client.query(sql, &[]).await;

--- a/packages/cipherstash-proxy-integration/src/set_keyset_error.rs
+++ b/packages/cipherstash-proxy-integration/src/set_keyset_error.rs
@@ -28,7 +28,7 @@ mod tests {
     async fn set_keyset_id_with_default_config_error() {
         trace();
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql = "SET CIPHERSTASH.KEYSET_ID = '2cace9db-3a2a-4b46-a184-ba412b3e0730'";
 
@@ -49,7 +49,7 @@ mod tests {
     async fn set_keyset_name_with_default_config_error() {
         trace();
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let sql = "SET CIPHERSTASH.KEYSET_NAME = 'tenant-1'";
 

--- a/packages/cipherstash-proxy-integration/src/simple_protocol/error_handling.rs
+++ b/packages/cipherstash-proxy-integration/src/simple_protocol/error_handling.rs
@@ -4,7 +4,7 @@ mod tests {
 
     #[tokio::test]
     async fn frontend_error_does_not_crash_connection() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         // Statement has the wrong column name
         let sql = format!(

--- a/packages/cipherstash-proxy-integration/src/simple_protocol/map_literals.rs
+++ b/packages/cipherstash-proxy-integration/src/simple_protocol/map_literals.rs
@@ -6,7 +6,7 @@ mod tests {
 
     #[tokio::test]
     async fn simple_protocol_without_encryption() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let id = random_id();
         let sql = format!("INSERT INTO encrypted (id, plaintext) VALUES ({id}, 'plain')");
         client
@@ -28,7 +28,7 @@ mod tests {
 
     #[tokio::test]
     async fn simple_protocol_text() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let encrypted_text = "hello@cipherstash.com";
@@ -68,7 +68,7 @@ mod tests {
 
     #[tokio::test]
     async fn simple_protocol_int2() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let encrypted_int2: i16 = 42;
@@ -108,7 +108,7 @@ mod tests {
 
     #[tokio::test]
     async fn simple_protocol_date() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let encrypted_date = NaiveDate::parse_from_str("2025-01-01", "%Y-%m-%d").unwrap();
@@ -149,7 +149,7 @@ mod tests {
 
     #[tokio::test]
     async fn simple_protocol_date_with_iso() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let encrypted_date =
@@ -191,7 +191,7 @@ mod tests {
 
     #[tokio::test]
     async fn simple_protocol_int4() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let encrypted_int4: i32 = 42;
@@ -243,7 +243,7 @@ mod tests {
 
     #[tokio::test]
     async fn frontend_error_does_not_crash_connection() {
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         // Statement has the wrong column name
         let sql = format!(

--- a/packages/cipherstash-proxy-integration/src/simple_protocol/map_nulls.rs
+++ b/packages/cipherstash-proxy-integration/src/simple_protocol/map_nulls.rs
@@ -9,7 +9,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
         let encrypted_text: Option<&str> = None;
@@ -51,7 +51,7 @@ mod tests {
 
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let id = random_id();
 

--- a/packages/cipherstash-proxy-integration/src/simple_protocol/multiple_statements.rs
+++ b/packages/cipherstash-proxy-integration/src/simple_protocol/multiple_statements.rs
@@ -9,7 +9,7 @@ mod tests {
         trace();
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let data = (0..5)
             .map(|_| (random_id(), Faker.fake::<String>()))
@@ -53,7 +53,7 @@ mod tests {
         trace();
         clear().await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         let data = (0..5)
             .map(|_| (random_id(), Faker.fake::<String>(), Faker.fake::<String>()))

--- a/packages/cipherstash-proxy-integration/src/update/update_domain_type.rs
+++ b/packages/cipherstash-proxy-integration/src/update/update_domain_type.rs
@@ -54,7 +54,7 @@ mod tests {
         // Then update with RETURNING clause
         let sql = "UPDATE encrypted SET plaintext_domain = $1, encrypted_text = $2 WHERE id = $3 RETURNING id, plaintext_domain, encrypted_text";
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
         let result = client
             .query(sql, &[&updated_domain, &updated_text, &id])
             .await

--- a/packages/cipherstash-proxy-integration/src/update/update_with_reused_param.rs
+++ b/packages/cipherstash-proxy-integration/src/update/update_with_reused_param.rs
@@ -30,7 +30,7 @@ mod tests {
         )
         .await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         // The same placeholder is the stored value and the predicate operand.
         let sql = "UPDATE encrypted SET encrypted_text = $1 WHERE encrypted_text = $1";
@@ -59,7 +59,7 @@ mod tests {
         )
         .await;
 
-        let client = connect_with_tls(PROXY).await;
+        let client = connect_with_tls(*PROXY).await;
 
         // `$1` stores, `$2` queries; the reverse of the pairing above.
         let updated = "goodbye@cipherstash.com".to_string();


### PR DESCRIPTION
Prerequisite for the three plaintext-leak fixes stacked on top of this branch (CIP-3680, CIP-3682, CIP-3688). Small and standalone.

## Why

The four ports the integration suite connects to were hardcoded (`pub const PROXY: u16 = 6432`), so only one copy of the suite could run at a time. Fixing three separate Proxy defects in parallel needs three Proxy instances against three databases, which needs three sets of ports.

## What

`PROXY`, `PROXY_METRICS_PORT`, `PG_PORT` and `PG_TLS_PORT` become `LazyLock<u16>` reading `CS_TEST_PROXY_PORT`, `CS_TEST_PROXY_METRICS_PORT`, `CS_TEST_PG_PORT` and `CS_TEST_PG_TLS_PORT`, each falling back to its current value. An unconfigured run behaves exactly as before.

A malformed value **panics** rather than falling back to the default. Silently retargeting the whole suite at whatever else happens to be listening on 6432 is the one failure mode that looks like a pass.

## Note for anyone running the suite on custom ports

`mise exec` overrides `CS_DATABASE__PORT` from the parent shell, because `mise.toml` sets it to `5532`:

```
$ CS_DATABASE__PORT=5599 mise exec -- env | grep CS_DATABASE__PORT
CS_DATABASE__PORT=5532
```

Re-assert it inside: `mise exec -- env CS_DATABASE__PORT=5541 cargo …`. The `CS_TEST_*` variables introduced here are not set in `mise.toml`, so they pass through fine. Tests that run the migrate CLI in-process also need `CS_SERVER__PORT` set, since that CLI reads it to find Proxy.

## Testing

`cargo check -p cipherstash-proxy-integration --tests` clean; `cargo fmt` clean. Behaviour with no environment variables set is unchanged by construction.

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integration-test proxy and database ports can now be configured through environment variables, with defaults available when not specified.
* **Bug Fixes**
  * Updated connection handling across integration tests to use the runtime-configured ports.
* **Tests**
  * Maintained coverage for encryption, mapping, querying, multitenancy, diagnostics, and connection-resilience scenarios with the updated configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->