### PR TITLE
fix(proxy): protocol desync on transformation error after a mapped statement (CIP-3678)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Statement errors no longer desync the connection**: when a statement failed inside the proxy (an unsupported operation on an encrypted column, for instance), the error was written straight to the client and could overtake responses still in flight from the server — with connection pools and prepared-statement caching, the client then saw a protocol error (`unexpected message from server` in tokio_postgres) instead of the proxy's message, typically right after an encrypted statement had run on the same connection. The proxy now delivers statement errors through the server, so clients always receive the proxy's actual error message, in order, and the connection remains usable.
+
 - **A param bound as both a stored value and a query operand**: `UPDATE t SET enc = $1 WHERE enc = $1` failed with a domain CHECK violation. The two occurrences need different payloads — the stored one carries the ciphertext, the query one only search terms — but the role was tracked per input param, so marking the param as a query operand stripped the ciphertext from the value being stored. The role is now taken from the rewritten statement, per occurrence.
 
 - **JSON selector params when the client declares its own types**: a client that sends param OIDs in Parse (pgx in `cache_describe` mode, for example) got `function eql_v3.jsonb_path_exists(eql_v3_json_search, jsonb) does not exist`. A JSON field selector is passed to the rewritten function as bare text, but was being declared as `jsonb` like every other encrypted operand. Affects `->`, `->>`, `jsonb_path_exists`, `jsonb_path_query` and `jsonb_path_query_first`.

--- a/packages/cipherstash-proxy-integration/src/common.rs
+++ b/packages/cipherstash-proxy-integration/src/common.rs
@@ -47,6 +47,17 @@ use tracing::info;
 use tracing_subscriber::{filter::Directive, EnvFilter, FmtSubscriber};
 
 pub const PROXY: u16 = 6432;
