### PR TITLE
fix(proxy): refuse statements on a legacy eql_v2_encrypted column instead of serving it as plaintext (CIP-3688)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Equality on encrypted JSON fields**: `WHERE col -> 'field' = 'value'` now works on encrypted JSON columns, in both the simple and extended query protocols, and in the `->>` and `jsonb_path_query_first(col, path) = value` spellings. `<>` is supported as the negation. The field and the value are combined into a single encrypted value-selector needle and matched by containment, so a query never reveals the field and value separately. Matching is exact and case-sensitive; the value must be a JSON scalar (comparing a whole object or array to a field is rejected — use containment with `@>` instead).
 
+### Security
+
+- **A surviving `eql_v2_encrypted` column was served as plaintext**: after migrating to EQL v3, a column still declared with EQL v2's `eql_v2_encrypted` type had no v3 domain identity, so Proxy fell back to treating it as an ordinary plaintext column — no encryption on writes, no decryption on reads. An application writing to such a column stored plaintext in a database it believed was encrypted, and saw no error doing so; the only signal was a single warning at startup. This is the shape of a partly-completed migration, where most columns move to v3 domains and one is left behind.
+
+  Proxy now refuses every statement referencing a table that has such a column, with an error naming the column, its type and the need to migrate it. Other tables are unaffected, so one unmigrated column no longer costs you a deployment. The refusal is not subject to the `mapping_errors_enabled` passthrough — it applies whatever `CS_DEVELOPMENT__ENABLE_MAPPING_ERRORS` is set to. See [Unmappable encrypted column](docs/errors.md#mapping-unmappable-encrypted-column).
+
 ### Fixed
 
 - **Statement errors no longer desync the connection**: when a statement failed inside the proxy (an unsupported operation on an encrypted column, for instance), the error was written straight to the client and could overtake responses still in flight from the server — with connection pools and prepared-statement caching, the client then saw a protocol error (`unexpected message from server` in tokio_postgres) instead of the proxy's message, typically right after an encrypted statement had run on the same connection. The proxy now delivers statement errors through the server, so clients always receive the proxy's actual error message, in order, and the connection remains usable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **A NULL JSON selector forwarded the compared value to the database in plaintext**: `WHERE col -> $1 = $2` with `$1` bound NULL builds no needle, so `$2` was never encrypted — and it was then sent to PostgreSQL exactly as the client bound it, putting the plaintext comparand on the wire and into the server log when the column's domain CHECK rejected it. An encrypted operand that produced no ciphertext is now bound NULL, which is also what the SQL means: a comparison against NULL is NULL, so the query returns no rows.
 
+- **A surviving `eql_v2_encrypted` column was served as plaintext**: after migrating to EQL v3, a column still declared with EQL v2's `eql_v2_encrypted` type had no v3 domain identity, so Proxy fell back to treating it as an ordinary plaintext column — no encryption on writes, no decryption on reads. An application writing to such a column stored plaintext in a database it believed was encrypted, and saw no error doing so; the only signal was a single warning at startup. This is the shape of a partly-completed migration, where most columns move to v3 domains and one is left behind.
+
+  Proxy now refuses every statement referencing a table that has such a column, with an error naming the column, its type and the need to migrate it. Other tables are unaffected, so one unmigrated column no longer costs you a deployment. The refusal is not subject to the `mapping_errors_enabled` passthrough — it applies whatever `CS_DEVELOPMENT__ENABLE_MAPPING_ERRORS` is set to. See [Unmappable encrypted column](docs/errors.md#mapping-unmappable-encrypted-column).
+
 ## [3.0.0] - 2026-08-05
 
 ### Changed
@@ -43,12 +47,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`SELECT DISTINCT` ordered by an encrypted column**: `SELECT DISTINCT … ORDER BY <encrypted column>` now works. Ordering an encrypted column requires its ordering term, which PostgreSQL will not accept under `DISTINCT` unless it also appears in the select list, so the query is rewritten to project the term from a subquery and order the outer query by it. The term is never returned to the client and column names are preserved. Two shapes remain unsupported and are reported as such: `SELECT DISTINCT ON (…)` and `SELECT DISTINCT *`, both when combined with `ORDER BY` on an encrypted column — list the columns explicitly for the latter.
 
 - **Equality on encrypted JSON fields**: `WHERE col -> 'field' = 'value'` now works on encrypted JSON columns, in both the simple and extended query protocols, and in the `->>` and `jsonb_path_query_first(col, path) = value` spellings. `<>` is supported as the negation. The field and the value are combined into a single encrypted value-selector needle and matched by containment, so a query never reveals the field and value separately. Matching is exact and case-sensitive; the value must be a JSON scalar (comparing a whole object or array to a field is rejected — use containment with `@>` instead).
-
-### Security
-
-- **A surviving `eql_v2_encrypted` column was served as plaintext**: after migrating to EQL v3, a column still declared with EQL v2's `eql_v2_encrypted` type had no v3 domain identity, so Proxy fell back to treating it as an ordinary plaintext column — no encryption on writes, no decryption on reads. An application writing to such a column stored plaintext in a database it believed was encrypted, and saw no error doing so; the only signal was a single warning at startup. This is the shape of a partly-completed migration, where most columns move to v3 domains and one is left behind.
-
-  Proxy now refuses every statement referencing a table that has such a column, with an error naming the column, its type and the need to migrate it. Other tables are unaffected, so one unmigrated column no longer costs you a deployment. The refusal is not subject to the `mapping_errors_enabled` passthrough — it applies whatever `CS_DEVELOPMENT__ENABLE_MAPPING_ERRORS` is set to. See [Unmappable encrypted column](docs/errors.md#mapping-unmappable-encrypted-column).
 
 ### Fixed
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -12,6 +12,7 @@
   - [Invalid SQL statement](#mapping-invalid-sql-statement)
   - [Unsupported parameter type](#mapping-unsupported-parameter-type)
   - [Statement could not be type checked](#mapping-statement-could-not-be-type-checked)
+  - [Unmappable encrypted column](#mapping-unmappable-encrypted-column)
   - [Internal Error](#mapping-internal-error)
 
 - Encrypt errors:
@@ -245,6 +246,60 @@ In most cases, this error will occur if the statement contains invalid or unsupp
 Check if you are running the latest version of CipherStash Proxy, and update to the latest version if not.
 
 If the error persists, please contact CipherStash [support](https://cipherstash.com/support).
+
+
+
+<!-- ---------------------------------------------------------------------------------------------------- -->
+
+
+## Unmappable encrypted column <a id='mapping-unmappable-encrypted-column'></a>
+
+A table referenced by the statement has a column declared with the legacy EQL v2
+`eql_v2_encrypted` type. This version of Proxy targets EQL v3 and cannot encrypt or
+decrypt that type, so it refuses the statement rather than serve the column.
+
+### Error message
+
+```
+Column '{table}.{column}' is declared as 'eql_v2_encrypted', a legacy EQL v2 type that this
+version of CipherStash Proxy cannot encrypt or decrypt. Statements referencing '{table}' are
+refused so that plaintext is never written to the column. Migrate '{table}.{column}' to an
+EQL v3 domain type.
+```
+
+### Notes
+
+This is the signature of a partly-completed EQL v2 to v3 migration: most columns moved to
+v3 domain types, and one was left behind.
+
+Proxy identifies encrypted columns by their type. An EQL v3 encrypted column is a
+`jsonb`-backed domain whose name encodes its scalar type and searchable capabilities
+(`eql_v3_text_search`, `eql_v3_integer_ord`, and so on). EQL v2's `eql_v2_encrypted` carries
+none of that information, so Proxy has no way to encrypt a value written to such a column,
+and no way to decrypt one read back.
+
+**Every statement referencing the table is refused, not only those naming the column.** This
+is deliberate. A statement can reach a column it never names — through `SELECT *`, column
+defaults, `RETURNING`, triggers or rules — and getting that analysis wrong would mean writing
+plaintext into a column you believe is encrypted. Refusing on the table needs no such
+analysis. Other tables are unaffected, and Proxy continues to serve them normally.
+
+Unlike a type-check failure, this refusal is **not** subject to the `mapping_errors_enabled`
+passthrough. That fallback exists for statements Proxy does not understand, on the reasoning
+that they probably touch nothing encrypted. Here Proxy understands the statement exactly, and
+forwarding it is the specific harm the error exists to prevent, so the statement is refused
+whatever `CS_DEVELOPMENT__ENABLE_MAPPING_ERRORS` is set to.
+
+Proxy also logs a warning naming each such column when it loads the schema at startup.
+
+### How to fix
+
+Migrate the column to the EQL v3 domain type matching the data it holds and the operations
+you run against it — for example `eql_v3_text_search` for searchable text, or
+`eql_v3_integer_ord` for an orderable integer. Existing v2 ciphertext must be decrypted and
+re-encrypted as part of that migration; it cannot be reinterpreted in place.
+
+If the column is no longer used, dropping it also resolves the error.
 
 
 

--- a/packages/cipherstash-proxy-integration/src/legacy_v2_column.rs
+++ b/packages/cipherstash-proxy-integration/src/legacy_v2_column.rs
@@ -27,7 +27,7 @@
 //! rejected the statement.
 #[cfg(test)]
 mod tests {
-    use crate::common::{connect_with_tls, random_id, PG_PORT, PROXY};
+    use crate::common::{connect_with_tls, get_database_port, random_id, PROXY};
     use tokio_postgres::Client;
 
     /// A connection that does not go through Proxy.
@@ -36,8 +36,14 @@ mod tests {
     /// Proxy what is in the table cannot answer the question, because Proxy
     /// refuses to read the table at all — and even if it did, a decrypting read
     /// would hide the very thing being looked for.
+    ///
+    /// The port must be `get_database_port()`, the database Proxy is backed by,
+    /// not `PG_PORT`. Under the TLS suite Proxy sits in front of `postgres-tls`
+    /// on 5617 while `PG_PORT` is 5532, so a hardcoded `PG_PORT` would inspect a
+    /// different database — and a test that asserts a row is *absent* passes
+    /// trivially against the wrong, empty one.
     async fn direct_to_postgres() -> Client {
-        connect_with_tls(*PG_PORT).await
+        connect_with_tls(get_database_port()).await
     }
 
     async fn rows_in_fixture(pg: &Client) -> i64 {

--- a/packages/cipherstash-proxy-integration/src/legacy_v2_column.rs
+++ b/packages/cipherstash-proxy-integration/src/legacy_v2_column.rs
@@ -1,0 +1,292 @@
+//! A column left behind by a partly-completed EQL v2 -> v3 migration must be
+//! refused, not served as plaintext (CIP-3688).
+//!
+//! The fixture is `encrypted_v2_legacy` in `tests/sql/schema.sql`: a table whose
+//! `encrypted_text` column migrated to a v3 domain and whose `encrypted_v2`
+//! column is still declared with EQL v2's `eql_v2_encrypted` composite type.
+//! That type carries no v3 domain identity, so Proxy can neither encrypt writes
+//! to it nor decrypt reads from it.
+//!
+//! # What these tests actually assert
+//!
+//! That the client saw an error is the *weak* half of the claim: a statement
+//! could be executed and then reported as failed, and the plaintext would still
+//! be sitting in PostgreSQL. So every write test here also connects **directly**
+//! to PostgreSQL, bypassing Proxy entirely, and asserts the row never landed.
+//! That is the assertion the ticket is about.
+//!
+//! # Why these run with the mapping-error fallback at its default
+//!
+//! Nothing here sets `CS_DEVELOPMENT__ENABLE_MAPPING_ERRORS`. With that unset —
+//! the default, and what the proxy container runs with — a mapper rejection
+//! normally falls back to forwarding the original statement to PostgreSQL
+//! unchanged, which for this defect would send the plaintext write on its way.
+//! This refusal is deliberately exempt from that fallback, and running these
+//! tests against a default-configured Proxy is what pins that exemption. If the
+//! exemption regressed, these tests would fail even though the mapper still
+//! rejected the statement.
+#[cfg(test)]
+mod tests {
+    use crate::common::{connect_with_tls, random_id, PG_PORT, PROXY};
+    use tokio_postgres::Client;
+
+    /// A connection that does not go through Proxy.
+    ///
+    /// Every claim about what is or is not stored has to be made here. Asking
+    /// Proxy what is in the table cannot answer the question, because Proxy
+    /// refuses to read the table at all — and even if it did, a decrypting read
+    /// would hide the very thing being looked for.
+    async fn direct_to_postgres() -> Client {
+        connect_with_tls(*PG_PORT).await
+    }
+
+    async fn rows_in_fixture(pg: &Client) -> i64 {
+        pg.query_one("SELECT count(*) FROM encrypted_v2_legacy", &[])
+            .await
+            .unwrap()
+            .get(0)
+    }
+
+    /// Asserts the error is *this* refusal and not some unrelated failure.
+    ///
+    /// Worth being strict about: "the statement failed" would also be satisfied
+    /// by a typo in the test's SQL, which would make the test pass while proving
+    /// nothing. The message is also the only thing an operator gets, so its
+    /// content — which column, which type, what to do — is part of the contract.
+    fn assert_is_the_v2_refusal(err: &tokio_postgres::Error, context: &str) {
+        let message = err.to_string();
+        let db_message = std::error::Error::source(err)
+            .map(|source| source.to_string())
+            .unwrap_or(message);
+
+        assert!(
+            db_message.contains("encrypted_v2"),
+            "{context}: refusal must name the column to migrate, got: {db_message}"
+        );
+        assert!(
+            db_message.contains("eql_v2_encrypted"),
+            "{context}: refusal must name the offending type, got: {db_message}"
+        );
+        assert!(
+            db_message.contains("EQL v3"),
+            "{context}: refusal must tell the operator to migrate, got: {db_message}"
+        );
+    }
+
+    /// The write path the ticket is about, naming the legacy column directly.
+    #[tokio::test]
+    async fn insert_naming_the_legacy_column_is_refused_and_stores_nothing() {
+        let client = connect_with_tls(*PROXY).await;
+        let pg = direct_to_postgres().await;
+
+        let id = random_id();
+        let before = rows_in_fixture(&pg).await;
+
+        let err = client
+            .query(
+                "INSERT INTO encrypted_v2_legacy (id, encrypted_v2) VALUES ($1, ROW($2)::eql_v2_encrypted)",
+                &[&id, &serde_json::json!({"secret": "value"})],
+            )
+            .await
+            .expect_err("INSERT into a legacy EQL v2 column must be refused");
+
+        assert_is_the_v2_refusal(&err, "insert naming the legacy column");
+
+        // The decisive assertion: asked directly, PostgreSQL has no such row.
+        assert_eq!(
+            rows_in_fixture(&pg).await,
+            before,
+            "a refused INSERT must not have reached PostgreSQL"
+        );
+    }
+
+    /// The subtler write: the statement never mentions the legacy column, so a
+    /// column-scoped guard would wave it through. It is refused because the
+    /// refusal is scoped to the table.
+    ///
+    /// This is the case that makes the fix fail *closed*. Proving a statement
+    /// can never route a value into the legacy column — across `*`, defaults,
+    /// triggers, `RETURNING` and rules — is a negative that fails open whenever
+    /// it is wrong, and failing open is the bug.
+    #[tokio::test]
+    async fn insert_avoiding_the_legacy_column_is_still_refused_and_stores_nothing() {
+        let client = connect_with_tls(*PROXY).await;
+        let pg = direct_to_postgres().await;
+
+        let id = random_id();
+        let before = rows_in_fixture(&pg).await;
+
+        let err = client
+            .query(
+                "INSERT INTO encrypted_v2_legacy (id, plaintext) VALUES ($1, $2)",
+                &[&id, &"plaintext that must not be stored"],
+            )
+            .await
+            .expect_err("INSERT into a table with a legacy EQL v2 column must be refused");
+
+        assert_is_the_v2_refusal(&err, "insert avoiding the legacy column");
+
+        assert_eq!(
+            rows_in_fixture(&pg).await,
+            before,
+            "a refused INSERT must not have reached PostgreSQL"
+        );
+    }
+
+    /// The same write over the simple query protocol, which reaches the type
+    /// checker by a different path in the frontend than the extended protocol
+    /// above. Both paths have to refuse, and only one of them was exercised by
+    /// the test above.
+    #[tokio::test]
+    async fn simple_protocol_insert_is_refused_and_stores_nothing() {
+        let client = connect_with_tls(*PROXY).await;
+        let pg = direct_to_postgres().await;
+
+        let id = random_id();
+        let before = rows_in_fixture(&pg).await;
+
+        let err = client
+            .simple_query(&format!(
+                "INSERT INTO encrypted_v2_legacy (id, plaintext) VALUES ({id}, 'leaked')"
+            ))
+            .await
+            .expect_err("simple-protocol INSERT must be refused too");
+
+        assert_is_the_v2_refusal(&err, "simple protocol insert");
+
+        assert_eq!(
+            rows_in_fixture(&pg).await,
+            before,
+            "a refused simple-protocol INSERT must not have reached PostgreSQL"
+        );
+    }
+
+    /// UPDATE is a write like any other, and the one an operator is most likely
+    /// to reach for on a table that already has rows.
+    #[tokio::test]
+    async fn update_is_refused_and_changes_nothing() {
+        let client = connect_with_tls(*PROXY).await;
+        let pg = direct_to_postgres().await;
+
+        // Seed a row the only way it can be seeded: behind Proxy's back.
+        let id = random_id();
+        pg.execute(
+            "INSERT INTO encrypted_v2_legacy (id, plaintext) VALUES ($1, $2)",
+            &[&id, &"original"],
+        )
+        .await
+        .unwrap();
+
+        let err = client
+            .query(
+                "UPDATE encrypted_v2_legacy SET plaintext = $1 WHERE id = $2",
+                &[&"overwritten", &id],
+            )
+            .await
+            .expect_err("UPDATE on a table with a legacy EQL v2 column must be refused");
+
+        assert_is_the_v2_refusal(&err, "update");
+
+        let still: String = pg
+            .query_one(
+                "SELECT plaintext FROM encrypted_v2_legacy WHERE id = $1",
+                &[&id],
+            )
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(still, "original", "a refused UPDATE must not have applied");
+
+        pg.execute("DELETE FROM encrypted_v2_legacy WHERE id = $1", &[&id])
+            .await
+            .unwrap();
+    }
+
+    /// The read path.
+    ///
+    /// Reading back v2 ciphertext is not itself the data-at-rest exposure the
+    /// ticket is about — the stored bytes are already encrypted, and returning
+    /// them undecrypted leaks nothing. Reads are refused anyway, for two
+    /// reasons. First, Proxy cannot decrypt the value, so the alternative is
+    /// handing the client ciphertext it will read as data — silently wrong in a
+    /// different direction. Second, and decisively, a *predicate* on the column
+    /// would send the comparison value to PostgreSQL in the clear, which is a
+    /// plaintext exposure on a nominally read-only statement. Refusing the
+    /// statement covers both without having to tell them apart.
+    #[tokio::test]
+    async fn select_is_refused() {
+        let client = connect_with_tls(*PROXY).await;
+
+        let err = client
+            .query("SELECT id, encrypted_v2 FROM encrypted_v2_legacy", &[])
+            .await
+            .expect_err("SELECT of a legacy EQL v2 column must be refused");
+
+        assert_is_the_v2_refusal(&err, "select of the legacy column");
+    }
+
+    /// A read that never names the legacy column, refused for the same
+    /// table-scoped reason as the equivalent INSERT.
+    #[tokio::test]
+    async fn select_avoiding_the_legacy_column_is_still_refused() {
+        let client = connect_with_tls(*PROXY).await;
+
+        let err = client
+            .query("SELECT id FROM encrypted_v2_legacy", &[])
+            .await
+            .expect_err("SELECT on a table with a legacy EQL v2 column must be refused");
+
+        assert_is_the_v2_refusal(&err, "select avoiding the legacy column");
+    }
+
+    /// A predicate on the legacy column is the read-path case that is a genuine
+    /// exposure: unrefused, the comparison value travels to PostgreSQL in the
+    /// clear and appears in its logs and statistics.
+    #[tokio::test]
+    async fn select_with_a_predicate_on_the_legacy_column_is_refused() {
+        let client = connect_with_tls(*PROXY).await;
+
+        let err = client
+            .query(
+                "SELECT id FROM encrypted_v2_legacy WHERE encrypted_v2 = ROW($1)::eql_v2_encrypted",
+                &[&serde_json::json!({"secret": "value"})],
+            )
+            .await
+            .expect_err("a predicate on a legacy EQL v2 column must be refused");
+
+        assert_is_the_v2_refusal(&err, "select with a predicate on the legacy column");
+    }
+
+    /// The blast radius stays bounded to the unmigrated table.
+    ///
+    /// This is the argument for refusing per statement rather than refusing to
+    /// start: one column left behind must not take a whole deployment offline,
+    /// including for the tables nobody has a problem with.
+    #[tokio::test]
+    async fn tables_without_a_legacy_column_are_unaffected() {
+        let client = connect_with_tls(*PROXY).await;
+
+        let id = random_id();
+        client
+            .query(
+                "INSERT INTO encrypted (id, encrypted_text) VALUES ($1, $2)",
+                &[&id, &"still works"],
+            )
+            .await
+            .unwrap();
+
+        let rows = client
+            .query("SELECT encrypted_text FROM encrypted WHERE id = $1", &[&id])
+            .await
+            .unwrap();
+
+        assert_eq!(rows.len(), 1);
+        let value: String = rows[0].get("encrypted_text");
+        assert_eq!(value, "still works");
+
+        client
+            .query("DELETE FROM encrypted WHERE id = $1", &[&id])
+            .await
+            .unwrap();
+    }
+}

--- a/packages/cipherstash-proxy-integration/src/lib.rs
+++ b/packages/cipherstash-proxy-integration/src/lib.rs
@@ -8,6 +8,7 @@ mod encryption_sanity;
 mod eql_regression;
 mod extended_protocol_error_messages;
 mod insert;
+mod legacy_v2_column;
 mod map_concat;
 mod map_literals;
 mod map_match_index;

--- a/packages/cipherstash-proxy/src/error.rs
+++ b/packages/cipherstash-proxy/src/error.rs
@@ -58,6 +58,27 @@ pub enum Error {
     SendError(#[from] tokio::sync::mpsc::error::SendError<BytesMut>),
 }
 
+impl Error {
+    /// Whether this error must be returned to the client even when the proxy is
+    /// configured to fall back to forwarding statements it could not map.
+    ///
+    /// That fallback exists for mapper *coverage gaps*: a statement Proxy does
+    /// not understand is passed through unchanged, on the reasoning that it
+    /// probably touches nothing encrypted. Some errors are not coverage gaps but
+    /// deliberate refusals, where forwarding the statement is the very harm the
+    /// error was raised to prevent. Those are listed here and are never
+    /// downgraded to a passthrough.
+    pub fn must_fail_closed(&self) -> bool {
+        matches!(
+            self,
+            // Forwarding a statement that references a legacy EQL v2 column
+            // stores plaintext in a column its operator believes is encrypted
+            // (CIP-3688). No configuration may turn that back on.
+            Error::Mapping(MappingError::UnmappableEncryptedColumn { .. })
+        )
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum ContextError {
     #[error("Portal could not be found in context")]
@@ -97,6 +118,13 @@ pub enum MappingError {
 
     #[error("Statement could not be type checked: {}. For help visit {}#mapping-statement-could-not-be-type-checked", _0, ERROR_DOC_BASE_URL)]
     StatementCouldNotBeTypeChecked(String),
+
+    #[error("Column '{table}.{column}' is declared as '{column_type}', a legacy EQL v2 type that this version of CipherStash Proxy cannot encrypt or decrypt. Statements referencing '{table}' are refused so that plaintext is never written to the column. Migrate '{table}.{column}' to an EQL v3 domain type. For help visit {}#mapping-unmappable-encrypted-column", ERROR_DOC_BASE_URL)]
+    UnmappableEncryptedColumn {
+        table: String,
+        column: String,
+        column_type: String,
+    },
 
     #[error("Statement could not be transformed: {0}")]
     StatementCouldNotBeTransformed(String),

--- a/packages/cipherstash-proxy/src/postgresql/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/frontend.rs
@@ -472,7 +472,12 @@ where
             let typed_statement = match self.type_check(statement) {
                 Ok(ts) => ts,
                 Err(err) => {
-                    if self.context.mapping_errors_enabled() {
+                    // `must_fail_closed` errors are refusals: passing the
+                    // original statement to the database is the harm they exist
+                    // to prevent, so they ignore the passthrough fallback. This
+                    // holds today, independently of CIP-3680 removing that
+                    // fallback altogether.
+                    if self.context.mapping_errors_enabled() || err.must_fail_closed() {
                         return Err(err);
                     } else {
                         return Ok(None);
@@ -848,7 +853,9 @@ where
         let typed_statement = match self.type_check(&statement) {
             Ok(ts) => ts,
             Err(err) => {
-                if self.context.mapping_errors_enabled() {
+                // See the matching comment on the simple-protocol path: a
+                // refusal is never downgraded to a passthrough.
+                if self.context.mapping_errors_enabled() || err.must_fail_closed() {
                     return Err(err);
                 } else {
                     return Ok(None);
@@ -1210,6 +1217,26 @@ where
                 );
 
                 Ok(typed_statement)
+            }
+            // A column this build cannot map is a refusal, not a coverage gap,
+            // so it gets its own error: `must_fail_closed` keys off it to stop
+            // the passthrough fallback from serving the statement anyway.
+            Err(err) if err.as_unmappable_encrypted_column().is_some() => {
+                let (table, column, column_type) = err.as_unmappable_encrypted_column().unwrap();
+                warn!(
+                    client_id = self.context.client_id,
+                    msg = "Statement refused: it references a column declared with a legacy EQL v2 type that this build cannot encrypt or decrypt. Migrate the column to an EQL v3 domain type.",
+                    table,
+                    column,
+                    column_type,
+                );
+                counter!(STATEMENTS_UNMAPPABLE_TOTAL).increment(1);
+                Err(MappingError::UnmappableEncryptedColumn {
+                    table: table.to_string(),
+                    column: column.to_string(),
+                    column_type: column_type.to_string(),
+                }
+                .into())
             }
             Err(EqlMapperError::InternalError(str)) => {
                 warn!(

--- a/packages/cipherstash-proxy/src/proxy/schema/manager.rs
+++ b/packages/cipherstash-proxy/src/proxy/schema/manager.rs
@@ -117,6 +117,63 @@ async fn load_schema_with_retry(config: &DatabaseConfig) -> Result<Schema, Error
     }
 }
 
+/// The legacy EQL v2 encrypted column type.
+const EQL_V2_ENCRYPTED_TYPE: &str = "eql_v2_encrypted";
+
+/// Whether a column is declared with the legacy EQL v2 encrypted type.
+///
+/// Both catalog columns are checked because the two shapes EQL v2 shipped land
+/// in different places in `information_schema.columns`:
+///
+/// - as a composite type (what EQL v2 installs), `udt_name` is
+///   `eql_v2_encrypted` and `domain_name` is NULL;
+/// - as a DOMAIN, `udt_name` is the base type (`jsonb`) and only `domain_name`
+///   carries `eql_v2_encrypted`.
+///
+/// Checking `udt_name` alone — as this loader previously did — silently misses
+/// the domain shape, and a missed v2 column is precisely a plaintext column.
+fn is_legacy_eql_v2(column_type_name: Option<&str>, column_domain_name: Option<&str>) -> bool {
+    column_type_name == Some(EQL_V2_ENCRYPTED_TYPE) || column_domain_name == Some(EQL_V2_ENCRYPTED_TYPE)
+}
+
+/// Decides what a single catalog row means for the type checker.
+///
+/// Split out from [`load_schema`] so the classification — the security-relevant
+/// part — is testable without a database.
+fn classify_column(
+    table_name: &str,
+    column_name: &str,
+    column_type_name: Option<&str>,
+    column_domain_name: Option<&str>,
+) -> Column {
+    let ident = Ident::with_quote('"', column_name);
+
+    // Prefer the v3 domain: encrypted columns are jsonb-backed DOMAINs whose
+    // typname encodes the token type and capabilities. The domain identity and
+    // traits are read from the eql-bindings catalog (ADR-0002).
+    if let Some((identity, eql_traits)) = column_domain_name.and_then(eql_domains::resolve) {
+        debug!(target: SCHEMA, msg = "eql_v3 column", table = table_name, column = column_name, domain = %identity.domain.value, traits = %eql_traits);
+        return Column::eql(ident, eql_traits, identity);
+    }
+
+    // Legacy EQL v2 columns have no v3 domain identity, so this v3-only build
+    // can neither encrypt writes to them nor decrypt reads from them.
+    //
+    // They are NOT served as native (plaintext) columns. That was the CIP-3688
+    // defect: a partially-completed migration left one column behind, and Proxy
+    // silently accumulated plaintext in it, with nothing but a startup log line
+    // to say so. The column is marked unmappable instead, which makes the type
+    // checker refuse every statement referencing the table — failing closed, and
+    // naming the column that needs migrating.
+    if is_legacy_eql_v2(column_type_name, column_domain_name) {
+        warn!(target: SCHEMA, msg = "Column is declared with the legacy EQL v2 encrypted type, which this EQL v3 build cannot encrypt or decrypt. Statements referencing this table will be REFUSED so that plaintext is never written to the column. Migrate the column to an EQL v3 domain type.", table = table_name, column = column_name);
+        return Column::unmappable_encrypted(ident, EQL_V2_ENCRYPTED_TYPE);
+    }
+
+    // Any other unrecognised type is an ordinary plaintext column.
+    Column::native(ident)
+}
+
 pub async fn load_schema(config: &DatabaseConfig) -> Result<Schema, Error> {
     let client = connect::database(config).await?;
 
@@ -142,39 +199,12 @@ pub async fn load_schema(config: &DatabaseConfig) -> Result<Schema, Error> {
             .zip(column_type_names)
             .zip(column_domain_names)
             .for_each(|((col, column_type_name), column_domain_name)| {
-                let ident = Ident::with_quote('"', col);
-
-                // Prefer the v3 domain: encrypted columns are jsonb-backed
-                // DOMAINs whose typname encodes the token type and capabilities.
-                // The domain identity and traits are read from the eql-bindings
-                // catalog (ADR-0002); a domain we do not recognise is treated as
-                // a plaintext column.
-                let v3 = column_domain_name
-                    .as_deref()
-                    .and_then(eql_domains::resolve);
-
-                let column = match v3 {
-                    Some((identity, eql_traits)) => {
-                        debug!(target: SCHEMA, msg = "eql_v3 column", table = table_name, column = col, domain = %identity.domain.value, traits = %eql_traits);
-                        Column::eql(ident, eql_traits, identity)
-                    }
-                    None => {
-                        // Legacy EQL v2 columns (the `eql_v2_encrypted` composite
-                        // type) have no v3 domain identity and are unsupported on
-                        // this v3-only build — warn rather than silently treating
-                        // them as encrypted or plaintext.
-                        //
-                        // The column is served as a native passthrough: Proxy runs
-                        // no encrypt/decrypt on it, so new writes are stored as-is
-                        // (in plaintext) and existing values are returned as-is.
-                        // This is a data-at-rest exposure on the write path, so the
-                        // warning must be impossible to miss in ops.
-                        if column_type_name.as_deref() == Some("eql_v2_encrypted") {
-                            warn!(target: SCHEMA, msg = "eql_v2_encrypted column is unsupported on this EQL v3 build and is being served as a PLAINTEXT (native) column: Proxy performs no encryption on writes or decryption on reads. Migrate the column to an EQL v3 domain before writing to it.", table = table_name, column = col);
-                        }
-                        Column::native(ident)
-                    }
-                };
+                let column = classify_column(
+                    &table_name,
+                    col,
+                    column_type_name.as_deref(),
+                    column_domain_name.as_deref(),
+                );
 
                 table.add_column(Arc::new(column));
             });
@@ -192,4 +222,68 @@ pub async fn load_schema(config: &DatabaseConfig) -> Result<Schema, Error> {
         .collect();
 
     Ok(schema)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use eql_mapper::ColumnKind;
+
+    /// The shape `information_schema.columns` reports for a column declared with
+    /// the EQL v2 composite type, verified against PostgreSQL 17: `udt_name` is
+    /// the type name, `domain_name` is NULL.
+    const V2_COMPOSITE: (Option<&str>, Option<&str>) = (Some("eql_v2_encrypted"), None);
+
+    /// The same column had EQL v2 shipped `eql_v2_encrypted` as a DOMAIN over
+    /// jsonb: `udt_name` is the base type, `domain_name` carries the type name.
+    const V2_DOMAIN: (Option<&str>, Option<&str>) = (Some("jsonb"), Some("eql_v2_encrypted"));
+
+    fn kind(column_type_name: Option<&str>, column_domain_name: Option<&str>) -> ColumnKind {
+        classify_column("users", "secret", column_type_name, column_domain_name).kind
+    }
+
+    #[test]
+    fn legacy_v2_composite_column_is_never_native() {
+        // The regression this pins: `Native` here is a plaintext passthrough, so
+        // classifying a v2 column that way makes Proxy write plaintext into a
+        // column its operator believes is encrypted (CIP-3688). Assert the exact
+        // kind rather than `!= Native` so a future third "just serve it" kind
+        // cannot quietly take its place either.
+        assert_eq!(
+            kind(V2_COMPOSITE.0, V2_COMPOSITE.1),
+            ColumnKind::UnmappableEncrypted("eql_v2_encrypted".to_string())
+        );
+    }
+
+    #[test]
+    fn legacy_v2_domain_column_is_never_native() {
+        // The loader originally keyed only on `udt_name`, which misses this
+        // shape entirely — and a missed v2 column is a plaintext column.
+        assert_eq!(
+            kind(V2_DOMAIN.0, V2_DOMAIN.1),
+            ColumnKind::UnmappableEncrypted("eql_v2_encrypted".to_string())
+        );
+    }
+
+    #[test]
+    fn v3_domain_columns_still_resolve_to_eql() {
+        assert!(matches!(
+            kind(Some("jsonb"), Some("eql_v3_text_search")),
+            ColumnKind::Eql(_, _)
+        ));
+    }
+
+    #[test]
+    fn ordinary_columns_are_still_native() {
+        assert_eq!(kind(Some("text"), None), ColumnKind::Native);
+        assert_eq!(kind(Some("int4"), None), ColumnKind::Native);
+        // An unrecognised domain is a plaintext column, not a refusal: refusing
+        // every user-defined domain would be a very different change.
+        assert_eq!(
+            kind(Some("text"), Some("domain_type_with_check")),
+            ColumnKind::Native
+        );
+        // Only the exact v2 type name refuses; a lookalike does not.
+        assert_eq!(kind(Some("eql_v2_encrypted_backup"), None), ColumnKind::Native);
+    }
 }

--- a/packages/cipherstash-proxy/src/proxy/schema/manager.rs
+++ b/packages/cipherstash-proxy/src/proxy/schema/manager.rs
@@ -133,7 +133,8 @@ const EQL_V2_ENCRYPTED_TYPE: &str = "eql_v2_encrypted";
 /// Checking `udt_name` alone — as this loader previously did — silently misses
 /// the domain shape, and a missed v2 column is precisely a plaintext column.
 fn is_legacy_eql_v2(column_type_name: Option<&str>, column_domain_name: Option<&str>) -> bool {
-    column_type_name == Some(EQL_V2_ENCRYPTED_TYPE) || column_domain_name == Some(EQL_V2_ENCRYPTED_TYPE)
+    column_type_name == Some(EQL_V2_ENCRYPTED_TYPE)
+        || column_domain_name == Some(EQL_V2_ENCRYPTED_TYPE)
 }
 
 /// Decides what a single catalog row means for the type checker.
@@ -284,6 +285,9 @@ mod test {
             ColumnKind::Native
         );
         // Only the exact v2 type name refuses; a lookalike does not.
-        assert_eq!(kind(Some("eql_v2_encrypted_backup"), None), ColumnKind::Native);
+        assert_eq!(
+            kind(Some("eql_v2_encrypted_backup"), None),
+            ColumnKind::Native
+        );
     }
 }

--- a/packages/eql-mapper/src/eql_mapper.rs
+++ b/packages/eql-mapper/src/eql_mapper.rs
@@ -96,6 +96,31 @@ pub enum EqlMapperError {
     Param(#[from] ParamError),
 }
 
+impl EqlMapperError {
+    /// Returns `(table, column, column_type)` when this error is the refusal
+    /// raised for a column whose encrypted type this build cannot map
+    /// ([`crate::ColumnKind::UnmappableEncrypted`]).
+    ///
+    /// The refusal surfaces either directly as a [`TypeError`] or wrapped in an
+    /// [`ImportError`], depending on whether the table entered the type system
+    /// via an INSERT target list or a FROM clause; callers should not have to
+    /// know which.
+    ///
+    /// This exists so a caller can tell a *refusal* apart from a type-check
+    /// *failure*. Those must not be handled alike: a failure may be answered by
+    /// forwarding the original statement unchanged, a refusal never may — doing
+    /// so is exactly the plaintext write the refusal prevents.
+    pub fn as_unmappable_encrypted_column(&self) -> Option<(&str, &str, &str)> {
+        match self {
+            EqlMapperError::Type(err) => err.as_unmappable_encrypted_column(),
+            EqlMapperError::Import(ImportError::TypeError(err)) => {
+                err.as_unmappable_encrypted_column()
+            }
+            _ => None,
+        }
+    }
+}
+
 /// `EqlMapper` can safely convert a SQL statement into an equivalent statement where all of the plaintext literals have
 /// been converted to EQL payloads containing the encrypted literal and/or encrypted representations of those literals.
 struct EqlMapper<'ast> {

--- a/packages/eql-mapper/src/importer.rs
+++ b/packages/eql-mapper/src/importer.rs
@@ -45,7 +45,7 @@ impl<'ast> Importer<'ast> {
         {
             let table = self.table_resolver.resolve_table(table_name)?;
 
-            let projection = Projection::new_from_schema_table(table.clone());
+            let projection = Projection::new_from_schema_table(table.clone())?;
 
             // The relation is named — by its alias when one is written, by the
             // table name otherwise — so that qualified references (`t.col` in
@@ -138,7 +138,7 @@ impl<'ast> Importer<'ast> {
                 if scope_tracker.resolve_relation(name).is_err() {
                     let table = self.table_resolver.resolve_table(name)?;
 
-                    let projection = Projection::new_from_schema_table(table.clone());
+                    let projection = Projection::new_from_schema_table(table.clone())?;
 
                     scope_tracker.add_relation(Relation {
                         name: record_as.cloned().ok(),

--- a/packages/eql-mapper/src/inference/infer_type_impls/insert_statement.rs
+++ b/packages/eql-mapper/src/inference/infer_type_impls/insert_statement.rs
@@ -38,7 +38,7 @@ fn stored_value_type(stc: &SchemaTableColumn) -> Result<(Value, TableColumn), Ty
                 // in `Projection`.
                 column: stc.column.value.clone(),
                 column_type: column_type.clone(),
-            })
+            });
         }
     };
 

--- a/packages/eql-mapper/src/inference/infer_type_impls/insert_statement.rs
+++ b/packages/eql-mapper/src/inference/infer_type_impls/insert_statement.rs
@@ -13,7 +13,12 @@ use sqltk::parser::ast::{
 
 /// The type of the value stored in a schema column: the column's EQL type when
 /// it is encrypted, its native identity otherwise.
-fn stored_value_type(stc: &SchemaTableColumn) -> (Value, TableColumn) {
+///
+/// Naming a column as a write target (an INSERT column list, or an
+/// `ON CONFLICT DO UPDATE` assignment) is the path the unmappable-column
+/// refusal exists for: there is no way to encrypt the incoming value, so
+/// accepting it would store plaintext. (CIP-3688)
+fn stored_value_type(stc: &SchemaTableColumn) -> Result<(Value, TableColumn), TypeError> {
     let tc = TableColumn {
         table: stc.table.clone(),
         column: stc.column.clone(),
@@ -26,9 +31,16 @@ fn stored_value_type(stc: &SchemaTableColumn) -> (Value, TableColumn) {
             identity.clone(),
             *features,
         ))),
+        ColumnKind::UnmappableEncrypted(column_type) => {
+            return Err(TypeError::UnmappableEncryptedColumn {
+                table: stc.table.to_string(),
+                column: stc.column.to_string(),
+                column_type: column_type.clone(),
+            })
+        }
     };
 
-    (value_ty, tc)
+    Ok((value_ty, tc))
 }
 
 #[trace_infer]
@@ -68,10 +80,10 @@ impl<'ast> InferType<'ast, Insert> for TypeInferencer<'ast> {
                 &table_columns
                     .into_iter()
                     .map(|stc| {
-                        let (value_ty, tc) = stored_value_type(&stc);
-                        (Arc::new(Type::Value(value_ty)), Some(tc.column))
+                        let (value_ty, tc) = stored_value_type(&stc)?;
+                        Ok((Arc::new(Type::Value(value_ty)), Some(tc.column)))
                     })
-                    .collect::<Vec<_>>(),
+                    .collect::<Result<Vec<_>, TypeError>>()?,
             );
 
             if let Some(source) = source {
@@ -187,7 +199,7 @@ impl<'ast> TypeInferencer<'ast> {
                             let stc = self
                                 .table_resolver
                                 .resolve_table_column(table_name, ident)?;
-                            let (value_ty, _) = stored_value_type(&stc);
+                            let (value_ty, _) = stored_value_type(&stc)?;
                             self.unify_node_with_type(&assignment.value, Type::Value(value_ty))?;
                         }
 

--- a/packages/eql-mapper/src/inference/infer_type_impls/insert_statement.rs
+++ b/packages/eql-mapper/src/inference/infer_type_impls/insert_statement.rs
@@ -33,8 +33,10 @@ fn stored_value_type(stc: &SchemaTableColumn) -> Result<(Value, TableColumn), Ty
         ))),
         ColumnKind::UnmappableEncrypted(column_type) => {
             return Err(TypeError::UnmappableEncryptedColumn {
-                table: stc.table.to_string(),
-                column: stc.column.to_string(),
+                table: stc.table.value.clone(),
+                // `.value` rather than `.to_string()` — see the matching note
+                // in `Projection`.
+                column: stc.column.value.clone(),
                 column_type: column_type.clone(),
             })
         }

--- a/packages/eql-mapper/src/inference/infer_type_impls/statement.rs
+++ b/packages/eql-mapper/src/inference/infer_type_impls/statement.rs
@@ -68,8 +68,10 @@ impl<'ast> InferType<'ast, Statement> for TypeInferencer<'ast> {
                                 // accepting it would store plaintext. (CIP-3688)
                                 ColumnKind::UnmappableEncrypted(column_type) => {
                                     return Err(TypeError::UnmappableEncryptedColumn {
-                                        table: stc.table.to_string(),
-                                        column: stc.column.to_string(),
+                                        table: stc.table.value.clone(),
+                                        // `.value` rather than `.to_string()` —
+                                        // see the matching note in `Projection`.
+                                        column: stc.column.value.clone(),
                                         column_type: column_type.clone(),
                                     })
                                 }

--- a/packages/eql-mapper/src/inference/infer_type_impls/statement.rs
+++ b/packages/eql-mapper/src/inference/infer_type_impls/statement.rs
@@ -73,7 +73,7 @@ impl<'ast> InferType<'ast, Statement> for TypeInferencer<'ast> {
                                         // see the matching note in `Projection`.
                                         column: stc.column.value.clone(),
                                         column_type: column_type.clone(),
-                                    })
+                                    });
                                 }
                             };
 

--- a/packages/eql-mapper/src/inference/infer_type_impls/statement.rs
+++ b/packages/eql-mapper/src/inference/infer_type_impls/statement.rs
@@ -63,6 +63,16 @@ impl<'ast> InferType<'ast, Statement> for TypeInferencer<'ast> {
                                 ColumnKind::Eql(features, identity) => Value::Eql(EqlTerm::Full(
                                     EqlValue(tc, identity.clone(), *features),
                                 )),
+                                // An UPDATE assignment is a write path: there is
+                                // no way to encrypt the incoming value, so
+                                // accepting it would store plaintext. (CIP-3688)
+                                ColumnKind::UnmappableEncrypted(column_type) => {
+                                    return Err(TypeError::UnmappableEncryptedColumn {
+                                        table: stc.table.to_string(),
+                                        column: stc.column.to_string(),
+                                        column_type: column_type.clone(),
+                                    })
+                                }
                             };
 
                             self.unify_node_with_type(

--- a/packages/eql-mapper/src/inference/type_error.rs
+++ b/packages/eql-mapper/src/inference/type_error.rs
@@ -95,4 +95,41 @@ pub enum TypeError {
 
     #[error("{}", _0)]
     TypeSignature(String),
+
+    /// A referenced table has a column declared with an encrypted-column type
+    /// this build cannot map (see [`crate::ColumnKind::UnmappableEncrypted`]).
+    ///
+    /// This is a refusal, not a coverage gap: serving the statement would mean
+    /// treating the column as plaintext.
+    #[error(
+        "Column `{}.{}` is declared as `{}`, which this build of CipherStash Proxy cannot encrypt or decrypt. Statements referencing `{}` are refused so that plaintext is never written to it. Migrate the column to an EQL v3 domain type.",
+        table,
+        column,
+        column_type,
+        table
+    )]
+    UnmappableEncryptedColumn {
+        table: String,
+        column: String,
+        column_type: String,
+    },
+}
+
+impl TypeError {
+    /// Returns `(table, column, column_type)` when this error is the
+    /// unmappable-encrypted-column refusal.
+    ///
+    /// Callers use this to tell a refusal apart from an ordinary type-check
+    /// failure, because the two must not be handled the same way: a type-check
+    /// failure may fall back to passthrough, a refusal never may.
+    pub fn as_unmappable_encrypted_column(&self) -> Option<(&str, &str, &str)> {
+        match self {
+            TypeError::UnmappableEncryptedColumn {
+                table,
+                column,
+                column_type,
+            } => Some((table, column, column_type)),
+            _ => None,
+        }
+    }
 }

--- a/packages/eql-mapper/src/inference/unifier/types.rs
+++ b/packages/eql-mapper/src/inference/unifier/types.rs
@@ -850,10 +850,15 @@ impl Projection {
                     ))),
                     ColumnKind::UnmappableEncrypted(column_type) => {
                         return Err(TypeError::UnmappableEncryptedColumn {
-                            table: table.name.to_string(),
-                            column: col.name.to_string(),
+                            table: table.name.value.clone(),
+                            // `.value`, not `.to_string()`: the schema loader
+                            // builds column idents with `Ident::with_quote`, so
+                            // `to_string` would render `"col"` and the operator
+                            // would be told to migrate a column whose name
+                            // appears to include quote characters.
+                            column: col.name.value.clone(),
                             column_type: column_type.clone(),
-                        })
+                        });
                     }
                 };
 

--- a/packages/eql-mapper/src/inference/unifier/types.rs
+++ b/packages/eql-mapper/src/inference/unifier/types.rs
@@ -825,28 +825,42 @@ impl Projection {
         Self(columns)
     }
 
-    pub(crate) fn new_from_schema_table(table: Arc<Table>) -> Self {
-        Self(
-            table
-                .columns
-                .iter()
-                .map(|col| {
-                    let tc = TableColumn {
-                        table: table.name.clone(),
-                        column: col.name.clone(),
-                    };
+    /// Builds the projection a schema table contributes when it is brought into
+    /// scope.
+    ///
+    /// Fallible because of [`ColumnKind::UnmappableEncrypted`]: a table with such
+    /// a column has no safe projection. There is no type to give it — modelling
+    /// it as native would make Proxy serve ciphertext as plaintext and accept
+    /// plaintext writes into it — so the whole statement is refused here, at the
+    /// single point where schema columns enter the type system. (CIP-3688)
+    pub(crate) fn new_from_schema_table(table: Arc<Table>) -> Result<Self, TypeError> {
+        table
+            .columns
+            .iter()
+            .map(|col| {
+                let tc = TableColumn {
+                    table: table.name.clone(),
+                    column: col.name.clone(),
+                };
 
-                    let value_ty = match &col.kind {
-                        ColumnKind::Native => Type::Value(Value::Native(NativeValue(Some(tc)))),
-                        ColumnKind::Eql(features, identity) => Type::Value(Value::Eql(
-                            EqlTerm::Full(EqlValue(tc, identity.clone(), *features)),
-                        )),
-                    };
+                let value_ty = match &col.kind {
+                    ColumnKind::Native => Type::Value(Value::Native(NativeValue(Some(tc)))),
+                    ColumnKind::Eql(features, identity) => Type::Value(Value::Eql(EqlTerm::Full(
+                        EqlValue(tc, identity.clone(), *features),
+                    ))),
+                    ColumnKind::UnmappableEncrypted(column_type) => {
+                        return Err(TypeError::UnmappableEncryptedColumn {
+                            table: table.name.to_string(),
+                            column: col.name.to_string(),
+                            column_type: column_type.clone(),
+                        })
+                    }
+                };
 
-                    ProjectionColumn::new(value_ty, Some(col.name.clone()))
-                })
-                .collect(),
-        )
+                Ok(ProjectionColumn::new(value_ty, Some(col.name.clone())))
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(Self)
     }
 
     pub fn len(&self) -> usize {

--- a/packages/eql-mapper/src/lib.rs
+++ b/packages/eql-mapper/src/lib.rs
@@ -376,6 +376,98 @@ mod test {
         );
     }
 
+    /// A table left behind by a partial EQL v2 -> v3 migration: 19 columns
+    /// migrated, one still declared with the legacy `eql_v2_encrypted` type.
+    fn legacy_v2_schema() -> Arc<TableResolver> {
+        resolver(schema! {
+            tables: {
+                users: {
+                    id,
+                    email (EQL: Eq),
+                    legacy (UNMAPPABLE("eql_v2_encrypted")),
+                }
+            }
+        })
+    }
+
+    /// Asserts the statement is refused, and specifically that it is refused as
+    /// the unmappable-column *refusal* rather than as some incidental type
+    /// error. That distinction is load-bearing: only the refusal is exempt from
+    /// the proxy's passthrough fallback, so a statement that failed for any
+    /// other reason would still be forwarded to the database in plaintext.
+    fn assert_refused(sql: &str) {
+        let statement = parse(sql);
+        let err = match type_check(legacy_v2_schema(), &statement) {
+            Ok(_) => panic!("statement was accepted but must be refused: {sql}"),
+            Err(err) => err,
+        };
+
+        assert_eq!(
+            err.as_unmappable_encrypted_column(),
+            Some(("users", "legacy", "eql_v2_encrypted")),
+            "refused for the wrong reason ({err}): {sql}"
+        );
+    }
+
+    #[test]
+    fn insert_into_a_legacy_v2_column_is_refused() {
+        // The write path this refusal exists for. Accepting it stores plaintext.
+        assert_refused("INSERT INTO users (id, legacy) VALUES (1, 'secret')");
+        assert_refused("INSERT INTO users VALUES (1, 'a', 'secret')");
+        assert_refused("UPDATE users SET legacy = 'secret' WHERE id = 1");
+    }
+
+    #[test]
+    fn reading_a_legacy_v2_column_is_refused() {
+        // Reading back v2 ciphertext is not itself an exposure, but it is served
+        // undecrypted and a client cannot tell that from plaintext. More
+        // importantly a *predicate* on the column sends the comparison value to
+        // the database in the clear, which is an exposure on a nominally
+        // read-only statement. Both are refused.
+        assert_refused("SELECT legacy FROM users");
+        assert_refused("SELECT * FROM users");
+        assert_refused("SELECT id FROM users WHERE legacy = 'secret'");
+        assert_refused("DELETE FROM users WHERE legacy = 'secret'");
+    }
+
+    #[test]
+    fn the_whole_table_is_refused_not_just_the_column() {
+        // Deliberately coarse. Proving that a statement can never route a value
+        // into or out of the column — across `*`, CTEs, subqueries, RETURNING and
+        // defaults — is the kind of negative that fails *open* when it is wrong,
+        // which is the bug being fixed. Refusing on the table needs no such
+        // proof. The blast radius stays bounded to the one unmigrated table.
+        assert_refused("SELECT id FROM users");
+        assert_refused("INSERT INTO users (id) VALUES (1)");
+        assert_refused("SELECT u.id FROM users AS u");
+        assert_refused("SELECT id FROM (SELECT id FROM users) AS sub");
+        assert_refused("WITH c AS (SELECT id FROM users) SELECT id FROM c");
+    }
+
+    #[test]
+    fn other_tables_are_unaffected() {
+        // The reason this is not a startup refusal: one unmigrated table must
+        // not take down a whole deployment.
+        let schema = resolver(schema! {
+            tables: {
+                users: {
+                    id,
+                    legacy (UNMAPPABLE("eql_v2_encrypted")),
+                }
+                accounts: {
+                    id,
+                    email (EQL: Eq),
+                }
+            }
+        });
+
+        let statement = parse("SELECT id FROM accounts WHERE email = 'a@b.com'");
+        assert!(
+            type_check(schema, &statement).is_ok(),
+            "a table with no legacy column must still be served"
+        );
+    }
+
     #[test]
     fn update_set_casts_stored_value() {
         // ADR-0003's second stored-value context: an UPDATE SET on an encrypted

--- a/packages/eql-mapper/src/model/schema.rs
+++ b/packages/eql-mapper/src/model/schema.rs
@@ -50,6 +50,21 @@ pub enum ColumnKind {
     /// domain name.
     #[display("Eql({})", _0)]
     Eql(EqlTraits, DomainIdentity),
+    /// A column whose declared type says "this holds encrypted data", but which
+    /// this build of Proxy cannot map. Today that is only the legacy EQL v2
+    /// `eql_v2_encrypted` type, which carries no v3 domain identity.
+    ///
+    /// It is deliberately **not** [`ColumnKind::Native`]. A native column is a
+    /// plaintext passthrough — no encryption on write, no decryption on read —
+    /// so classifying an unmigrated v2 column that way makes Proxy quietly write
+    /// new plaintext into a column its operator believes is encrypted
+    /// (CIP-3688). Instead the type checker refuses any statement that brings
+    /// the owning table into scope, so the failure is loud and names the column.
+    ///
+    /// The payload is the declared type name, purely so the refusal can quote it
+    /// back to the operator.
+    #[display("Unmappable({})", _0)]
+    UnmappableEncrypted(String),
 }
 
 impl Column {
@@ -64,6 +79,15 @@ impl Column {
         Self {
             name,
             kind: ColumnKind::Native,
+        }
+    }
+
+    /// A column declared with an encrypted-column type this build cannot map.
+    /// See [`ColumnKind::UnmappableEncrypted`].
+    pub fn unmappable_encrypted(name: Ident, column_type: impl Into<String>) -> Self {
+        Self {
+            name,
+            kind: ColumnKind::UnmappableEncrypted(column_type.into()),
         }
     }
 }
@@ -307,6 +331,14 @@ macro_rules! schema {
                 $crate::unifier::DomainIdentity::canonical($crate::unifier::TokenType::Text, __traits),
             )));
         }
+    };
+    // A column whose encrypted type this build cannot map, e.g. one left behind
+    // by a partial EQL v2 -> v3 migration: `col (UNMAPPABLE("eql_v2_encrypted"))`.
+    (@add_column $table:ident $column_name:ident (UNMAPPABLE($column_type:literal)) ) => {
+        $table.add_column(std::sync::Arc::new($crate::model::Column::unmappable_encrypted(
+            ::sqltk::parser::ast::Ident::new(stringify!($column_name)),
+            $column_type,
+        )));
     };
     (@add_column $table:ident $column_name:ident (PK) ) => {
         $table.add_column(

--- a/tests/sql/schema-uninstall.sql
+++ b/tests/sql/schema-uninstall.sql
@@ -10,3 +10,10 @@ DROP TABLE IF EXISTS unconfigured;
 DROP TABLE IF EXISTS encrypted_elixir;
 
 DROP TABLE IF EXISTS unconfigured_elixir;
+
+-- The legacy EQL v2 fixture. The type is dropped after the table that uses it,
+-- and is dropped at all because EQL v3 does not own it — the test schema
+-- declares it, so the test schema has to take it away again.
+DROP TABLE IF EXISTS encrypted_v2_legacy;
+
+DROP TYPE IF EXISTS eql_v2_encrypted;

--- a/tests/sql/schema.sql
+++ b/tests/sql/schema.sql
@@ -62,6 +62,34 @@ CREATE TABLE unconfigured (
 );
 
 
+-- A table left behind by a partly-completed EQL v2 -> v3 migration: the text
+-- column moved to a v3 domain, one column did not.
+--
+-- EQL v3 never creates `eql_v2_encrypted`, so it is declared here to reproduce
+-- the catalog shape the schema loader actually sees on a database migrated from
+-- EQL v2. EQL v2 shipped it as a *composite* type, which
+-- `information_schema.columns` reports as `udt_name = 'eql_v2_encrypted'` with a
+-- NULL `domain_name` — the mirror image of a v3 encrypted column, where
+-- `udt_name` is the `jsonb` base type and the domain name is in `domain_name`.
+-- Getting this the wrong way round would exercise a condition adjacent to the
+-- real one rather than the real one.
+--
+-- Proxy refuses every statement referencing this table rather than serve the v2
+-- column as a plaintext passthrough (CIP-3688), so nothing else in the suite may
+-- read or write it.
+DROP TABLE IF EXISTS encrypted_v2_legacy;
+DROP TYPE IF EXISTS eql_v2_encrypted;
+CREATE TYPE eql_v2_encrypted AS (data jsonb);
+
+CREATE TABLE encrypted_v2_legacy (
+    id bigint,
+    plaintext text,
+    encrypted_text eql_v3_text_search,
+    encrypted_v2 eql_v2_encrypted,
+    PRIMARY KEY(id)
+);
+
+
 -- Per-test encrypted index fixture tables.
 --
 -- Each integration test that exercises ORE/OPE range or order operators gets


### PR DESCRIPTION
On this EQL v3-only build, a column still declared as the legacy `eql_v2_encrypted` composite type has no v3 domain identity, so `SchemaManager` fell back to `Column::native(ident)` — a **plaintext passthrough**. Proxy performed no encryption on writes and no decryption on reads.

> Stacked on #434, which this PR targets. Review that one first — it is three lines of substance.

The only guard was a `warn!` emitted once at schema load. The code's own comment admitted the problem: *"This is a data-at-rest exposure on the write path, so the warning must be impossible to miss in ops."*

This is the shape of a partially-completed migration: move 19 of 20 columns to v3 domains, restart Proxy, and the twentieth starts accumulating plaintext in PostgreSQL with no error visible to the application.

## The fix, and why this option

**Statement-level rejection**, scoped to the **table** rather than the column.

The alternatives were weighed and rejected. Refusing at startup takes a whole deployment offline for one unmigrated column, including tables nobody queries. An opt-in flag re-creates the identical silent plaintext write for anyone who sets it, and the whole value of failing closed is that it cannot be switched off by accident.

Table scope rather than column scope is deliberate: proving a statement can never route a value into the column — across `*`, defaults, `RETURNING`, triggers, rules — is a negative that fails *open* when wrong, and failing open is the bug being fixed.

## Independent of CIP-3680 — verified, not assumed

`Error::must_fail_closed()` exempts this one error from the mapping-error passthrough fallback, so the guard holds with `CS_DEVELOPMENT__ENABLE_MAPPING_ERRORS` **unset** — the default, and what the proxy container runs with. All the integration tests run against a default-configured Proxy; if the exemption regressed they would fail. **No dependency on #436 landing first**, though the two are related and #436 removes that flag entirely.

## The fixture

PostgreSQL was probed rather than guessed: a composite type reports `udt_name='eql_v2_encrypted'` with `domain_name=NULL`; a domain reports the reverse. EQL v2 shipped it as a composite, which is what the loader keys on. The fixture table carries a v3 domain column *and* the v2 column, reproducing the partial-migration shape rather than something adjacent to it.

## The tests catch the bug

Reverting `classify_column` to `Column::native` and re-running: 7 of 8 tests fail (only the control passes), and `{"secret": "value"}` lands in the encrypted column in cleartext. The exposure is reproduced and then closed. The decisive assertion connects **directly** to PostgreSQL, bypassing Proxy, and asserts no plaintext row landed — a test that only checks the client saw an error would still pass if the write succeeded and the error came afterwards.

## Testing

| | before | after |
|---|---|---|
| integration (serial) | 348 pass / 1 fail | 356 pass / 1 fail |
| eql-mapper | 134 pass | 138 pass |
| cipherstash-proxy lib | 119–120 pass / 1–2 fail | 124 pass / 1 fail |

The one integration failure is `migrate::tests::migrate_text`, which fails identically before and after: it runs the migrate CLI in-process, and that CLI reads `CS_SERVER__PORT` to find Proxy, so it needs that variable set when the suite runs on non-default ports. Not a defect in this change. `config::tandem::tests::prometheus_config` is a pre-existing environment-dependent flake that also fails on the base.

`cargo fmt` and `clippy --all --all-targets -D warnings` clean. `CHANGELOG.md` has a `### Security` entry and `docs/errors.md` documents the new error, which names the offending column so an operator knows what to migrate.

## Worth a reviewer's opinion

The startup warning is kept, but it sits under `target: SCHEMA` and so is invisible unless `CS_LOG__SCHEMA_LEVEL=debug`. That is unchanged from before, and it is precisely why the ticket says the only signal "has long since scrolled away" — pre-fix deployments had effectively *no* warning, not a quiet one. The statement-level refusal is what actually fixes visibility, so the log target was left alone as a broader logging-config decision.

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.