### PR TITLE
chore: prepare release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-08-05
+
 ### Changed
 
 - **EQL v3 (searchable encryption)**: Proxy now targets EQL v3. Encrypted columns are declared with self-configuring, typed `jsonb` domains (for example `eql_v3_text_search`, `eql_v3_integer_ord`, `eql_v3_json_search`) that encode both the scalar type and the column's searchable capabilities in the column type itself, replacing EQL v2's opaque `eql_v2_encrypted` composite type and its separate `eql_v2_configuration` table. The bundled `cipherstash-client` is upgraded to 0.42.0 and EQL to 3.0.4. Existing v2-encrypted data and schemas must be migrated to v3.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-proxy"
-version = "2.2.4"
+version = "3.0.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "eql-mapper-macros"
-version = "2.2.4"
+version = "3.0.0"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -4178,7 +4178,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "showcase"
-version = "2.2.4"
+version = "3.0.0"
 dependencies = [
  "rand 0.9.2",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["packages/*"]
 
 [workspace.package]
-version = "2.2.4"
+version = "3.0.0"
 edition = "2021"
 
 [profile.dev]


### PR DESCRIPTION
## Summary

- bump the workspace version from 2.2.4 to 3.0.0
- refresh Cargo.lock for the workspace package versions
- promote the accumulated EQL v3 release notes from Unreleased to 3.0.0 (2026-08-05)

This is the prepare-release PR required by DEVELOPMENT.md. After it merges, release v3.0.0 can be cut from an up-to-date main with mise run release v3.0.0.

## Verification

- mise run check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 3.0.0, dated August 5, 2026.

* **Chores**
  * Updated the application version to 3.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->