### PR TITLE
test(proxy): harden transactional schema lifecycle coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Query cancellation through Proxy**: Cancellation requests now reach the matching PostgreSQL connection, and their routing entries are removed when the client connection exits. Previously cancellation requests arrived on a separate connection that could not find the original route; retaining those routes globally without cleanup could also leak memory and eventually reject a new connection if PostgreSQL reused a cancellation key.
+
 - **Configured default keyset selection**: when a connection has not selected a keyset explicitly, Proxy now scopes encryption and decryption to `CS_DEFAULT_KEYSET_ID`. Previously it passed no keyset to ZeroKMS and could silently use the account default instead, deriving different searchable-encryption terms when the two defaults differed. Before upgrading, verify that the configured and account defaults are intentional; values written by an affected version under the unintended account default must be decrypted with that old keyset and re-encrypted under the configured default.
 
 - **PostgreSQL protocol error handling after the pg-proto migration**: Proxy now rejects `require_tls` configurations that omit a certificate, preserves PostgreSQL transaction state when statement mapping fails, returns decryption failures as PostgreSQL errors without dropping the connection, and reloads changed schemas only after PostgreSQL confirms the transaction boundary. Prepared-statement replacement also preserves existing portals and overlapping statement metrics.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,6 +487,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,6 +863,7 @@ dependencies = [
  "pg-proto",
  "postgres-protocol",
  "postgres-types",
+ "proptest",
  "rand 0.9.2",
  "recipher 0.1.3",
  "regex",
@@ -1715,6 +1731,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1888,7 +1910,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc3655aa6818d65bc620d6911f05aa7b6aeb596291e1e9f79e52df85583d1e30"
 dependencies = [
- "rustix",
+ "rustix 0.38.44",
  "windows-targets 0.52.6",
 ]
 
@@ -2684,6 +2706,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "litemap"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3404,6 +3432,8 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
+ "bit-set",
+ "bit-vec",
  "bitflags",
  "lazy_static",
  "num-traits",
@@ -3411,6 +3441,8 @@ dependencies = [
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
+ "rusty-fork",
+ "tempfile",
  "unarray",
 ]
 
@@ -3457,6 +3489,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -3969,8 +4007,21 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4075,6 +4126,18 @@ name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -4725,6 +4788,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
 dependencies = [
  "parking_lot",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.2",
+ "once_cell",
+ "rustix 1.1.3",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5486,6 +5562,15 @@ dependencies = [
  "vitaminc-protected 0.2.0-pre.1",
  "vitaminc-random",
  "zeroize",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/packages/cipherstash-proxy-integration/src/schema_change.rs
+++ b/packages/cipherstash-proxy-integration/src/schema_change.rs
@@ -86,7 +86,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn concurrent_schema_publications_are_both_visible_after_readiness() {
+    async fn concurrent_commits_are_both_visible_after_readiness() {
         let observer = connect_for_test(*PROXY).await;
         let first = connect_for_test(*PROXY).await;
         let second = connect_for_test(*PROXY).await;
@@ -257,6 +257,34 @@ mod tests {
         client.batch_execute("COMMIT").await.unwrap();
 
         assert_ciphertext_at_rest(&table, 1, "after safe alter").await;
+    }
+
+    #[tokio::test]
+    async fn native_temporary_table_remains_usable_without_blocking_encrypted_mapping() {
+        let client = connect_for_test(*PROXY).await;
+        let temporary = table("bug_308_native_temp");
+        let encrypted = table("bug_308_after_native_temp");
+
+        client
+            .batch_execute(&format!(
+                "CREATE TEMPORARY TABLE {temporary} (id bigint PRIMARY KEY, name text); \
+                 INSERT INTO {temporary} (id, name) VALUES (1, 'temporary')"
+            ))
+            .await
+            .unwrap();
+        let name: String = client
+            .query_one(&format!("SELECT name FROM {temporary} WHERE id = 1"), &[])
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(name, "temporary");
+
+        client
+            .execute(&create_encrypted_table(&encrypted), &[])
+            .await
+            .unwrap();
+        insert_secret(&client, &encrypted, 1, "after native temporary table").await;
+        assert_ciphertext_at_rest(&encrypted, 1, "after native temporary table").await;
     }
 
     #[tokio::test]

--- a/packages/cipherstash-proxy-integration/src/schema_change.rs
+++ b/packages/cipherstash-proxy-integration/src/schema_change.rs
@@ -1,7 +1,13 @@
 #[cfg(test)]
 /// End-to-end schema-change tests through Proxy and directly against PostgreSQL.
 mod tests {
-    use crate::common::{connect, connect_with_tls, get_database_port, random_id, PROXY};
+    use crate::common::{
+        configure_test_client, connect, connect_with_tls, connection_config, get_database_port,
+        random_id, PROXY,
+    };
+    use std::sync::Arc;
+    use tokio::sync::Barrier;
+    use tokio::time::{timeout, Duration, Instant};
     use tokio_postgres::Client;
 
     async fn connect_for_test(port: u16) -> Client {
@@ -9,6 +15,24 @@ mod tests {
             connect(port).await
         } else {
             connect_with_tls(port).await
+        }
+    }
+
+    async fn connect_for_disconnect_test(port: u16) -> (Client, tokio::task::JoinHandle<()>) {
+        let config = connection_config(port);
+        if std::env::var("CS_TEST_USE_TLS").as_deref() == Ok("false") {
+            let (client, connection) = config.connect(tokio_postgres::NoTls).await.unwrap();
+            let task = tokio::spawn(async move {
+                let _ = connection.await;
+            });
+            (client, task)
+        } else {
+            let tls = tokio_postgres_rustls::MakeRustlsConnect::new(configure_test_client());
+            let (client, connection) = config.connect(tls).await.unwrap();
+            let task = tokio::spawn(async move {
+                let _ = connection.await;
+            });
+            (client, task)
         }
     }
 
@@ -39,6 +63,147 @@ mod tests {
     async fn insert_secret(client: &Client, table: &str, id: i64, plaintext: &str) {
         let sql = format!("INSERT INTO {table} (id, secret) VALUES ($1, $2)");
         assert_eq!(client.execute(&sql, &[&id, &plaintext]).await.unwrap(), 1);
+    }
+
+    async fn wait_until_alter_is_blocked(postgres: &Client, table: &str) {
+        wait_for_alter_lock_state(postgres, table, true).await;
+    }
+
+    async fn wait_for_alter_lock_state(postgres: &Client, table: &str, expected: bool) {
+        let sql = "SELECT EXISTS (SELECT 1 FROM pg_locks WHERE relation = to_regclass($1) AND NOT granted)";
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let blocked: bool = postgres.query_one(sql, &[&table]).await.unwrap().get(0);
+            if blocked == expected {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "ALTER TABLE lock state did not become {expected}"
+            );
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn concurrent_schema_publications_are_both_visible_after_readiness() {
+        let observer = connect_for_test(*PROXY).await;
+        let first = connect_for_test(*PROXY).await;
+        let second = connect_for_test(*PROXY).await;
+        let first_table = table("bug_308_concurrent_first");
+        let second_table = table("bug_308_concurrent_second");
+        first.batch_execute("BEGIN").await.unwrap();
+        second.batch_execute("BEGIN").await.unwrap();
+        first
+            .execute(&create_encrypted_table(&first_table), &[])
+            .await
+            .unwrap();
+        second
+            .execute(&create_encrypted_table(&second_table), &[])
+            .await
+            .unwrap();
+
+        let barrier = Arc::new(Barrier::new(3));
+        let first_commit = tokio::spawn({
+            let barrier = barrier.clone();
+            async move {
+                barrier.wait().await;
+                first.batch_execute("COMMIT").await.unwrap()
+            }
+        });
+        let second_commit = tokio::spawn({
+            let barrier = barrier.clone();
+            async move {
+                barrier.wait().await;
+                second.batch_execute("COMMIT").await.unwrap()
+            }
+        });
+        barrier.wait().await;
+        first_commit.await.unwrap();
+        second_commit.await.unwrap();
+
+        insert_secret(&observer, &first_table, 1, "first concurrent secret").await;
+        insert_secret(&observer, &second_table, 2, "second concurrent secret").await;
+        assert_ciphertext_at_rest(&first_table, 1, "first concurrent secret").await;
+        assert_ciphertext_at_rest(&second_table, 2, "second concurrent secret").await;
+    }
+
+    #[tokio::test]
+    async fn cancelling_blocked_ddl_does_not_activate_a_schema_change() {
+        timeout(Duration::from_secs(20), async {
+            let postgres = connect_for_test(get_database_port()).await;
+            let proxy = connect_for_test(*PROXY).await;
+            let table = table("bug_308_cancel");
+            proxy
+                .batch_execute(&format!("CREATE TABLE {table} (id bigint)"))
+                .await
+                .unwrap();
+            postgres
+                .batch_execute(&format!(
+                    "BEGIN; LOCK TABLE {table} IN ACCESS SHARE MODE"
+                ))
+                .await
+                .unwrap();
+
+            let cancel = proxy.cancel_token();
+            let alter = format!("ALTER TABLE {table} ADD COLUMN secret eql_v3_text_search");
+            let task = tokio::spawn(async move { proxy.batch_execute(&alter).await });
+            wait_until_alter_is_blocked(&postgres, &table).await;
+            if std::env::var("CS_TEST_USE_TLS").as_deref() == Ok("false") {
+                cancel.cancel_query(tokio_postgres::NoTls).await.unwrap();
+            } else {
+                let tls = tokio_postgres_rustls::MakeRustlsConnect::new(configure_test_client());
+                cancel.cancel_query(tls).await.unwrap();
+            }
+            assert!(task.await.unwrap().is_err());
+            postgres.batch_execute("ROLLBACK").await.unwrap();
+
+            let fresh = connect_for_test(*PROXY).await;
+            assert_eq!(fresh.execute(&format!("INSERT INTO {table} (id) VALUES (1)"), &[]).await.unwrap(), 1);
+            let exists: bool = postgres.query_one(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = $1 AND column_name = 'secret')",
+                &[&table],
+            ).await.unwrap().get(0);
+            assert!(!exists);
+        }).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn disconnecting_during_blocked_ddl_does_not_cancel_the_upstream_schema_change() {
+        timeout(Duration::from_secs(20), async {
+            let postgres = connect_for_test(get_database_port()).await;
+            let (proxy, connection_task) = connect_for_disconnect_test(*PROXY).await;
+            let table = table("bug_308_disconnect");
+            proxy
+                .batch_execute(&format!("CREATE TABLE {table} (id bigint)"))
+                .await
+                .unwrap();
+            postgres
+                .batch_execute(&format!(
+                    "BEGIN; LOCK TABLE {table} IN ACCESS SHARE MODE"
+                ))
+                .await
+                .unwrap();
+
+            let alter = format!("ALTER TABLE {table} ADD COLUMN secret eql_v3_text_search");
+            let task = tokio::spawn(async move { proxy.batch_execute(&alter).await });
+            wait_until_alter_is_blocked(&postgres, &table).await;
+            connection_task.abort();
+            assert!(connection_task.await.unwrap_err().is_cancelled());
+            assert!(task.await.unwrap().is_err());
+
+            // Proxy has already forwarded the statement to PostgreSQL. Losing
+            // the client connection does not cancel that upstream execution.
+            postgres.batch_execute("ROLLBACK").await.unwrap();
+
+            let fresh = connect_for_test(*PROXY).await;
+            assert_eq!(fresh.execute(&format!("INSERT INTO {table} (id) VALUES (1)"), &[]).await.unwrap(), 1);
+            let exists: bool = postgres.query_one(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = $1 AND column_name = 'secret')",
+                &[&table],
+            ).await.unwrap().get(0);
+            assert!(exists);
+        }).await.unwrap();
     }
 
     #[tokio::test]

--- a/packages/cipherstash-proxy/Cargo.toml
+++ b/packages/cipherstash-proxy/Cargo.toml
@@ -59,5 +59,6 @@ vitaminc-protected = "0.1.0-pre4.2"
 
 
 [dev-dependencies]
+proptest = "1.7"
 recipher = "0.1.3"
 temp-env = "0.3.6"

--- a/packages/cipherstash-proxy/src/postgresql/driver.rs
+++ b/packages/cipherstash-proxy/src/postgresql/driver.rs
@@ -102,114 +102,123 @@ where
                 pg_proto::IntermediaryAccept::Session(session) => session,
                 pg_proto::IntermediaryAccept::CancellationForwarded => return Ok(()),
             };
-            'session: loop {
-                let forward = session.forward_next();
-                let forwarded = match connection_timeout {
-                    Some(duration) => tokio::time::timeout(duration, forward)
-                        .await
-                        .map_err(|_| Error::ConnectionTimeout { duration })?,
-                    None => forward.await,
-                };
-                let forwarded = match forwarded {
-                    Ok(forwarded) => forwarded,
-                    Err(pg_proto::ForwardError::Frontend(
-                        pg_proto::FrontendProjectionError::Capacity(_),
-                    )) => {
-                        // pg-proto retains the rejected frontend message. Drain
-                        // one upstream response at a time to release pipeline
-                        // capacity, then retry that exact message through the
-                        // dedicated frontend path. In particular, this lets a
-                        // retained Sync reach PostgreSQL instead of waiting for
-                        // responses that PostgreSQL may buffer until Sync.
-                        loop {
-                            let backend = session.forward_backend();
-                            let drained = match connection_timeout {
-                                Some(duration) => tokio::time::timeout(duration, backend)
-                                    .await
-                                    .map_err(|_| Error::ConnectionTimeout { duration })?,
-                                None => backend.await,
-                            };
-                            match drained {
-                                Ok(
-                                    BackendForwarding::Forwarded(_)
-                                    | BackendForwarding::Expanded { .. }
-                                    | BackendForwarding::Suppressed(_)
-                                    | BackendForwarding::Held,
-                                ) => {}
-                                Err(pg_proto::ForwardError::Middleware(error)) => {
-                                    return Err(error)
+            let result = async {
+                'session: loop {
+                    let forward = session.forward_next();
+                    let forwarded = match connection_timeout {
+                        Some(duration) => tokio::time::timeout(duration, forward)
+                            .await
+                            .map_err(|_| Error::ConnectionTimeout { duration })?,
+                        None => forward.await,
+                    };
+                    let forwarded = match forwarded {
+                        Ok(forwarded) => forwarded,
+                        Err(pg_proto::ForwardError::Frontend(
+                            pg_proto::FrontendProjectionError::Capacity(_),
+                        )) => {
+                            // pg-proto retains the rejected frontend message. Drain
+                            // one upstream response at a time to release pipeline
+                            // capacity, then retry that exact message through the
+                            // dedicated frontend path. In particular, this lets a
+                            // retained Sync reach PostgreSQL instead of waiting for
+                            // responses that PostgreSQL may buffer until Sync.
+                            loop {
+                                let backend = session.forward_backend();
+                                let drained = match connection_timeout {
+                                    Some(duration) => tokio::time::timeout(duration, backend)
+                                        .await
+                                        .map_err(|_| Error::ConnectionTimeout { duration })?,
+                                    None => backend.await,
+                                };
+                                match drained {
+                                    Ok(
+                                        BackendForwarding::Forwarded(_)
+                                        | BackendForwarding::Expanded { .. }
+                                        | BackendForwarding::Suppressed(_)
+                                        | BackendForwarding::Held,
+                                    ) => {}
+                                    Err(pg_proto::ForwardError::Middleware(error)) => {
+                                        return Err(error)
+                                    }
+                                    Err(error) => return Err(invalid_data(error)),
                                 }
-                                Err(error) => return Err(invalid_data(error)),
-                            }
 
-                            let retry = session.forward_frontend();
-                            let retried = match connection_timeout {
-                                Some(duration) => tokio::time::timeout(duration, retry)
-                                    .await
-                                    .map_err(|_| Error::ConnectionTimeout { duration })?,
-                                None => retry.await,
-                            };
-                            match retried {
-                                Ok(FrontendForwarding::Forwarded(FrontendMessage::Terminate)) => {
-                                    break 'session;
+                                let retry = session.forward_frontend();
+                                let retried =
+                                    match connection_timeout {
+                                        Some(duration) => tokio::time::timeout(duration, retry)
+                                            .await
+                                            .map_err(|_| Error::ConnectionTimeout { duration })?,
+                                        None => retry.await,
+                                    };
+                                match retried {
+                                    Ok(FrontendForwarding::Forwarded(
+                                        FrontendMessage::Terminate,
+                                    )) => {
+                                        break 'session;
+                                    }
+                                    Ok(_) => break,
+                                    Err(pg_proto::ForwardError::Frontend(
+                                        pg_proto::FrontendProjectionError::Capacity(_),
+                                    )) => {}
+                                    Err(pg_proto::ForwardError::Middleware(error)) => {
+                                        return Err(error)
+                                    }
+                                    Err(error) => return Err(invalid_data(error)),
                                 }
-                                Ok(_) => break,
-                                Err(pg_proto::ForwardError::Frontend(
-                                    pg_proto::FrontendProjectionError::Capacity(_),
-                                )) => {}
-                                Err(pg_proto::ForwardError::Middleware(error)) => {
-                                    return Err(error)
-                                }
-                                Err(error) => return Err(invalid_data(error)),
                             }
+                            continue;
                         }
-                        continue;
+                        Err(pg_proto::ForwardError::Middleware(error)) => return Err(error),
+                        Err(error) => return Err(invalid_data(error)),
+                    };
+                    if matches!(&forwarded, ForwardedMessage::FrontendExpanded { .. }) {
+                        // A DDL Execute is expanded to Execute + Flush so PostgreSQL can
+                        // report its outcome before later schema-dependent frontend work.
+                        // Keep the single-task intermediary progressing on the backend
+                        // leg until that DDL resolves; otherwise a later frontend mapping
+                        // call can wait for an outcome this task has not read yet.
+                        // Box the whole secondary forwarding state machine so it
+                        // does not enlarge the normal frontend driver's stack frame.
+                        Box::pin(async {
+                            while context.schema_ddl_in_flight() {
+                                let backend = session.forward_backend();
+                                let drained = match connection_timeout {
+                                    Some(duration) => tokio::time::timeout(duration, backend)
+                                        .await
+                                        .map_err(|_| Error::ConnectionTimeout { duration })?,
+                                    None => backend.await,
+                                };
+                                match drained {
+                                    Ok(
+                                        BackendForwarding::Forwarded(_)
+                                        | BackendForwarding::Expanded { .. }
+                                        | BackendForwarding::Suppressed(_)
+                                        | BackendForwarding::Held,
+                                    ) => {}
+                                    Err(pg_proto::ForwardError::Middleware(error)) => {
+                                        return Err(error)
+                                    }
+                                    Err(error) => return Err(invalid_data(error)),
+                                }
+                            }
+                            Ok(())
+                        })
+                        .await?;
                     }
-                    Err(pg_proto::ForwardError::Middleware(error)) => return Err(error),
-                    Err(error) => return Err(invalid_data(error)),
-                };
-                if matches!(&forwarded, ForwardedMessage::FrontendExpanded { .. }) {
-                    // A DDL Execute is expanded to Execute + Flush so PostgreSQL can
-                    // report its outcome before later schema-dependent frontend work.
-                    // Keep the single-task intermediary progressing on the backend
-                    // leg until that DDL resolves; otherwise a later frontend mapping
-                    // call can wait for an outcome this task has not read yet.
-                    // Box the whole secondary forwarding state machine so it
-                    // does not enlarge the normal frontend driver's stack frame.
-                    Box::pin(async {
-                        while context.schema_ddl_in_flight() {
-                            let backend = session.forward_backend();
-                            let drained = match connection_timeout {
-                                Some(duration) => tokio::time::timeout(duration, backend)
-                                    .await
-                                    .map_err(|_| Error::ConnectionTimeout { duration })?,
-                                None => backend.await,
-                            };
-                            match drained {
-                                Ok(
-                                    BackendForwarding::Forwarded(_)
-                                    | BackendForwarding::Expanded { .. }
-                                    | BackendForwarding::Suppressed(_)
-                                    | BackendForwarding::Held,
-                                ) => {}
-                                Err(pg_proto::ForwardError::Middleware(error)) => {
-                                    return Err(error)
-                                }
-                                Err(error) => return Err(invalid_data(error)),
-                            }
-                        }
-                        Ok(())
-                    })
-                    .await?;
+                    if matches!(
+                        forwarded,
+                        ForwardedMessage::Frontend(FrontendMessage::Terminate)
+                    ) {
+                        break;
+                    }
                 }
-                if matches!(
-                    forwarded,
-                    ForwardedMessage::Frontend(FrontendMessage::Terminate)
-                ) {
-                    break;
-                }
+                Ok(())
             }
-            Ok(())
+            .await;
+            finish_connection(result, || {
+                let _ = session.detach_cancellation();
+            })
         }};
     }
 
@@ -286,6 +295,14 @@ fn invalid_data(error: impl std::fmt::Display) -> Error {
     std::io::Error::new(std::io::ErrorKind::InvalidData, error.to_string()).into()
 }
 
+fn finish_connection<T, E>(
+    result: Result<T, E>,
+    detach_cancellation: impl FnOnce(),
+) -> Result<T, E> {
+    detach_cancellation();
+    result
+}
+
 fn upstream_ssl_mode(config: &crate::TandemConfig) -> SslMode {
     if config.database.with_tls_verification {
         SslMode::VerifyFull
@@ -299,6 +316,35 @@ fn upstream_ssl_mode(config: &crate::TandemConfig) -> SslMode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
+    use pg_proto::{
+        CancelKey, CancellationRoute, InMemoryCancellationRegistryError,
+        IntermediaryCancellationRegistry,
+    };
+
+    #[test]
+    fn connection_exit_releases_its_cancellation_key() {
+        for result in [Ok(()), Err("connection failed")] {
+            let registry = InMemoryCancellationRegistry::default();
+            let key = CancelKey {
+                process_id: 42,
+                secret_key: Bytes::from_static(b"secret"),
+            };
+            let route = CancellationRoute::new(ConnectTarget::new("database"), key.clone());
+            assert_eq!(registry.register(route.clone()), Ok(key.clone()));
+            assert_eq!(
+                registry.register(route.clone()),
+                Err(InMemoryCancellationRegistryError::DuplicateKey)
+            );
+
+            let returned = finish_connection(result, || {
+                registry.detach(&key).unwrap();
+            });
+
+            assert_eq!(returned, result);
+            assert_eq!(registry.register(route), Ok(key));
+        }
+    }
 
     #[test]
     fn upstream_tls_without_verification_is_opportunistic() {

--- a/packages/cipherstash-proxy/src/postgresql/driver.rs
+++ b/packages/cipherstash-proxy/src/postgresql/driver.rs
@@ -12,9 +12,17 @@ use pg_proto::{
     ServerIdentity, ServerIdentityProvider, ServerTlsPolicy, SslMode, StartupParameters,
     StartupRouteResolver, StaticClientCredentials, StaticMd5ServerCredentials,
 };
-use std::{convert::Infallible, sync::Arc};
+use std::{
+    convert::Infallible,
+    sync::{Arc, LazyLock},
+};
 use tokio::net::TcpStream;
 use tracing::info;
+
+/// Cancellation requests arrive on a new connection, so every intermediary
+/// must share the registry that maps client cancellation keys to upstream keys.
+static CANCELLATION_REGISTRY: LazyLock<InMemoryCancellationRegistry> =
+    LazyLock::new(InMemoryCancellationRegistry::default);
 
 #[derive(Clone)]
 struct Route(String);
@@ -77,7 +85,7 @@ where
                 .client($client)
                 .startup_resolver(Route(address.clone()))
                 .cancellation(CancellationPolicy::Forward)
-                .cancellation_registry(InMemoryCancellationRegistry::default())
+                .cancellation_registry(CANCELLATION_REGISTRY.clone())
                 .pipeline(BoundedPipeline::new(256).expect("non-zero pipeline bound"))
                 .middleware(CipherStashMiddlewareFactory(context.clone()))
                 .build()

--- a/packages/cipherstash-proxy/src/postgresql/middleware/backend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/middleware/backend.rs
@@ -812,6 +812,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn failed_transaction_readiness_is_forwarded_without_publishing_schema() {
+        let config = Arc::new(TandemConfig::for_testing());
+        let encrypt_config = Arc::new(EncryptConfig::default());
+        let schema = Arc::new(Schema::new("public"));
+        let (reload_sender, mut reload_receiver) = mpsc::unbounded_channel();
+        let context = Context::new(
+            1,
+            config,
+            encrypt_config,
+            schema,
+            Arc::new(rustls::RootCertStore::empty()),
+            TestService {},
+            reload_sender,
+        );
+        let ddl = SqlParser::parse_statement("create table reports (id bigint)").unwrap();
+        context.execute_simple_schema_statements(&[ddl]);
+        context.schema_execution_succeeded();
+
+        let mut backend = Backend::new(context);
+        let expected =
+            BackendMessage::ReadyForQuery(pg_proto::TransactionStatus::FailedTransaction);
+        let output = backend.intercept(None, expected.clone()).await.unwrap();
+
+        assert_eq!(output, BackendMiddlewareOutput::Forward(expected));
+        assert!(reload_receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
     async fn publication_failure_closes_connection_before_idle_readiness() {
         let config = Arc::new(TandemConfig::for_testing());
         let encrypt_config = Arc::new(EncryptConfig::default());

--- a/packages/cipherstash-proxy/src/proxy/schema/middleware.rs
+++ b/packages/cipherstash-proxy/src/proxy/schema/middleware.rs
@@ -847,8 +847,10 @@ fn is_modelled_ddl(statement: &Statement) -> bool {
 mod tests {
     use super::*;
     use eql_mapper::Table;
+    use proptest::prelude::*;
     use sqltk::parser::ast::{Ident, ObjectName, ObjectNamePart};
     use sqltk::parser::{dialect::PostgreSqlDialect, parser::Parser};
+    use std::collections::HashSet;
 
     fn parse(sql: &str) -> Statement {
         Parser::new(&PostgreSqlDialect {})
@@ -860,6 +862,86 @@ mod tests {
 
     fn table(name: &str) -> ObjectName {
         ObjectName(vec![ObjectNamePart::Identifier(Ident::new(name))])
+    }
+
+    #[derive(Clone, Debug)]
+    enum GeneratedEvent {
+        CreateSucceeded(u8),
+        CreateFailed(u8),
+        Rollback,
+        FailedTransactionBoundary,
+    }
+
+    fn generated_events() -> impl Strategy<Value = Vec<GeneratedEvent>> {
+        prop::collection::vec(
+            prop_oneof![
+                (0_u8..8).prop_map(GeneratedEvent::CreateSucceeded),
+                (0_u8..8).prop_map(GeneratedEvent::CreateFailed),
+                Just(GeneratedEvent::Rollback),
+                Just(GeneratedEvent::FailedTransactionBoundary),
+            ],
+            1..80,
+        )
+    }
+
+    fn execute_prepared(middleware: &SchemaMiddleware, name: String, statement: Statement) {
+        let statement_name = Name::from(format!("statement_{name}"));
+        let portal_name = Name::from(format!("portal_{name}"));
+        middleware.prepare(statement_name.clone(), statement);
+        middleware.bind(portal_name.clone(), &statement_name);
+        middleware.execute(&portal_name);
+    }
+
+    proptest! {
+        #[test]
+        fn generated_lifecycle_matches_an_independent_schema_model(events in generated_events()) {
+            let middleware = SchemaMiddleware::new(Arc::new(Schema::new("public")));
+            let mut expected_tables = HashSet::new();
+
+            for event in events {
+                match event {
+                    GeneratedEvent::CreateSucceeded(id) => {
+                        let name = format!("generated_{id}");
+                        execute_prepared(
+                            &middleware,
+                            format!("create_{id}"),
+                            parse(&format!(
+                                "create table {name} (id bigint, secret eql_v3_text_search)"
+                            )),
+                        );
+                        middleware.execution_succeeded();
+                        expected_tables.insert(name);
+                    }
+                    GeneratedEvent::CreateFailed(id) => {
+                        let name = format!("generated_{id}");
+                        execute_prepared(
+                            &middleware,
+                            format!("create_{id}"),
+                            parse(&format!(
+                                "create table {name} (id bigint, secret eql_v3_text_search)"
+                            )),
+                        );
+                        middleware.execution_failed();
+                    }
+                    GeneratedEvent::Rollback => {
+                        execute_prepared(&middleware, "rollback".to_owned(), parse("rollback"));
+                        middleware.execution_succeeded();
+                        expected_tables.clear();
+                    }
+                    GeneratedEvent::FailedTransactionBoundary => {
+                        middleware.ready_for_query(TransactionStatus::FailedTransaction)
+                    }
+                }
+
+                for id in 0_u8..8 {
+                    let name = format!("generated_{id}");
+                    let schema_has_table = middleware.resolver().resolve_table(&table(&name)).is_ok();
+                    let config_has_table = middleware.encrypt_config().contains_table(&name);
+                    prop_assert_eq!(schema_has_table, expected_tables.contains(&name));
+                    prop_assert_eq!(config_has_table, expected_tables.contains(&name));
+                }
+            }
+        }
     }
 
     #[test]

--- a/packages/cipherstash-proxy/src/proxy/schema/middleware.rs
+++ b/packages/cipherstash-proxy/src/proxy/schema/middleware.rs
@@ -894,7 +894,7 @@ mod tests {
 
     proptest! {
         #[test]
-        fn generated_lifecycle_matches_an_independent_schema_model(events in generated_events()) {
+        fn generated_create_outcomes_and_rollbacks_match_schema_overlay(events in generated_events()) {
             let middleware = SchemaMiddleware::new(Arc::new(Schema::new("public")));
             let mut expected_tables = HashSet::new();
 


### PR DESCRIPTION
## Summary

- add property-based coverage that keeps schema and encryption overlays aligned across successful and failed DDL execution and rollback
- verify failed-transaction readiness does not publish schema state
- cover concurrent commit visibility, blocked-DDL cancellation, and client disconnection through database-backed tests
- share PostgreSQL cancellation routing across connections so cancellation requests reach the original upstream connection
- verify native temporary tables remain usable without blocking subsequent encrypted schema mapping

## Validation

- focused schema lifecycle and backend adapter unit tests
- integration test suite compilation
- formatting and diff checks
- CI across PostgreSQL 14, 15, 16, and 17
- encrypted burn-in and performance regression checks

## Acknowledgment

By submitting this pull request, I confirm that CipherStash can use, modify, copy, and redistribute this contribution, under the terms of CipherStash's choice.
