### PR TITLE
chore: prepare release v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.0.1] - 2026-08-05
+
 ### Added
 
 - **Multi-step JSON paths on encrypted columns, everywhere**: `col -> 'a' -> 'b'` now works wherever a single field access does — in the select list, in an ordering comparison (`<`, `<=`, `>`, `>=`), and in the `->`, `->>` and `jsonb_path_query_first` spellings mixed freely, to any depth, with each step written as a literal or a placeholder. Previously only exact equality accepted a multi-step path and everything else was rejected. A chain is a single path into a single document, so it is now rewritten to one field access keyed on the whole composed path (`$.a.b`) instead of the nested accessors that would search an already-extracted entry and return NULL. Exact equality continues to fold the path and the value into one needle, which remains the stronger match.
@@ -353,7 +355,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Integration with CipherStash ZeroKMS.
 - Encrypt Query Language (EQL) for indexing and searching encrypted data.
 
-[Unreleased]: https://github.com/cipherstash/proxy/compare/v2.2.4...HEAD
+[Unreleased]: https://github.com/cipherstash/proxy/compare/v3.0.1...HEAD
+[3.0.1]: https://github.com/cipherstash/proxy/compare/v3.0.0...v3.0.1
+[3.0.0]: https://github.com/cipherstash/proxy/compare/v2.2.4...v3.0.0
 [2.2.4]: https://github.com/cipherstash/proxy/compare/v2.2.3...v2.2.4
 [2.2.3]: https://github.com/cipherstash/proxy/compare/v2.2.2...v2.2.3
 [2.2.2]: https://github.com/cipherstash/proxy/compare/v2.2.1...v2.2.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-proxy"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "eql-mapper-macros"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -4178,7 +4178,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "showcase"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "rand 0.9.2",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["packages/*"]
 
 [workspace.package]
-version = "3.0.0"
+version = "3.0.1"
 edition = "2021"
 
 [profile.dev]


### PR DESCRIPTION
Prepares the 3.0.1 release, following the same shape as the 3.0.0 prep (#444).

## Version

- `[workspace.package] version` bumped `3.0.0` → `3.0.1` in the root `Cargo.toml`, with `cargo update --workspace` run so `Cargo.lock` matches (only the workspace crates' own versions change).

## Changelog

- The `[Unreleased]` content is now the `## [3.0.1] - 2026-08-05` section: 2 Added, 5 Fixed and 3 Security entries, covering PRs #435, #437, #439, #440, #441 and #442.
- Also repairs the link references at the bottom of the file, which the 3.0.0 release had left stale: `[Unreleased]` still compared from `v2.2.4` and `[3.0.0]` had no link at all. Both now resolve, and `[3.0.1]` is added.

## Verification

- `mise run check` — exit 0.