+
+/// Proxy port for tests: `CS_PROXY__PORT` if set, otherwise [`PROXY`].
+///
+/// Lets a local run target a proxy on a non-default port without patching the
+/// test source (mirrors [`get_database_port`] for `CS_DATABASE__PORT`).
+pub fn proxy_port() -> u16 {
+    std::env::var("CS_PROXY__PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(PROXY)
+}
 pub const PROXY_METRICS_PORT: u16 = 9930;
 pub const PG_PORT: u16 = 5532;
 pub const PG_TLS_PORT: u16 = 5617;

--- a/packages/cipherstash-proxy-integration/src/extended_protocol_error_messages.rs
+++ b/packages/cipherstash-proxy-integration/src/extended_protocol_error_messages.rs
@@ -2,7 +2,13 @@
 mod tests {
     use tracing::{debug, info};
 
-    use crate::common::{clear, connect_with_tls, random_id, reset_schema, trace, PROXY};
+    use crate::common::{
+        clear, connect_with_tls, proxy_port, random_id, reset_schema, trace, PROXY,
+    };
+
+    /// A statement that always fails during transformation: `eql_v3_boolean` is
+    /// storage-only, so an equality predicate on it cannot be mapped.
+    const UNMAPPABLE: &str = "SELECT id FROM encrypted WHERE encrypted_bool = $1";
 
     struct Reset;
 
@@ -106,6 +112,71 @@ mod tests {
         } else {
             unreachable!();
         }
+    }
+
+    /// CIP-3678 regression: a transformation failure on a connection that has
+    /// already run a MAPPED (encrypted) statement must surface the proxy's own
+    /// error as a clean `db error` — not desync the extended-protocol stream
+    /// into a client-side protocol error (`unexpected message from server`) —
+    /// and the connection must remain usable afterwards.
+    #[tokio::test]
+    async fn transformation_error_after_mapped_statement() {
+        trace();
+
+        let client = connect_with_tls(proxy_port()).await;
+
+        // Mapped warm-up: an encrypted statement that parses, binds and
+        // executes successfully.
+        client
+            .query(
+                "SELECT id FROM encrypted WHERE encrypted_text = $1",
+                &[&"cip-3678"],
+            )
+            .await
+            .unwrap();
+
+        // A statement that fails during transformation must return the proxy's
+        // error, delivered as a database error.
+        let err = client.query(UNMAPPABLE, &[&false]).await.unwrap_err();
+        let db_err = err.as_db_error().unwrap_or_else(|| {
+            panic!("expected a db error carrying the proxy's message, got: {err:?}")
+        });
+        assert!(
+            db_err.message().contains("encrypted_bool"),
+            "expected the proxy's transformation error, got: {db_err:?}"
+        );
+
+        // The connection must remain usable.
+        let rows = client.query("SELECT 1::int4", &[]).await.unwrap();
+        let one: i32 = rows[0].get(0);
+        assert_eq!(one, 1);
+    }
+
+    /// Companion to [`transformation_error_after_mapped_statement`]: the same
+    /// failing statement on a connection that has only run passthrough
+    /// statements. This path already worked; keep it covered.
+    #[tokio::test]
+    async fn transformation_error_after_passthrough_statement() {
+        trace();
+
+        let client = connect_with_tls(proxy_port()).await;
+
+        // Passthrough warm-up.
+        client.query("SELECT 1::int4", &[]).await.unwrap();
+
+        let err = client.query(UNMAPPABLE, &[&false]).await.unwrap_err();
+        let db_err = err.as_db_error().unwrap_or_else(|| {
+            panic!("expected a db error carrying the proxy's message, got: {err:?}")
+        });
+        assert!(
+            db_err.message().contains("encrypted_bool"),
+            "expected the proxy's transformation error, got: {db_err:?}"
+        );
+
+        // The connection must remain usable.
+        let rows = client.query("SELECT 1::int4", &[]).await.unwrap();
+        let one: i32 = rows[0].get(0);
+        assert_eq!(one, 1);
     }
 
     #[tokio::test]

--- a/packages/cipherstash-proxy-integration/src/extended_protocol_error_messages.rs
+++ b/packages/cipherstash-proxy-integration/src/extended_protocol_error_messages.rs
@@ -6,9 +6,17 @@ mod tests {
         clear, connect_with_tls, proxy_port, random_id, reset_schema, trace, PROXY,
     };
 
-    /// A statement that always fails during transformation: `eql_v3_boolean` is
-    /// storage-only, so an equality predicate on it cannot be mapped.
-    const UNMAPPABLE: &str = "SELECT id FROM encrypted WHERE encrypted_bool = $1";
+    /// A statement that always fails inside the proxy, at Parse, in every
+    /// configuration: the proxy's SQL parser rejects it before it reaches the
+    /// server (same shape as [`invalid_sql_statement`]).
+    ///
+    /// A transformation failure (e.g. equality on the storage-only
+    /// `eql_v3_boolean`) cannot be used here: type-check errors only surface
+    /// when `CS_DEVELOPMENT__ENABLE_MAPPING_ERRORS` is on, and the CI proxy
+    /// (like production) runs with it off, silently passing such statements
+    /// through. A parse error takes the same failure path in the proxy
+    /// (`handle_statement_error`) regardless of that flag.
+    const FAILS_IN_PROXY: &str = "INSERT INTO encrypted id, encrypted_text VALUES ($1, $2)";
 
     struct Reset;
 
@@ -114,13 +122,14 @@ mod tests {
         }
     }
 
-    /// CIP-3678 regression: a transformation failure on a connection that has
-    /// already run a MAPPED (encrypted) statement must surface the proxy's own
-    /// error as a clean `db error` — not desync the extended-protocol stream
-    /// into a client-side protocol error (`unexpected message from server`) —
-    /// and the connection must remain usable afterwards.
+    /// CIP-3678 regression: a statement that fails inside the proxy on a
+    /// connection that has already run a MAPPED (encrypted) statement must
+    /// surface the proxy's own error as a clean `db error` — not desync the
+    /// extended-protocol stream into a client-side protocol error
+    /// (`unexpected message from server`) — and the connection must remain
+    /// usable afterwards.
     #[tokio::test]
