### PR TITLE
fix(deps): patch quinn-proto to 0.11.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3421,9 +3421,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Summary
- Bumps `quinn-proto` (transitive dependency via `quinn`) from 0.11.14 to 0.11.15
- Fixes advisory GHSA-4w2j-m93h-cj5j (High severity), flagged by Dependabot/Vanta
- A prior fix already bumped quinn-proto to >=0.11.14 for an earlier advisory; this bumps one patch version further
- `cargo update -p quinn-proto --precise 0.11.15` resolved cleanly within the existing `quinn = 0.11.8` constraint, so no `quinn` version bump or `Cargo.toml` change was needed

## Test plan
- [x] `cargo build --workspace` succeeds
- [x] `cargo test --lib -p cipherstash-proxy` (132 tests) passes single-threaded
- [ ] Full integration suite (`mise run test`, requires docker-compose Postgres) not run locally — no docker available in this environment; CI will cover it