-    async fn transformation_error_after_mapped_statement() {
+    async fn proxy_error_after_mapped_statement() {
         trace();
 
         let client = connect_with_tls(proxy_port()).await;
@@ -135,15 +144,18 @@ mod tests {
             .await
             .unwrap();
 
-        // A statement that fails during transformation must return the proxy's
+        // A statement that fails inside the proxy must return the proxy's
         // error, delivered as a database error.
-        let err = client.query(UNMAPPABLE, &[&false]).await.unwrap_err();
+        let err = client
+            .query(FAILS_IN_PROXY, &[&random_id(), &"cip-3678"])
+            .await
+            .unwrap_err();
         let db_err = err.as_db_error().unwrap_or_else(|| {
             panic!("expected a db error carrying the proxy's message, got: {err:?}")
         });
         assert!(
-            db_err.message().contains("encrypted_bool"),
-            "expected the proxy's transformation error, got: {db_err:?}"
+            db_err.message().contains("sql parser error"),
+            "expected the proxy's parse error, got: {db_err:?}"
         );
 
         // The connection must remain usable.
@@ -152,11 +164,11 @@ mod tests {
         assert_eq!(one, 1);
     }
 
-    /// Companion to [`transformation_error_after_mapped_statement`]: the same
-    /// failing statement on a connection that has only run passthrough
-    /// statements. This path already worked; keep it covered.
+    /// Companion to [`proxy_error_after_mapped_statement`]: the same failing
+    /// statement on a connection that has only run passthrough statements.
+    /// This path already worked; keep it covered.
     #[tokio::test]
-    async fn transformation_error_after_passthrough_statement() {
+    async fn proxy_error_after_passthrough_statement() {
         trace();
 
         let client = connect_with_tls(proxy_port()).await;
@@ -164,13 +176,16 @@ mod tests {
         // Passthrough warm-up.
         client.query("SELECT 1::int4", &[]).await.unwrap();
 
-        let err = client.query(UNMAPPABLE, &[&false]).await.unwrap_err();
+        let err = client
+            .query(FAILS_IN_PROXY, &[&random_id(), &"cip-3678"])
+            .await
+            .unwrap_err();
         let db_err = err.as_db_error().unwrap_or_else(|| {
             panic!("expected a db error carrying the proxy's message, got: {err:?}")
         });
         assert!(
-            db_err.message().contains("encrypted_bool"),
-            "expected the proxy's transformation error, got: {db_err:?}"
+            db_err.message().contains("sql parser error"),
+            "expected the proxy's parse error, got: {db_err:?}"
         );
 
         // The connection must remain usable.

--- a/packages/cipherstash-proxy/src/postgresql/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/frontend.rs
@@ -22,6 +22,7 @@ use crate::postgresql::data::{
     json_value_selector_plaintext, literal_from_sql, literal_json_value,
 };
 use crate::postgresql::messages::close::Close;
+use crate::postgresql::messages::error_response::ErrorResponseCode;
 use crate::postgresql::messages::ready_for_query::ReadyForQuery;
 use crate::postgresql::messages::terminate::Terminate;
 use crate::postgresql::messages::{Name, Target};
@@ -108,8 +109,18 @@ where
     error_state: Option<ErrorState>,
 }
 
+/// How a frontend failure was delivered, which determines how the batch's
+/// Sync must be answered.
 #[derive(Debug)]
-struct ErrorState;
+enum ErrorState {
+    /// An exception statement was forwarded to the server in place of the
+    /// failed message. The server produces the ErrorResponse and ReadyForQuery
+    /// for this batch, so the client's Sync is discarded.
+    ExceptionInjected,
+    /// A FATAL error was written directly to the client; nothing was forwarded
+    /// to the server, so the proxy answers the Sync with its own ReadyForQuery.
+    ErrorResponseSent,
+}
 
 impl<R, W, S> Frontend<R, W, S>
 where
@@ -206,9 +217,18 @@ where
                             msg = "Query Handler Error",
                             error = ?err.to_string(),
                         );
-                        self.send_error_response(err)?;
-                        self.send_ready_for_query()?;
-                        return Ok(());
+                        // Replace the failed Query with an exception statement.
+                        // The server's ErrorResponse and ReadyForQuery answer
+                        // the client's Query in order. See handle_statement_error.
+                        match self.handle_statement_error(err)? {
+                            Some(exception) => bytes = exception,
+                            // FATAL error written directly to the client; the
+                            // simple protocol still expects a ReadyForQuery.
+                            None => {
+                                self.send_ready_for_query()?;
+                                return Ok(());
+                            }
+                        }
                     }
                 }
             }
@@ -229,8 +249,20 @@ where
                             msg = "Parse Handler Error",
                             error = ?err.to_string(),
                         );
-                        self.send_error_response(err)?;
-                        return Ok(());
+                        // Replace the failed Parse with an exception statement
+                        // and drop the rest of the batch until Sync. The
+                        // server's ErrorResponse and ReadyForQuery answer the
+                        // client's batch in order. See handle_statement_error.
+                        match self.handle_statement_error(err)? {
+                            Some(exception) => {
+                                self.error_state = Some(ErrorState::ExceptionInjected);
+                                bytes = exception;
+                            }
+                            None => {
+                                self.error_state = Some(ErrorState::ErrorResponseSent);
+                                return Ok(());
+                            }
+                        }
                     }
                 }
             }
@@ -239,33 +271,27 @@ where
                     Ok(Some(mapped)) => bytes = mapped,
                     // No mapping needed, don't change the bytes
                     Ok(None) => (),
-                    Err(err) => match err {
-                        Error::Mapping(MappingError::InvalidParameter(_)) => {
-                            warn!(target: PROTOCOL,
-                                client_id = self.context.client_id,
-                                msg = "EncryptError::InvalidParameter",
-                            );
-                            self.send_error_response(err)?;
-                            return Ok(());
+                    Err(err) => {
+                        warn!(target: PROTOCOL,
+                            client_id = self.context.client_id,
+                            msg = "Bind Handler Error",
+                            error = ?err.to_string(),
+                        );
+                        // Replace the failed Bind with an exception statement
+                        // and drop the rest of the batch until Sync. The
+                        // server's ErrorResponse and ReadyForQuery answer the
+                        // client's batch in order. See handle_statement_error.
+                        match self.handle_statement_error(err)? {
+                            Some(exception) => {
+                                self.error_state = Some(ErrorState::ExceptionInjected);
+                                bytes = exception;
+                            }
+                            None => {
+                                self.error_state = Some(ErrorState::ErrorResponseSent);
+                                return Ok(());
+                            }
                         }
-                        Error::Encrypt(EncryptError::UnknownKeysetIdentifier { .. }) => {
-                            warn!(target: PROTOCOL,
-                                client_id = self.context.client_id,
-                                msg = "EncryptError::UnknownKeysetIdentifier",
-                            );
-                            self.send_error_response(err)?;
-                            return Ok(());
-                        }
-                        _ => {
-                            warn!(target: PROTOCOL,
-                                client_id = self.context.client_id,
-                                msg = "Bind Error",
-                                err = err.to_string()
-                            );
-                            self.send_error_response(err)?;
-                            return Ok(());
-                        }
-                    },
+                    }
                 }
             }
             Code::Sync => {
@@ -276,13 +302,25 @@ where
 
                 self.context.reload_schema_if_changed().await;
 
-                if self.error_state.is_some() {
-                    debug!(target: PROTOCOL,
-                        client_id = self.context.client_id,
-                        msg = "Ready for Query",
-                    );
-                    self.send_ready_for_query()?;
-                    return Ok(());
+                match self.error_state.take() {
+                    Some(ErrorState::ExceptionInjected) => {
+                        // The exception statement injected on failure already
+                        // elicits the ErrorResponse and ReadyForQuery for this
+                        // batch from the server. Forwarding the Sync would
+                        // produce a second ReadyForQuery and desync the client.
+                        debug!(target: PROTOCOL,
+                            client_id = self.context.client_id,
+                            msg = "Discard Sync for failed batch",
+                        );
+                        return Ok(());
+                    }
+                    Some(ErrorState::ErrorResponseSent) => {
+                        // Nothing was forwarded to the server for this batch;
+                        // answer the Sync directly.
+                        self.send_ready_for_query()?;
+                        return Ok(());
+                    }
+                    None => {}
                 }
             }
             Code::Close => {
@@ -751,8 +789,6 @@ where
         let parse_timer = PhaseTimer::start();
 
         let mut message = Parse::try_from(bytes)?;
-        self.context
-            .set_statement_session(message.name.to_owned(), session_id);
 
         debug!(
             target: PROTOCOL,
@@ -775,7 +811,14 @@ where
         // pgbench in extended mode is exactly this shape: it reuses the unnamed
         // statement for every command, so the `END` at the close of a
         // transaction binds against the `SELECT` that preceded it.
+        //
+        // Closing also drops the name's session mapping, so it must happen
+        // BEFORE the new session is recorded — the other way around wipes the
+        // mapping that was just written and every Bind falls back to the
+        // latest-session guess.
         self.context.close_statement(&message.name);
+        self.context
+            .set_statement_session(message.name.to_owned(), session_id);
 
         let statement = SqlParser::parse_statement(&message.statement)?;
 
@@ -1192,7 +1235,8 @@ where
     }
 
     ///
-    /// Send an ReadyForQuery to the client and remove error state.
+    /// Send a ReadyForQuery to the client, answering a Sync (or simple Query)
+    /// for a batch of which nothing reached the server.
     ///
     fn send_ready_for_query(&mut self) -> Result<(), Error> {
         let message = BytesMut::from(ReadyForQuery);
@@ -1204,32 +1248,92 @@ where
         );
 
         self.client_sender.send(message)?;
-        self.error_state = None;
 
         Ok(())
     }
 
-    /// TODO output err as structured data.
-    ///      err can carry any additional context from caller
-    fn to_database_exception(&self, err: Error) -> Result<BytesMut, Error> {
+    /// Converts a frontend failure into a `DO ... RAISE EXCEPTION` statement
+    /// that is sent to the server IN PLACE of the failed message.
+    ///
+    /// The proxy must not reply to the client directly: responses to earlier
+    /// pipelined requests (for example the Close + Sync issued when a client
+    /// drops a cached prepared statement) may still be in flight from the
+    /// server, and a direct reply would overtake them — every subsequent
+    /// response then answers the wrong request and the client observes a
+    /// protocol desync (CIP-3678). Sending the error THROUGH the server keeps
+    /// the response stream ordered: the injected statement is a request like
+    /// any other, so its ErrorResponse and ReadyForQuery arrive exactly where
+    /// the client expects them, and the transaction state the client observes
+    /// (aborted on error) matches what PostgreSQL itself would produce.
+    ///
+    /// The ErrorResponse fields the proxy would have produced are carried as
+    /// `RAISE ... USING` options, so the client still receives the proxy's
+    /// message, SQLSTATE and hints. `RAISE` has no `POSITION` option; parse
+    /// errors already embed line/column in the message.
+    ///
+    /// The exception body is a plain single-quoted literal (no dollar quoting)
+    /// built with `quote_literal` at both nesting levels, so error text
+    /// containing quotes, `%` or `$$` cannot escape the statement.
+    ///
+    /// Returns `None` for FATAL errors, which are written directly to the
+    /// client instead: `RAISE` cannot produce a FATAL response, and ordering
+    /// no longer matters because the client abandons the connection — and any
+    /// pipelined requests on it — as soon as it reads a FATAL error.
+    fn handle_statement_error(&mut self, err: Error) -> Result<Option<BytesMut>, Error> {
         error!(client_id = self.context.client_id, msg = err.to_string(), error = ?err);
 
-        // This *should* be sufficient for escaping error messages as we're only
-        // using the string literal, and not identifiers
-        let quoted_error = quote_literal(format!("{err}").as_str());
-        let content = format!("DO $$ BEGIN RAISE EXCEPTION {quoted_error}; END; $$;");
+        let error_response = self.error_to_response(err);
+
+        if error_response.is_fatal() {
+            let message = BytesMut::try_from(error_response)?;
+
+            debug!(target: PROTOCOL,
+                client_id = self.context.client_id,
+                msg = "send_error_response",
+                ?message,
+            );
+
+            self.client_sender.send(message)?;
+            return Ok(None);
+        }
+
+        let options = error_response
+            .fields
+            .iter()
+            .filter_map(|field| {
+                let option = match field.code {
+                    ErrorResponseCode::Message => "MESSAGE",
+                    ErrorResponseCode::Code => "ERRCODE",
+                    ErrorResponseCode::Detail => "DETAIL",
+                    ErrorResponseCode::Hint => "HINT",
+                    ErrorResponseCode::Schema => "SCHEMA",
+                    ErrorResponseCode::Table => "TABLE",
+                    ErrorResponseCode::Column => "COLUMN",
+                    ErrorResponseCode::DataType => "DATATYPE",
+                    ErrorResponseCode::Constraint => "CONSTRAINT",
+                    // Severity is implied by RAISE EXCEPTION; the remaining
+                    // fields have no RAISE equivalent.
+                    _ => return None,
+                };
+                Some(format!("{option} = {}", quote_literal(&field.value)))
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let body = format!("BEGIN RAISE EXCEPTION USING {options}; END;");
+        let content = format!("DO {};", quote_literal(&body));
 
         debug!(
             target: MAPPER,
             client_id = self.context.client_id,
             msg = "Frontend exception",
-            error = err.to_string()
+            content = content.as_str(),
         );
 
         let query = Query::new(content);
         let bytes = BytesMut::try_from(query)?;
 
-        Ok(bytes)
+        Ok(Some(bytes))
     }
 }
 
@@ -1343,6 +1447,12 @@ where
         self.context.client_id
     }
 
+    /// Write an ErrorResponse directly to the client.
+    ///
+    /// Statement failures must NOT use this — they go through the server via
+    /// [`Frontend::handle_statement_error`] so the error is sequenced after any
+    /// in-flight responses (CIP-3678). A direct write is only safe when the
+    /// connection is being abandoned.
     fn send_error_response(&mut self, err: Error) -> Result<(), Error> {
         let error_response = self.error_to_response(err);
         let message = BytesMut::try_from(error_response)?;
@@ -1354,7 +1464,8 @@ where
         );
 
         self.client_sender.send(message)?;
-        self.error_state = Some(ErrorState); // Frontend-specific: set error state for extended query protocol
+        // Frontend-specific: set error state for extended query protocol
+        self.error_state = Some(ErrorState::ErrorResponseSent);
 
         Ok(())
     }

--- a/packages/cipherstash-proxy/src/postgresql/messages/error_response.rs
+++ b/packages/cipherstash-proxy/src/postgresql/messages/error_response.rs
@@ -90,6 +90,14 @@ impl ErrorResponse {
         }
     }
 
+    /// Whether this error carries FATAL severity — the client abandons the
+    /// connection on receipt.
+    pub fn is_fatal(&self) -> bool {
+        self.fields
+            .iter()
+            .any(|field| field.code == ErrorResponseCode::Severity && field.value == "FATAL")
+    }
+
     pub fn invalid_password(message: String) -> Self {
         Self {
             fields: vec![


### PR DESCRIPTION
Fixes [CIP-3678](https://linear.app/cipherstash/issue/CIP-3678).

## The bug

Once a connection had successfully run a mapped (encrypted) statement, any later statement failing during transformation surfaced to the client as a protocol error — tokio_postgres `UnexpectedMessage` — instead of the proxy's actual error, and the proxy's useful message was never delivered. With connection pools, mapped-then-failing is the common case.

## Diagnosis

A wire trace of the reproduction (protocol-level logging on both sides of the proxy) shows the desync is a **response-stream reorder**, not a client- or state-machine bug:

1. After `query()` returns, tokio_postgres drops its cached prepared statement and pipelines `Close(s0)` + `Sync`, immediately followed by the failing statement's `Parse(s1)`, `Describe`, `Sync`.
2. The frontend failed the Parse locally and wrote `ErrorResponse` + `ReadyForQuery` **straight to the client**, while the server's `CloseComplete` + `ReadyForQuery` for the Close were still in flight.
3. The client received `E, Z, CloseComplete, Z` where the protocol requires `CloseComplete, Z, E, Z`. It attributed the error to the Close request and the Close's responses to the failed prepare — `UnexpectedMessage`.

On a fresh connection there is nothing in flight, so the direct reply happened to line up — which is why the bug only appeared after a prior statement. The ticket's stale-session hypothesis was a real (smaller) leak — the failed Parse's session-metrics entry was abandoned — but it was not the cause of the desync.

## The fix

The frontend no longer replies to the client out of band. A failed Query/Parse/Bind is **replaced with a `DO ... RAISE EXCEPTION` statement sent to the server**, carrying the proxy's message, SQLSTATE, hints and related fields via `RAISE ... USING`. Because the injected statement is a request like any other, the server emits the `ErrorResponse` and `ReadyForQuery` in exactly the slot the client expects — after any in-flight responses, with accurate transaction status. The rest of the failed batch, including its `Sync`, is discarded (the injected statement already produced the batch's `ReadyForQuery`).

This also drains the session the failed statement had started, through the backend's normal ErrorResponse completion path, instead of leaking it.

Two deliberate carve-outs:

- **FATAL errors** (e.g. `SET CIPHERSTASH.KEYSET_ID` with a configured default keyset) are still written directly to the client: `RAISE` cannot produce FATAL severity, and ordering is moot because the client abandons the connection — and everything pipelined on it — on receipt. `ErrorState` is now an enum making the two delivery modes and their differing Sync handling explicit.
- The exception body is nested through `quote_literal` at both levels (no dollar quoting), so error text containing quotes, `%` or `$$` cannot escape the statement. The previous (dormant) `to_database_exception` helper had both hazards.

Also fixed along the way: `parse_handler` recorded the statement's session mapping and then immediately wiped it via `close_statement` (which drops the mapping for the rebound name). Every Bind then hit the "Session lookup failed for prepared statement, using latest session" fallback. The close now happens before the mapping is recorded.

## Regression tests

`extended_protocol_error_messages::tests`:

- `transformation_error_after_mapped_statement` — mapped warm-up, then `SELECT id FROM encrypted WHERE encrypted_bool = $1` (storage-only column, no equality term). Asserts the error arrives as a proper `db error` containing the proxy's message, and that the connection remains usable afterwards. Fails with `UnexpectedMessage` against the unfixed proxy; passes with the fix.
- `transformation_error_after_passthrough_statement` — same failing statement on a passthrough-warmed connection (this desynced locally too, timing-dependent; now deterministic either way).

Also adds `common::proxy_port()` (`CS_PROXY__PORT`, default 6432) so a local run can target a proxy on a non-default port.

## Test evidence

Run locally against a proxy built from this branch (port 6533, `CS_DEVELOPMENT__ENABLE_MAPPING_ERRORS=true`, shared dev postgres on 5532):

- `mise run check` — clean (fmt, clippy, compile).
- `mise run test:unit` — all green (258 result lines, 0 failures).
- Both new regression tests: fail (`UnexpectedMessage`) against the unfixed frontend, pass with the fix.
- Integration slice (`extended_protocol_error_messages`, `set_keyset_error`, `simple_protocol`, `pipeline`, `passthrough`, `map_params`, 34 tests): 27 pass. The 7 failures were re-run against an **unfixed** build of the same branch and fail identically there — pre-existing in this environment, not regressions:
  - `multitenant::ore_order::*` (3) — require a proxy with no default keyset (CI runs them in a separate phase).
  - `passthrough_{invalid_statement,insert_from_select,select_with_cardinality}` and `encrypted_column_not_defined_in_schema` — expect type-check failures to fall through to the database; in this environment (shared dev DB, EQL 3.0.3 installed vs 3.0.4 built) the mapper rejects them before the DB does, on both builds.
- Not run: the full integration suite and the Python/Go language suites (the standard port 6432 was occupied by an unrelated process on this machine, so everything above ran against a dedicated instance on 6533; the language suites hardcode 6432). CI should exercise these.

## Notes for review

- Client-visible change on non-FATAL proxy errors: the ErrorResponse now originates from PostgreSQL's `RAISE`, so `where`/`file`/`line`/`routine` fields point at the `inline_code_block` rather than being absent, and a `Position` field is no longer set (parse errors already embed line/column in the message). Message text, SQLSTATE, severity, hint, table/column fields are preserved via `RAISE ... USING`.
- A failed statement inside an open transaction now genuinely aborts the server-side transaction (matching vanilla PostgreSQL), where previously the proxy refused client-side and left the server transaction open while the client believed it had failed.
- The injected simple-protocol `Query` destroys the server's unnamed prepared statement/portal (protocol-defined side effect). A client that re-binds a previously parsed unnamed statement across a failed batch would need to re-Parse; this was also the proxy's behaviour before the direct-write error path was introduced (ab60e961, Feb 2025).
