### PR TITLE
CIP-3933: Deepen Context protocol lifecycle ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- **Extended-protocol execution lifecycle regressions**: statement duration and slow-statement metrics now describe each execution rather than the lifetime of its cached prepared statement; suspended executions retain their metrics until completion; untracked rows and terminal responses retain PostgreSQL passthrough behavior; decryption failures no longer report pending schema changes as successful; disabling mapping no longer creates empty statement metrics; and inaccessible connection protocol state now closes the connection instead of silently omitting metadata transitions.
+- **Extended-protocol execution lifecycle regressions**: statement duration and slow-statement metrics now describe each execution rather than the lifetime of its cached prepared statement; distinct portals keep isolated Bind measurements; suspended executions retain their metrics until completion; correlated stale responses and inaccessible connection protocol state close the connection instead of silently omitting metadata transitions; uncorrelated responses retain PostgreSQL passthrough behavior; decryption failures no longer report pending schema changes as successful; and disabling mapping no longer creates empty statement metrics.
 
 - **Query cancellation through Proxy**: Cancellation requests now reach the matching PostgreSQL connection, and their routing entries are removed when the client connection exits. Previously cancellation requests arrived on a separate connection that could not find the original route; retaining those routes globally without cleanup could also leak memory and eventually reject a new connection if PostgreSQL reused a cancellation key.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **PostgreSQL execution lifecycle ownership**: Proxy now tracks prepared statements, portals, Describe operations, execution outcomes, and execution metrics as one connection-local protocol lifecycle. Suspended executions retain their original metrics scope until completion, repeated portal executions receive distinct scopes, and terminal errors replace upstream responses atomically while schema outcomes are reported exactly once.
+
 - **Upstream TLS verification for client traffic**: Connections with `with_tls_verification` enabled now use a cached snapshot of the system root certificates, loaded once when Proxy starts. Unlike Proxy's background database connections, pg-proto client-traffic connections do not apply operating-system revocation checks or enterprise verification policy. Restart Proxy after changing the system trust store.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Extended-protocol execution lifecycle regressions**: statement duration and slow-statement metrics now describe each execution rather than the lifetime of its cached prepared statement; suspended executions retain their metrics until completion; untracked rows and terminal responses retain PostgreSQL passthrough behavior; decryption failures no longer report pending schema changes as successful; disabling mapping no longer creates empty statement metrics; and inaccessible connection protocol state now closes the connection instead of silently omitting metadata transitions.
+
 - **Query cancellation through Proxy**: Cancellation requests now reach the matching PostgreSQL connection, and their routing entries are removed when the client connection exits. Previously cancellation requests arrived on a separate connection that could not find the original route; retaining those routes globally without cleanup could also leak memory and eventually reject a new connection if PostgreSQL reused a cancellation key.
 
 - **Configured default keyset selection**: when a connection has not selected a keyset explicitly, Proxy now scopes encryption and decryption to `CS_DEFAULT_KEYSET_ID`. Previously it passed no keyset to ZeroKMS and could silently use the account default instead, deriving different searchable-encryption terms when the two defaults differed. Before upgrading, verify that the configured and account defaults are intentional; values written by an affected version under the unintended account default must be decrypted with that old keyset and re-encrypted under the configured default.

--- a/packages/cipherstash-proxy-integration/src/schema_change.rs
+++ b/packages/cipherstash-proxy-integration/src/schema_change.rs
@@ -455,4 +455,21 @@ mod tests {
         assert!(exists);
         assert_ciphertext_at_rest(&encrypted, 1, "preserved batch secret").await;
     }
+
+    #[tokio::test]
+    async fn multi_statement_simple_query_keeps_the_connection_usable() {
+        let client = connect_for_test(*PROXY).await;
+        let first = table("execution_lifecycle_first");
+        let second = table("execution_lifecycle_second");
+
+        client
+            .batch_execute(&format!(
+                "CREATE TABLE {first} (id bigint); CREATE TABLE {second} (id bigint)"
+            ))
+            .await
+            .unwrap();
+
+        let value: i32 = client.query_one("SELECT 1", &[]).await.unwrap().get(0);
+        assert_eq!(value, 1);
+    }
 }

--- a/packages/cipherstash-proxy/CONTEXT.md
+++ b/packages/cipherstash-proxy/CONTEXT.md
@@ -34,8 +34,10 @@ A prepared statement bound to parameter values, ready to execute. Either `Encryp
 carrying the analysed statement, or `Passthrough` when nothing in it is encrypted.
 
 **Statement metrics scope**:
-The measurement window around a single statement — opened at Parse or Query, closed when
-the statement completes. Many of these occur per connection.
+The measurement window around one statement execution occurrence. A simple Query owns one;
+an extended-protocol Execute owns one from its first execution through any suspension and
+resumption until completion or failure, while Parse timing belongs to the prepared Statement
+and may be attributed to each execution occurrence.
 _Avoid_: session (`start_session`, `SessionId` and the
 `..._statements_session_duration_seconds` metric all use this sense and are misnamed).
 

--- a/packages/cipherstash-proxy/docs/adr/0002-context-owns-protocol-metadata-transitions.md
+++ b/packages/cipherstash-proxy/docs/adr/0002-context-owns-protocol-metadata-transitions.md
@@ -1,0 +1,23 @@
+---
+status: accepted
+---
+
+# Context owns CipherStash protocol metadata transitions
+
+`Context` is the connection seam for CipherStash metadata associated with PostgreSQL Statements,
+Portals, operations, and statement metrics scopes. Frontend and Backend remain protocol adapters:
+they interpret wire messages, while Context applies each correlated metadata transition atomically
+and returns the knowledge or effects the adapter needs. pg-proto continues to own protocol ordering
+and backpressure, and Schema middleware continues to own transactional schema state under ADR-0001.
+
+The correlated protocol state is kept in one internal state model rather than independently locked
+maps. Context never holds that state lock across asynchronous work, metrics emission, or Schema
+middleware calls; a transition first changes protocol state and returns explicit effects, then
+Context applies those effects. Passthrough and encrypted traffic use the same lifecycle seam, and
+inaccessible, stale, or inconsistent state fails the connection closed rather than silently omitting
+a transition.
+
+Statement metrics scopes belong to execution occurrences, not prepared Statements. A suspended and
+resumed execution retains one scope until completion or failure; distinct Portals and repeated
+executions receive distinct scopes, while Parse timing remains knowledge of the prepared Statement
+that may be attributed to each execution observation. Existing Prometheus metric names remain stable.

--- a/packages/cipherstash-proxy/src/config/tandem.rs
+++ b/packages/cipherstash-proxy/src/config/tandem.rs
@@ -343,6 +343,15 @@ impl TandemConfig {
             development: None,
         }
     }
+
+    #[cfg(test)]
+    pub fn disable_mapping_for_testing(&mut self) {
+        self.development = Some(DevelopmentConfig {
+            disable_mapping: true,
+            disable_database_tls: false,
+            enable_mapping_errors: false,
+        });
+    }
 }
 
 impl EncryptConfig {

--- a/packages/cipherstash-proxy/src/error.rs
+++ b/packages/cipherstash-proxy/src/error.rs
@@ -85,6 +85,18 @@ impl Error {
 
 #[derive(Error, Debug)]
 pub enum ContextError {
+    #[error("Operation has no in-flight Execute state")]
+    OperationWithoutExecute,
+
+    #[error("Connection protocol state is unavailable")]
+    ProtocolStateUnavailable,
+
+    #[error("Operation could not be found in connection protocol state")]
+    UnknownOperation,
+
+    #[error("Operation has no in-flight Describe state")]
+    UnknownDescribe,
+
     #[error("Portal could not be found in context")]
     UnknownPortal,
 }

--- a/packages/cipherstash-proxy/src/error.rs
+++ b/packages/cipherstash-proxy/src/error.rs
@@ -97,6 +97,9 @@ pub enum ContextError {
     #[error("Operation has no in-flight Describe state")]
     UnknownDescribe,
 
+    #[error("Prepared statement has no metrics template")]
+    StatementMetricsUnavailable,
+
     #[error("Portal could not be found in context")]
     UnknownPortal,
 }

--- a/packages/cipherstash-proxy/src/postgresql/context/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/context/mod.rs
@@ -766,19 +766,21 @@ where
     }
 
     pub fn discard_operation(&mut self, operation: OperationId) -> Result<(), Error> {
-        let finished_metrics_scope = {
+        let finished_metrics_scopes = {
             let mut state = self
                 .protocol_state
                 .write()
                 .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
-            let session_id = state
+            let metrics_scope_id = state
                 .operations
                 .remove(&operation)
                 .and_then(|operation| operation.execute)
                 .and_then(|execute| execute.session_id());
-            session_id.and_then(|session_id| state.statement_metrics.remove(&session_id))
+            state.take_unreferenced_metrics(metrics_scope_id)
         };
-        self.record_finished_metrics_scope(finished_metrics_scope);
+        for metrics_scope in finished_metrics_scopes {
+            self.record_finished_metrics_scope(Some(metrics_scope));
+        }
         Ok(())
     }
 
@@ -2434,6 +2436,28 @@ mod tests {
             .get_metrics_scope(execution_scope)
             .unwrap()
             .is_none());
+    }
+
+    #[test]
+    fn discarding_an_operation_preserves_a_metrics_scope_referenced_by_another_operation() {
+        let mut context = create_context();
+        let scope = context.start_metrics_scope().unwrap();
+        let first_operation = operation_id();
+        let second_operation = operation_id();
+        context
+            .set_execute(first_operation, Name::from("first"), Some(scope))
+            .unwrap();
+        context
+            .set_execute(second_operation, Name::from("second"), Some(scope))
+            .unwrap();
+
+        context.discard_operation(first_operation).unwrap();
+
+        assert!(context.get_metrics_scope(scope).unwrap().is_some());
+
+        context.discard_operation(second_operation).unwrap();
+
+        assert!(context.get_metrics_scope(scope).unwrap().is_none());
     }
 
     #[test]

--- a/packages/cipherstash-proxy/src/postgresql/context/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/context/mod.rs
@@ -59,11 +59,7 @@ where
     encryption: T,
     reload_sender: ReloadSender,
     schema_middleware: SchemaMiddleware,
-    statements: Arc<RwLock<HashMap<Name, Arc<Statement>>>>,
-    statement_sessions: Arc<RwLock<HashMap<Name, SessionId>>>,
-    portals: Arc<RwLock<HashMap<Name, Arc<Portal>>>>,
-    operations: Arc<RwLock<HashMap<OperationId, OperationContext>>>,
-    session_metrics: Arc<RwLock<HashMap<SessionId, SessionMetricsContext>>>,
+    protocol_state: Arc<RwLock<ConnectionProtocolState>>,
     upstream_tls_roots: Arc<rustls::RootCertStore>,
     unsafe_disable_mapping: bool,
     keyset_id: Arc<RwLock<Option<KeysetIdentifier>>>,
@@ -81,6 +77,7 @@ pub struct ExecuteContext {
     portal: Option<Arc<Portal>>,
     start: Instant,
     session_id: Option<SessionId>,
+    completes_at_readiness: bool,
 }
 
 impl ExecuteContext {
@@ -94,7 +91,13 @@ impl ExecuteContext {
             portal,
             start: Instant::now(),
             session_id,
+            completes_at_readiness: false,
         }
+    }
+
+    fn until_readiness(mut self) -> Self {
+        self.completes_at_readiness = true;
+        self
     }
 
     fn duration(&self) -> Duration {
@@ -108,15 +111,159 @@ impl ExecuteContext {
 
 #[derive(Clone, Debug, Default)]
 struct OperationContext {
-    describe_statement: Option<Arc<Statement>>,
+    describe: Option<DescribeContext>,
     execute: Option<ExecuteContext>,
     error_response: Option<DiagnosticResponse>,
+}
+
+#[derive(Clone, Debug)]
+struct DescribeContext {
+    statement: Option<Arc<Statement>>,
+}
+
+#[derive(Debug)]
+struct ConnectionProtocolState<K = OperationId> {
+    operations: HashMap<K, OperationContext>,
+    statement_metrics: HashMap<SessionId, SessionMetricsContext>,
+    suspended_executions: HashMap<Name, (K, ExecuteContext)>,
+    statements: HashMap<Name, Arc<Statement>>,
+    statement_metrics_scopes: HashMap<Name, SessionId>,
+    portals: HashMap<Name, Arc<Portal>>,
+    portal_operations: HashMap<Name, K>,
+}
+
+impl<K> Default for ConnectionProtocolState<K> {
+    fn default() -> Self {
+        Self {
+            operations: HashMap::new(),
+            statement_metrics: HashMap::new(),
+            suspended_executions: HashMap::new(),
+            statements: HashMap::new(),
+            statement_metrics_scopes: HashMap::new(),
+            portals: HashMap::new(),
+            portal_operations: HashMap::new(),
+        }
+    }
+}
+
+impl<K> ConnectionProtocolState<K>
+where
+    K: Copy + Eq + std::hash::Hash,
+{
+    fn metrics_referenced(&self, session_id: SessionId) -> bool {
+        self.statement_metrics_scopes
+            .values()
+            .any(|id| *id == session_id)
+            || self
+                .portals
+                .values()
+                .any(|portal| portal.session_id() == Some(session_id))
+            || self.operations.values().any(|operation| {
+                operation
+                    .execute
+                    .as_ref()
+                    .is_some_and(|execute| execute.session_id() == Some(session_id))
+            })
+            || self
+                .suspended_executions
+                .values()
+                .any(|(_, execute)| execute.session_id() == Some(session_id))
+    }
+
+    fn take_unreferenced_metrics(
+        &mut self,
+        candidates: impl IntoIterator<Item = SessionId>,
+    ) -> Vec<SessionMetricsContext> {
+        let mut metrics = Vec::new();
+        for session_id in candidates {
+            if !self.metrics_referenced(session_id) {
+                metrics.extend(self.statement_metrics.remove(&session_id));
+            }
+        }
+        metrics
+    }
+
+    fn finish_execution(
+        &mut self,
+        operation: &K,
+        outcome: ExecutionOutcome,
+    ) -> Result<ExecutionTransition, crate::error::ContextError> {
+        let Some(operation_context) = self.operations.get_mut(operation) else {
+            return Err(crate::error::ContextError::UnknownOperation);
+        };
+        if outcome == ExecutionOutcome::Completed
+            && operation_context
+                .execute
+                .as_ref()
+                .is_some_and(|execute| execute.completes_at_readiness)
+        {
+            return Ok(ExecutionTransition {
+                execute: operation_context.execute.clone(),
+                metrics: None,
+                finished_metrics: None,
+                replacement_error: None,
+                execution_finished: false,
+            });
+        }
+        let execute = operation_context.execute.take();
+        if execute.is_none() && outcome != ExecutionOutcome::Failed {
+            return Err(crate::error::ContextError::OperationWithoutExecute);
+        }
+        let replacement_error = if outcome == ExecutionOutcome::Failed {
+            operation_context.error_response.take()
+        } else {
+            None
+        };
+        let remove_operation =
+            outcome == ExecutionOutcome::Failed || operation_context.describe.is_none();
+        if remove_operation {
+            self.operations.remove(operation);
+        }
+        let metrics = execute
+            .as_ref()
+            .and_then(ExecuteContext::session_id)
+            .and_then(|id| self.statement_metrics.get(&id).cloned());
+        let finished_metrics = if outcome == ExecutionOutcome::Suspended {
+            let execute = execute.as_ref().unwrap();
+            self.suspended_executions
+                .insert(execute.name.clone(), (*operation, execute.clone()));
+            None
+        } else {
+            execute
+                .as_ref()
+                .and_then(ExecuteContext::session_id)
+                .and_then(|id| self.statement_metrics.remove(&id))
+        };
+        Ok(ExecutionTransition {
+            execute,
+            metrics,
+            finished_metrics,
+            replacement_error,
+            execution_finished: true,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExecutionOutcome {
+    Completed,
+    Suspended,
+    Failed,
+}
+
+struct ExecutionTransition {
+    execute: Option<ExecuteContext>,
+    metrics: Option<SessionMetricsContext>,
+    finished_metrics: Option<SessionMetricsContext>,
+    replacement_error: Option<DiagnosticResponse>,
+    execution_finished: bool,
 }
 
 #[derive(Clone, Debug)]
 pub struct SessionMetricsContext {
     id: SessionId,
     start: Instant,
+    records_session: bool,
     pub phase_timing: PhaseTiming,
     pub metadata: StatementMetadata,
 }
@@ -126,6 +273,7 @@ impl SessionMetricsContext {
         SessionMetricsContext {
             id,
             start: Instant::now(),
+            records_session: true,
             phase_timing: PhaseTiming::new(),
             metadata: StatementMetadata::new(),
         }
@@ -177,11 +325,7 @@ where
         let schema_middleware = SchemaMiddleware::from_store(schema_store);
 
         Context {
-            statements: Arc::new(RwLock::new(HashMap::new())),
-            statement_sessions: Arc::new(RwLock::new(HashMap::new())),
-            portals: Arc::new(RwLock::new(HashMap::new())),
-            operations: Arc::new(RwLock::new(HashMap::new())),
-            session_metrics: Arc::new(RwLock::new(HashMap::new())),
+            protocol_state: Arc::new(RwLock::new(ConnectionProtocolState::default())),
             upstream_tls_roots,
             client_id,
             config,
@@ -195,53 +339,102 @@ where
         }
     }
 
-    pub fn set_describe(&mut self, operation: OperationId, describe: Describe) {
+    pub fn set_describe(&self, operation: OperationId, describe: Describe) -> Result<(), Error> {
         debug!(target: CONTEXT, client_id = self.client_id, describe = ?describe);
+        let mut state = self
+            .protocol_state
+            .write()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
         let statement = match &describe {
             Describe {
                 name,
                 target: DescribeTarget::Portal,
-            } => self.get_portal_statement(name),
+            } => match state.portals.get(name).map(Arc::as_ref) {
+                Some(Portal::Encrypted { statement, .. }) => Some(statement.clone()),
+                Some(Portal::Passthrough { .. }) | None => None,
+            },
             Describe {
                 name,
                 target: DescribeTarget::Statement,
-            } => self.get_statement(name),
+            } => state.statements.get(name).cloned(),
         };
-        let _ = self.operations.write().map(|mut operations| {
-            operations.entry(operation).or_default().describe_statement = statement;
-        });
+        state.operations.entry(operation).or_default().describe =
+            Some(DescribeContext { statement });
+        Ok(())
+    }
+
+    pub fn set_non_execution(&self, operation: OperationId) -> Result<(), Error> {
+        self.protocol_state
+            .write()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?
+            .operations
+            .entry(operation)
+            .or_default();
+        Ok(())
+    }
+
+    pub fn complete_non_execution(&self, operation: OperationId) -> Result<(), Error> {
+        let mut state = self
+            .protocol_state
+            .write()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+        state.operations.remove(&operation);
+        Ok(())
     }
     ///
     /// Marks the current Describe as complete
     /// Removes the Describe from the Queue
     ///
-    pub fn complete_describe(&mut self, operation: OperationId) {
+    pub fn complete_describe(&self, operation: OperationId) -> Result<(), Error> {
         debug!(target: CONTEXT, client_id = self.client_id, msg = "Describe complete");
-        let _ = self.operations.write().map(|mut operations| {
-            if let Some(context) = operations.get_mut(&operation) {
-                context.describe_statement = None;
-                if context.execute.is_none() {
-                    operations.remove(&operation);
-                }
+        let mut state = self
+            .protocol_state
+            .write()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+        let Some(context) = state.operations.get_mut(&operation) else {
+            return Err(crate::error::ContextError::UnknownOperation.into());
+        };
+        if context.describe.take().is_none() {
+            if context.execute.is_some() {
+                return Ok(());
             }
-        });
+            state.operations.remove(&operation);
+            return Err(crate::error::ContextError::UnknownDescribe.into());
+        }
+        if context.execute.is_none() {
+            state.operations.remove(&operation);
+        }
+        Ok(())
     }
 
-    pub fn start_session(&mut self) -> SessionId {
+    pub fn start_metrics_scope(&mut self) -> SessionId {
         let id = SessionId(self.session_id_counter.fetch_add(1, Ordering::Relaxed));
         let ctx = SessionMetricsContext::new(id);
         let _ = self
-            .session_metrics
+            .protocol_state
             .write()
-            .map(|mut sessions| sessions.insert(id, ctx));
+            .map(|mut state| state.statement_metrics.insert(id, ctx));
         id
     }
 
-    pub fn finish_session(&mut self, session_id: Option<SessionId>) {
+    pub fn finish_metrics_scope(&mut self, session_id: Option<SessionId>) {
         debug!(target: CONTEXT, client_id = self.client_id, msg = "Session Metrics finished");
 
-        let session = session_id.and_then(|id| self.session_metrics.write().ok()?.remove(&id));
+        let session = session_id.and_then(|id| {
+            self.protocol_state
+                .write()
+                .ok()?
+                .statement_metrics
+                .remove(&id)
+        });
+        self.record_finished_session(session);
+    }
+
+    fn record_finished_session(&self, session: Option<SessionMetricsContext>) {
         if let Some(session) = session {
+            if !session.records_session {
+                return;
+            }
             let duration = session.duration();
             let metadata = &session.metadata;
 
@@ -308,57 +501,113 @@ where
         operation: OperationId,
         name: Name,
         session_id: Option<SessionId>,
-    ) {
+    ) -> Result<(), Error> {
+        debug!(target: CONTEXT, client_id = self.client_id, execute = ?name);
+        let mut state = self
+            .protocol_state
+            .write()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+        let portal = state.portals.get(&name).cloned();
+        let execute = ExecuteContext::new(name, portal, session_id);
+        state.operations.entry(operation).or_default().execute = Some(execute);
+        Ok(())
+    }
+
+    pub fn set_simple_query_execute_until_ready(
+        &mut self,
+        operation: OperationId,
+        name: Name,
+        session_id: Option<SessionId>,
+    ) -> Result<(), Error> {
         debug!(target: CONTEXT, client_id = self.client_id, execute = ?name);
 
-        let portal = self.get_portal(&name);
-        let ctx = ExecuteContext::new(name, portal, session_id);
-        let _ = self.operations.write().map(|mut operations| {
-            operations.entry(operation).or_default().execute = Some(ctx);
-        });
+        let mut state = self
+            .protocol_state
+            .write()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+        let portal = state.portals.get(&name).cloned();
+        let execute = ExecuteContext::new(name, portal, session_id).until_readiness();
+        state.operations.entry(operation).or_default().execute = Some(execute);
+        Ok(())
     }
 
     /// Set execute state for portal, looking up session ID internally.
-    pub fn set_execute_for_portal(&mut self, operation: OperationId, name: Name) {
-        let session_id = self.get_portal_session_id(&name);
-        self.set_execute(operation, name, session_id);
+    pub fn set_execute_for_portal(
+        &mut self,
+        operation: OperationId,
+        name: Name,
+    ) -> Result<(), Error> {
+        let execution_id = SessionId(self.session_id_counter.fetch_add(1, Ordering::Relaxed));
+        let mut state = self
+            .protocol_state
+            .write()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+        let portal = state.portals.get(&name).cloned();
+        let template_id = portal.as_ref().and_then(|portal| portal.session_id());
+        let execute = state
+            .suspended_executions
+            .remove(&name)
+            .map(|(_, execute)| execute)
+            .unwrap_or_else(|| {
+                let mut metrics = template_id
+                    .and_then(|id| state.statement_metrics.get(&id).cloned())
+                    .unwrap_or_else(|| SessionMetricsContext::new(execution_id));
+                metrics.id = execution_id;
+                metrics.start = Instant::now();
+                metrics.records_session = false;
+                state.statement_metrics.insert(execution_id, metrics);
+                ExecuteContext::new(name, portal, Some(execution_id))
+            });
+        state.operations.entry(operation).or_default().execute = Some(execute);
+        Ok(())
     }
 
-    /// Marks the current Execution as Complete.
-    ///
-    /// If the associated portal is Unnamed, it is closed.
-    ///
-    /// From the PostgreSQL Extended Query docs:
-    ///     If successfully created, a named portal object lasts till the end of the current transaction, unless explicitly destroyed.
-    ///     An unnamed portal is destroyed at the end of the transaction, or as soon as the next Bind statement specifying the unnamed portal as destination is issued
-    ///
-    /// https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
-    pub fn complete_execution(&mut self, operation: OperationId) -> Option<SessionId> {
-        debug!(target: CONTEXT, client_id = self.client_id, msg = "Execute complete");
+    /// Applies one terminal or suspended Execute outcome atomically.
+    pub fn finish_execution(
+        &self,
+        operation: OperationId,
+        outcome: ExecutionOutcome,
+    ) -> Result<Option<DiagnosticResponse>, Error> {
+        debug!(target: CONTEXT, client_id = self.client_id, ?outcome, msg = "Execute outcome");
 
-        let execute = self.operations.write().ok().and_then(|mut operations| {
-            let execute = operations.get_mut(&operation)?.execute.take();
-            if operations
-                .get(&operation)
-                .is_some_and(|context| context.describe_statement.is_none())
-            {
-                operations.remove(&operation);
+        let transition = {
+            let mut state = self
+                .protocol_state
+                .write()
+                .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+            state.finish_execution(&operation, outcome)?
+        };
+
+        if transition.execution_finished && outcome != ExecutionOutcome::Suspended {
+            if let Some(execute) = transition.execute.as_ref() {
+                self.record_execution_duration(execute, transition.metrics.as_ref());
+
+                if execute.name.is_empty() {
+                    self.close_portal_if_current(&execute.name, execute.portal.as_ref());
+                }
             }
-            execute
-        });
-        if let Some(execute) = execute {
-            // Get labels from current session metadata
-            let (statement_type, protocol, mapped, multi_statement) = if let Some(session) = execute
-                .session_id()
-                .and_then(|id| self.get_session_metrics(id))
-            {
+        }
+        self.record_finished_session(transition.finished_metrics);
+        Ok(transition.replacement_error)
+    }
+
+    fn record_execution_duration(
+        &self,
+        execute: &ExecuteContext,
+        metrics: Option<&SessionMetricsContext>,
+    ) {
+        let (statement_type, protocol, mapped, multi_statement) = metrics
+            .map(|session| {
                 let metadata = &session.metadata;
                 (
                     metadata
                         .statement_type
-                        .map(|t| t.as_label())
+                        .map(|kind| kind.as_label())
                         .unwrap_or("unknown"),
-                    metadata.protocol.map(|p| p.as_label()).unwrap_or("unknown"),
+                    metadata
+                        .protocol
+                        .map(|kind| kind.as_label())
+                        .unwrap_or("unknown"),
                     if metadata.encrypted { "true" } else { "false" },
                     if metadata.multi_statement {
                         "true"
@@ -366,65 +615,53 @@ where
                         "false"
                     },
                 )
-            } else {
-                ("unknown", "unknown", "false", "false")
-            };
-
-            histogram!(
-                STATEMENTS_EXECUTION_DURATION_SECONDS,
-                "statement_type" => statement_type,
-                "protocol" => protocol,
-                "mapped" => mapped,
-                "multi_statement" => multi_statement
-            )
-            .record(execute.duration());
-
-            if execute.name.is_empty() {
-                self.close_portal_if_current(&execute.name, execute.portal.as_ref());
-            }
-            return execute.session_id();
-        }
-        None
+            })
+            .unwrap_or(("unknown", "unknown", "false", "false"));
+        histogram!(
+            STATEMENTS_EXECUTION_DURATION_SECONDS,
+            "statement_type" => statement_type,
+            "protocol" => protocol,
+            "mapped" => mapped,
+            "multi_statement" => multi_statement
+        )
+        .record(execute.duration());
     }
 
-    pub fn add_statement(&mut self, name: Name, statement: Statement) {
+    pub fn add_statement(&self, name: Name, statement: Statement) -> Result<(), Error> {
         debug!(target: CONTEXT, client_id = self.client_id, statement = ?name);
-        let _ = self
-            .statements
+        self.protocol_state
             .write()
-            .map(|mut guarded| guarded.insert(name, Arc::new(statement)));
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?
+            .statements
+            .insert(name, Arc::new(statement));
+        Ok(())
     }
 
-    pub fn close_statement(&mut self, name: &Name) {
+    pub fn close_statement(&self, name: &Name) {
         debug!(target: CONTEXT, client_id = self.client_id, statement = ?name);
 
-        let session_id = self.get_statement_session(name);
-        let _ = self
-            .statements
-            .write()
-            .map(|mut guarded| guarded.remove(name));
-        let _ = self
-            .statement_sessions
-            .write()
-            .map(|mut guarded| guarded.remove(name));
-
-        let session_in_use = session_id.is_some_and(|session_id| {
-            self.portals.read().is_ok_and(|portals| {
-                portals
+        let finished_session = self.protocol_state.write().ok().and_then(|mut state| {
+            let session_id = state.statement_metrics_scopes.remove(name);
+            state.statements.remove(name);
+            let session_in_use = session_id.is_some_and(|session_id| {
+                state
+                    .portals
                     .values()
                     .any(|portal| portal.session_id() == Some(session_id))
-            }) || self.operations.read().is_ok_and(|operations| {
-                operations.values().any(|operation| {
-                    operation
-                        .execute
-                        .as_ref()
-                        .is_some_and(|execute| execute.session_id() == Some(session_id))
-                })
-            })
+                    || state.operations.values().any(|operation| {
+                        operation
+                            .execute
+                            .as_ref()
+                            .is_some_and(|execute| execute.session_id() == Some(session_id))
+                    })
+            });
+            if !session_in_use {
+                session_id.and_then(|session_id| state.statement_metrics.remove(&session_id))
+            } else {
+                None
+            }
         });
-        if !session_in_use {
-            self.finish_session(session_id);
-        }
+        self.record_finished_session(finished_session);
     }
 
     pub fn transaction_status(&self) -> TransactionStatus {
@@ -434,117 +671,239 @@ where
             .unwrap_or(TransactionStatus::Idle)
     }
 
-    pub fn set_transaction_status(&mut self, status: TransactionStatus) {
-        if let Ok(mut current) = self.transaction_status.write() {
-            *current = status;
+    pub fn ready_for_query(
+        &self,
+        status: TransactionStatus,
+        boundary: Option<OperationId>,
+    ) -> Result<(), Error> {
+        *self
+            .transaction_status
+            .write()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)? = status;
+        let Some(boundary) = boundary else {
+            return Ok(());
+        };
+
+        let (finished_executions, finished_sessions) = {
+            let mut state = self
+                .protocol_state
+                .write()
+                .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+            let mut candidates = Vec::new();
+            let mut executions = Vec::new();
+            if status == TransactionStatus::Idle {
+                let portal_names = state
+                    .portal_operations
+                    .iter()
+                    .filter_map(|(name, operation)| {
+                        (*operation <= boundary).then_some(name.clone())
+                    })
+                    .collect::<Vec<_>>();
+                for name in portal_names {
+                    state.portal_operations.remove(&name);
+                    candidates.extend(
+                        state
+                            .portals
+                            .remove(&name)
+                            .and_then(|portal| portal.session_id()),
+                    );
+                }
+
+                let suspended_names = state
+                    .suspended_executions
+                    .iter()
+                    .filter_map(|(name, (operation, _))| {
+                        (*operation <= boundary).then_some(name.clone())
+                    })
+                    .collect::<Vec<_>>();
+                for name in suspended_names {
+                    candidates.extend(
+                        state
+                            .suspended_executions
+                            .remove(&name)
+                            .and_then(|(_, execute)| execute.session_id()),
+                    );
+                }
+            }
+
+            let operation_ids = state
+                .operations
+                .keys()
+                .filter(|operation| **operation <= boundary)
+                .copied()
+                .collect::<Vec<_>>();
+            for operation in operation_ids {
+                if let Some(execute) = state
+                    .operations
+                    .remove(&operation)
+                    .and_then(|operation| operation.execute)
+                {
+                    let metrics = execute
+                        .session_id()
+                        .and_then(|id| state.statement_metrics.get(&id).cloned());
+                    candidates.extend(execute.session_id());
+                    executions.push((execute, metrics));
+                }
+            }
+            (executions, state.take_unreferenced_metrics(candidates))
+        };
+        for (execute, metrics) in finished_executions {
+            self.record_execution_duration(&execute, metrics.as_ref());
+            if execute.completes_at_readiness && execute.name.is_empty() {
+                self.close_portal_if_current(&execute.name, execute.portal.as_ref());
+            }
         }
+        for session in finished_sessions {
+            self.record_finished_session(Some(session));
+        }
+        Ok(())
     }
 
     /// Close a statement explicitly requested by the client.
     ///
     /// PostgreSQL portals retain the parsed statement they reference and remain
     /// valid after the statement name is closed, so they must not be removed.
-    pub fn close_statement_explicit(&mut self, name: &Name) {
+    pub fn close_statement_explicit(&self, name: &Name) {
         self.close_statement(name);
     }
 
     pub fn discard_operation(&mut self, operation: OperationId) {
-        let _ = self
-            .operations
-            .write()
-            .map(|mut operations| operations.remove(&operation));
+        let finished_session = self.protocol_state.write().ok().and_then(|mut state| {
+            let session_id = state
+                .operations
+                .remove(&operation)
+                .and_then(|operation| operation.execute)
+                .and_then(|execute| execute.session_id());
+            session_id.and_then(|session_id| state.statement_metrics.remove(&session_id))
+        });
+        self.record_finished_session(finished_session);
     }
 
     pub fn set_operation_error(&mut self, operation: OperationId, response: DiagnosticResponse) {
-        let _ = self.operations.write().map(|mut operations| {
-            operations.entry(operation).or_default().error_response = Some(response);
+        let _ = self.protocol_state.write().map(|mut state| {
+            state
+                .operations
+                .entry(operation)
+                .or_default()
+                .error_response = Some(response);
         });
     }
 
-    pub fn take_operation_error(&mut self, operation: OperationId) -> Option<DiagnosticResponse> {
-        self.operations
-            .write()
-            .ok()?
-            .get_mut(&operation)?
-            .error_response
-            .take()
-    }
-
-    pub fn add_portal(&mut self, name: Name, portal: Portal) {
+    pub fn add_portal(
+        &self,
+        operation: OperationId,
+        name: Name,
+        portal: Portal,
+    ) -> Result<(), Error> {
         debug!(target: CONTEXT, client_id = self.client_id, name = ?name, portal = ?portal);
-        let _ = self
-            .portals
-            .write()
-            .map(|mut portals| portals.insert(name, Arc::new(portal)));
+        let finished_metrics = {
+            let mut state = self
+                .protocol_state
+                .write()
+                .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+            let mut candidates = Vec::new();
+            candidates.extend(
+                state
+                    .portals
+                    .remove(&name)
+                    .and_then(|portal| portal.session_id()),
+            );
+            candidates.extend(
+                state
+                    .suspended_executions
+                    .remove(&name)
+                    .and_then(|(_, execute)| execute.session_id()),
+            );
+            state.portal_operations.insert(name.clone(), operation);
+            state.portals.insert(name, Arc::new(portal));
+            state.take_unreferenced_metrics(candidates)
+        };
+        for metrics in finished_metrics {
+            self.record_finished_session(Some(metrics));
+        }
+        Ok(())
     }
 
     pub fn get_statement(&self, name: &Name) -> Option<Arc<Statement>> {
         debug!(target: CONTEXT, client_id = self.client_id, statement = ?name);
-        let statements = self.statements.read().ok()?;
-        statements.get(name).cloned()
+        let state = self.protocol_state.read().ok()?;
+        state.statements.get(name).cloned()
     }
 
-    pub fn set_statement_session(&mut self, name: Name, session_id: SessionId) {
-        let _ = self
-            .statement_sessions
+    pub fn set_statement_session(
+        &mut self,
+        name: Name,
+        session_id: SessionId,
+    ) -> Result<(), Error> {
+        self.protocol_state
             .write()
-            .map(|mut sessions| sessions.insert(name, session_id));
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?
+            .statement_metrics_scopes
+            .insert(name, session_id);
+        Ok(())
     }
 
     pub fn get_statement_session(&self, name: &Name) -> Option<SessionId> {
-        let sessions = self.statement_sessions.read().ok()?;
-        sessions.get(name).copied()
-    }
-
-    /// Get session for statement, falling back to latest session with warning log.
-    pub fn get_statement_session_or_latest(&self, name: &Name) -> Option<SessionId> {
-        if let Some(id) = self.get_statement_session(name) {
-            return Some(id);
-        }
-
-        let fallback = self.latest_session_id();
-        if fallback.is_some() {
-            warn!(
-                target: CONTEXT,
-                client_id = self.client_id,
-                prepared_statement = %String::from_utf8_lossy(name),
-                msg = "Session lookup failed for prepared statement, using latest session"
-            );
-        }
-        fallback
+        let state = self.protocol_state.read().ok()?;
+        state.statement_metrics_scopes.get(name).copied()
     }
 
     ///
     /// Close the portal identified by `name`
     /// Portal is removed from  queue
     ///
-    pub fn close_portal(&mut self, name: &Name) {
+    pub fn close_portal(&self, name: &Name) -> Result<(), Error> {
         debug!(target: CONTEXT, client_id = self.client_id, msg = "Close Portal", name = ?name);
-        let _ = self.portals.write().map(|mut portals| portals.remove(name));
+        let finished_metrics = {
+            let mut state = self
+                .protocol_state
+                .write()
+                .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+            state.portal_operations.remove(name);
+            let mut candidates = Vec::new();
+            candidates.extend(
+                state
+                    .portals
+                    .remove(name)
+                    .and_then(|portal| portal.session_id()),
+            );
+            candidates.extend(
+                state
+                    .suspended_executions
+                    .remove(name)
+                    .and_then(|(_, execute)| execute.session_id()),
+            );
+            state.take_unreferenced_metrics(candidates)
+        };
+        for metrics in finished_metrics {
+            self.record_finished_session(Some(metrics));
+        }
+        Ok(())
     }
 
-    fn close_portal_if_current(&mut self, name: &Name, expected: Option<&Arc<Portal>>) {
-        let _ = self.portals.write().map(|mut portals| {
+    fn close_portal_if_current(&self, name: &Name, expected: Option<&Arc<Portal>>) {
+        let _ = self.protocol_state.write().map(|mut state| {
             if expected.is_some_and(|expected| {
-                portals
+                state
+                    .portals
                     .get(name)
                     .is_some_and(|current| Arc::ptr_eq(current, expected))
             }) {
-                portals.remove(name);
+                state.portals.remove(name);
+                state.portal_operations.remove(name);
             }
         });
     }
 
     pub fn get_portal(&self, name: &Name) -> Option<Arc<Portal>> {
         debug!(target: CONTEXT, client_id = self.client_id, src = "Get Portal", portal = ?name);
-        let portals = self.portals.read().ok()?;
-
-        portals.get(name).cloned()
+        let state = self.protocol_state.read().ok()?;
+        state.portals.get(name).cloned()
     }
 
     pub fn get_portal_statement(&self, name: &Name) -> Option<Arc<Statement>> {
-        let portals = self.portals.read().ok()?;
-        let portal = portals.get(name)?;
+        let state = self.protocol_state.read().ok()?;
+        let portal = state.portals.get(name)?;
 
         debug!(target: CONTEXT, client_id = self.client_id, portal = ?portal);
 
@@ -555,15 +914,19 @@ where
     }
 
     pub fn get_portal_session_id(&self, name: &Name) -> Option<SessionId> {
-        let portals = self.portals.read().ok()?;
-        let portal = portals.get(name)?;
+        let state = self.protocol_state.read().ok()?;
+        let portal = state.portals.get(name)?;
         portal.session_id()
     }
 
     pub fn get_statement_for_operation(&self, operation: OperationId) -> Option<Arc<Statement>> {
-        let operations = self.operations.read().ok()?;
-        let context = operations.get(&operation)?;
-        if let Some(statement) = &context.describe_statement {
+        let state = self.protocol_state.read().ok()?;
+        let context = state.operations.get(&operation)?;
+        if let Some(statement) = context
+            .describe
+            .as_ref()
+            .and_then(|describe| describe.statement.as_ref())
+        {
             return Some(statement.clone());
         }
         match context.execute.as_ref()?.portal.as_deref()? {
@@ -573,18 +936,22 @@ where
     }
 
     pub fn get_statement_from_describe(&self, operation: OperationId) -> Option<Arc<Statement>> {
-        self.operations
+        self.protocol_state
             .read()
             .ok()?
+            .operations
             .get(&operation)?
-            .describe_statement
+            .describe
+            .as_ref()?
+            .statement
             .clone()
     }
 
     pub fn get_portal_from_execute(&self, operation: OperationId) -> Option<Arc<Portal>> {
-        self.operations
+        self.protocol_state
             .read()
             .ok()?
+            .operations
             .get(&operation)?
             .execute
             .as_ref()?
@@ -593,17 +960,25 @@ where
     }
 
     pub fn get_execute(&self, operation: OperationId) -> Option<ExecuteContext> {
-        let operations = self.operations.read().ok()?;
-        let execute_context = operations.get(&operation)?.execute.as_ref()?;
+        let state = self.protocol_state.read().ok()?;
+        let execute_context = state.operations.get(&operation)?.execute.as_ref()?;
         debug!(target: CONTEXT, client_id = self.client_id, msg = "Get Execute", execute = ?execute_context);
         Some(execute_context.to_owned())
     }
 
     pub fn get_session_metrics(&self, session_id: SessionId) -> Option<SessionMetricsContext> {
-        let sessions = self.session_metrics.read().ok()?;
-        let session_context = sessions.get(&session_id)?;
+        let state = self.protocol_state.read().ok()?;
+        let session_context = state.statement_metrics.get(&session_id)?;
         debug!(target: CONTEXT, client_id = self.client_id, msg = "Get Session Metrics", session_metrics = ?session_context);
         Some(session_context.to_owned())
+    }
+
+    #[cfg(test)]
+    pub fn active_metrics_scopes(&self) -> usize {
+        self.protocol_state
+            .read()
+            .map(|state| state.statement_metrics.len())
+            .unwrap_or_default()
     }
 
     /// Returns the resolver for this connection's effective schema snapshot.
@@ -645,19 +1020,17 @@ where
         self.schema_middleware.protocol_boundary();
     }
 
-    /// Reports successful execution of the next queued statement.
-    pub fn schema_execution_succeeded(&self) {
-        self.schema_middleware.execution_succeeded();
-    }
-
-    /// Reports failed execution of the next queued statement.
-    pub fn schema_execution_failed(&self) {
-        self.schema_middleware.execution_failed();
-    }
-
     /// Waits for preceding schema-changing executions to resolve.
     pub async fn wait_for_schema_execution(&self) {
         self.schema_middleware.wait_for_ddl().await;
+    }
+
+    pub fn report_schema_execution_succeeded(&self) {
+        self.schema_middleware.execution_succeeded();
+    }
+
+    pub fn report_schema_execution_failed(&self) {
+        self.schema_middleware.execution_failed();
     }
 
     /// Returns whether a schema-changing execution is awaiting a backend outcome.
@@ -1054,16 +1427,11 @@ where
     where
         F: FnOnce(&mut SessionMetricsContext),
     {
-        if let Ok(mut sessions) = self.session_metrics.write() {
-            if let Some(session) = sessions.get_mut(&session_id) {
+        if let Ok(mut state) = self.protocol_state.write() {
+            if let Some(session) = state.statement_metrics.get_mut(&session_id) {
                 f(session);
             }
         }
-    }
-
-    pub fn latest_session_id(&self) -> Option<SessionId> {
-        let sessions = self.session_metrics.read().ok()?;
-        sessions.keys().max().copied()
     }
 
     /// Record parse phase duration for the session (first write wins)
@@ -1120,18 +1488,21 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{Context, KeysetIdentifier, Portal, Statement};
+    use super::{
+        ConnectionProtocolState, Context, ExecuteContext, ExecutionOutcome, KeysetIdentifier,
+        OperationContext, Portal, SessionId, SessionMetricsContext, Statement,
+    };
     use crate::{
         config::LogConfig,
         error::Error,
         log,
-        postgresql::{rewrite::Name, Column},
+        postgresql::{rewrite::Name, test_operation_id as operation_id, Column},
         proxy::{EncryptConfig, EncryptionService},
         TandemConfig,
     };
     use cipherstash_client::IdentifiedBy;
     use eql_mapper::Schema;
-    use pg_proto::TransactionStatus;
+    use pg_proto::{Describe, DescribeTarget, TransactionStatus};
     use sqltk::parser::{dialect::PostgreSqlDialect, parser::Parser};
     use std::sync::Arc;
     use tokio::sync::mpsc;
@@ -1166,6 +1537,171 @@ mod tests {
         ) -> Result<Vec<Option<cipherstash_client::encryption::Plaintext>>, Error> {
             Ok(vec![])
         }
+    }
+
+    #[test]
+    fn suspended_execution_retains_its_metrics_scope_until_resumed_completion() {
+        let session_id = SessionId(1);
+        let mut state = ConnectionProtocolState::<u64>::default();
+        state
+            .statement_metrics
+            .insert(session_id, SessionMetricsContext::new(session_id));
+        state.operations.insert(
+            1,
+            OperationContext {
+                execute: Some(ExecuteContext::new(Name::new(), None, Some(session_id))),
+                ..OperationContext::default()
+            },
+        );
+
+        let suspended = state
+            .finish_execution(&1, ExecutionOutcome::Suspended)
+            .unwrap();
+
+        assert!(suspended.finished_metrics.is_none());
+        assert!(state.statement_metrics.contains_key(&session_id));
+        assert!(!state.operations.contains_key(&1));
+
+        state.operations.insert(
+            2,
+            OperationContext {
+                execute: Some(ExecuteContext::new(Name::new(), None, Some(session_id))),
+                ..OperationContext::default()
+            },
+        );
+        let completed = state
+            .finish_execution(&2, ExecutionOutcome::Completed)
+            .unwrap();
+
+        assert_eq!(
+            completed.finished_metrics.map(|metrics| metrics.id()),
+            Some(session_id)
+        );
+        assert!(!state.statement_metrics.contains_key(&session_id));
+        assert!(!state.operations.contains_key(&2));
+    }
+
+    #[test]
+    fn execution_transition_rejects_stale_and_non_execute_operations() {
+        let mut state = ConnectionProtocolState::<u64>::default();
+
+        assert!(matches!(
+            state.finish_execution(&1, ExecutionOutcome::Completed),
+            Err(crate::error::ContextError::UnknownOperation)
+        ));
+
+        state.operations.insert(1, OperationContext::default());
+        assert!(matches!(
+            state.finish_execution(&1, ExecutionOutcome::Completed),
+            Err(crate::error::ContextError::OperationWithoutExecute)
+        ));
+    }
+
+    #[test]
+    fn failed_execution_rejects_an_unknown_operation() {
+        let context = create_context();
+
+        assert!(matches!(
+            context.finish_execution(operation_id(), ExecutionOutcome::Failed),
+            Err(Error::Context(crate::error::ContextError::UnknownOperation))
+        ));
+    }
+
+    #[test]
+    fn adding_a_statement_fails_when_protocol_state_is_unavailable() {
+        let context = create_context();
+        let protocol_state = context.protocol_state.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = protocol_state.write().unwrap();
+            panic!("poison protocol state");
+        })
+        .join();
+
+        assert!(matches!(
+            context.add_statement(
+                Name::new(),
+                Statement::new(vec![], vec![], vec![], vec![], vec![]),
+            ),
+            Err(Error::Context(
+                crate::error::ContextError::ProtocolStateUnavailable
+            ))
+        ));
+    }
+
+    #[test]
+    fn adding_a_portal_fails_when_protocol_state_is_unavailable() {
+        let context = create_context();
+        let protocol_state = context.protocol_state.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = protocol_state.write().unwrap();
+            panic!("poison protocol state");
+        })
+        .join();
+
+        assert!(matches!(
+            context.add_portal(operation_id(), Name::new(), Portal::passthrough(None)),
+            Err(Error::Context(
+                crate::error::ContextError::ProtocolStateUnavailable
+            ))
+        ));
+    }
+
+    #[test]
+    fn associating_statement_metrics_fails_when_protocol_state_is_unavailable() {
+        let mut context = create_context();
+        let protocol_state = context.protocol_state.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = protocol_state.write().unwrap();
+            panic!("poison protocol state");
+        })
+        .join();
+
+        assert!(matches!(
+            context.set_statement_session(Name::new(), SessionId(1)),
+            Err(Error::Context(
+                crate::error::ContextError::ProtocolStateUnavailable
+            ))
+        ));
+    }
+
+    #[test]
+    fn completing_an_unknown_describe_rejects_the_stale_operation() {
+        let context = create_context();
+
+        assert!(matches!(
+            context.complete_describe(operation_id()),
+            Err(Error::Context(crate::error::ContextError::UnknownOperation))
+        ));
+    }
+
+    #[test]
+    fn completing_an_operation_without_describe_rejects_and_removes_it() {
+        let mut context = create_context();
+        let operation = operation_id();
+        context.set_operation_error(
+            operation,
+            crate::postgresql::diagnostics::invalid_sql_statement("proxy error".to_owned()),
+        );
+
+        assert!(matches!(
+            context.complete_describe(operation),
+            Err(Error::Context(crate::error::ContextError::UnknownDescribe))
+        ));
+        assert!(matches!(
+            context.complete_describe(operation),
+            Err(Error::Context(crate::error::ContextError::UnknownOperation))
+        ));
+    }
+
+    #[test]
+    fn row_description_for_an_execution_does_not_require_describe_state() {
+        let mut context = create_context();
+        let operation = operation_id();
+        context.set_execute(operation, Name::new(), None).unwrap();
+
+        context.complete_describe(operation).unwrap();
+
+        assert!(context.get_execute(operation).is_some());
     }
 
     fn create_context() -> Context<TestService> {
@@ -1218,12 +1754,17 @@ mod tests {
     fn replacing_a_statement_does_not_finish_an_overlapping_execution_session() {
         let mut context = create_context();
         let name = Name::default();
-        let session_id = context.start_session();
-        context.set_statement_session(name.clone(), session_id);
-        context.add_portal(
-            Name::from("active_portal"),
-            Portal::passthrough(Some(session_id)),
-        );
+        let session_id = context.start_metrics_scope();
+        context
+            .set_statement_session(name.clone(), session_id)
+            .unwrap();
+        context
+            .add_portal(
+                operation_id(),
+                Name::from("active_portal"),
+                Portal::passthrough(Some(session_id)),
+            )
+            .unwrap();
 
         context.close_statement(&name);
 
@@ -1232,33 +1773,92 @@ mod tests {
     }
 
     #[test]
+    fn readiness_releases_reparsed_statement_metrics_after_their_portal_is_destroyed() {
+        let mut context = create_context();
+        let statement = Name::from("statement");
+        let scope = context.start_metrics_scope();
+        context
+            .set_statement_session(statement.clone(), scope)
+            .unwrap();
+        context
+            .add_portal(
+                operation_id(),
+                Name::from("named_portal"),
+                Portal::passthrough(Some(scope)),
+            )
+            .unwrap();
+
+        context.close_statement(&statement);
+        assert!(context.get_session_metrics(scope).is_some());
+
+        context
+            .ready_for_query(TransactionStatus::Idle, Some(operation_id()))
+            .unwrap();
+
+        assert!(context.get_session_metrics(scope).is_none());
+    }
+
+    #[test]
     fn closing_an_unreferenced_statement_finishes_its_metrics_session() {
         let mut context = create_context();
         let name = Name::default();
-        let session_id = context.start_session();
-        context.set_statement_session(name.clone(), session_id);
+        let session_id = context.start_metrics_scope();
+        context
+            .set_statement_session(name.clone(), session_id)
+            .unwrap();
+        let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
 
-        context.close_statement_explicit(&name);
+        metrics::with_local_recorder(&recorder, || {
+            context.close_statement_explicit(&name);
+        });
 
         assert!(context.get_session_metrics(session_id).is_none());
+        let rendered = handle.render();
+        assert!(
+            rendered.contains("cipherstash_proxy_statements_session_duration_seconds_count"),
+            "{rendered}"
+        );
     }
 
     #[test]
     fn replacing_a_statement_retains_existing_portals() {
-        let mut context = create_context();
+        let context = create_context();
         let closed_statement_name = Name::from("closed_statement");
         let retained_statement_name = Name::from("retained_statement");
-        context.add_statement(closed_statement_name.clone(), statement());
-        context.add_statement(retained_statement_name.clone(), statement());
+        context
+            .add_statement(closed_statement_name.clone(), statement())
+            .unwrap();
+        context
+            .add_statement(retained_statement_name.clone(), statement())
+            .unwrap();
 
         let closed_statement = context.get_statement(&closed_statement_name).unwrap();
         let retained_statement = context.get_statement(&retained_statement_name).unwrap();
         let closed_portal_name = Name::from("differently_named_portal");
         let retained_portal_name = Name::from("retained_portal");
         let passthrough_portal_name = Name::from("passthrough_portal");
-        context.add_portal(closed_portal_name.clone(), portal(&closed_statement));
-        context.add_portal(retained_portal_name.clone(), portal(&retained_statement));
-        context.add_portal(passthrough_portal_name.clone(), Portal::passthrough(None));
+        context
+            .add_portal(
+                operation_id(),
+                closed_portal_name.clone(),
+                portal(&closed_statement),
+            )
+            .unwrap();
+        context
+            .add_portal(
+                operation_id(),
+                retained_portal_name.clone(),
+                portal(&retained_statement),
+            )
+            .unwrap();
+        context
+            .add_portal(
+                operation_id(),
+                passthrough_portal_name.clone(),
+                Portal::passthrough(None),
+            )
+            .unwrap();
 
         context.close_statement(&closed_statement_name);
 
@@ -1269,15 +1869,293 @@ mod tests {
 
     #[test]
     fn transaction_status_tracks_backend_ready_state() {
-        let mut context = create_context();
+        let context = create_context();
         assert_eq!(context.transaction_status(), TransactionStatus::Idle);
 
-        context.set_transaction_status(TransactionStatus::InTransaction);
+        context
+            .ready_for_query(TransactionStatus::InTransaction, None)
+            .unwrap();
 
         assert_eq!(
             context.transaction_status(),
             TransactionStatus::InTransaction
         );
+    }
+
+    #[test]
+    fn idle_readiness_finishes_abandoned_suspended_execution_metrics() {
+        let mut context = create_context();
+        let portal = Name::from("limited_portal");
+        let template_scope = context.start_metrics_scope();
+        context
+            .add_portal(
+                operation_id(),
+                portal.clone(),
+                Portal::passthrough(Some(template_scope)),
+            )
+            .unwrap();
+        let operation = operation_id();
+        context.set_execute_for_portal(operation, portal).unwrap();
+        let execution_scope = context
+            .get_execute(operation)
+            .and_then(|execute| execute.session_id())
+            .unwrap();
+        context
+            .finish_execution(operation, ExecutionOutcome::Suspended)
+            .unwrap();
+
+        context
+            .ready_for_query(TransactionStatus::Idle, Some(operation_id()))
+            .unwrap();
+
+        assert!(context.get_session_metrics(execution_scope).is_none());
+    }
+
+    #[test]
+    fn idle_readiness_finishes_simple_query_execution() {
+        let mut context = create_context();
+        let operation = operation_id();
+        let scope = context.start_metrics_scope();
+        context
+            .set_simple_query_execute_until_ready(operation, Name::new(), Some(scope))
+            .unwrap();
+        context
+            .finish_execution(operation, ExecutionOutcome::Completed)
+            .unwrap();
+        let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+
+        metrics::with_local_recorder(&recorder, || {
+            context
+                .ready_for_query(TransactionStatus::Idle, Some(operation))
+                .unwrap();
+        });
+
+        assert!(context.get_execute(operation).is_none());
+        assert!(context.get_session_metrics(scope).is_none());
+        assert!(handle
+            .render()
+            .contains("cipherstash_proxy_statements_execution_duration_seconds_count"));
+    }
+
+    #[test]
+    fn readiness_for_one_query_preserves_later_pipelined_work() {
+        let mut context = create_context();
+        let query_a = operation_id();
+        let query_a_scope = context.start_metrics_scope();
+        context
+            .set_simple_query_execute_until_ready(query_a, Name::new(), Some(query_a_scope))
+            .unwrap();
+
+        let portal_b = Name::from("pipeline_b");
+        let bind_b = operation_id();
+        context
+            .add_portal(bind_b, portal_b.clone(), Portal::passthrough(None))
+            .unwrap();
+        let describe_b = operation_id();
+        context
+            .set_describe(
+                describe_b,
+                Describe {
+                    target: DescribeTarget::Portal,
+                    name: portal_b.clone(),
+                },
+            )
+            .unwrap();
+        let execute_b = operation_id();
+        context
+            .set_execute_for_portal(execute_b, portal_b.clone())
+            .unwrap();
+
+        context
+            .ready_for_query(TransactionStatus::Idle, Some(query_a))
+            .unwrap();
+
+        assert!(context.get_session_metrics(query_a_scope).is_none());
+        assert!(context.get_portal(&portal_b).is_some());
+        assert!(context.complete_describe(describe_b).is_ok());
+        assert!(context.get_execute(execute_b).is_some());
+    }
+
+    #[test]
+    fn transaction_readiness_finishes_one_query_and_preserves_later_pipelined_work() {
+        let mut context = create_context();
+        let query_a = operation_id();
+        let query_a_scope = context.start_metrics_scope();
+        context
+            .set_simple_query_execute_until_ready(query_a, Name::new(), Some(query_a_scope))
+            .unwrap();
+
+        let query_b = operation_id();
+        let query_b_scope = context.start_metrics_scope();
+        context
+            .set_simple_query_execute_until_ready(query_b, Name::new(), Some(query_b_scope))
+            .unwrap();
+
+        context
+            .ready_for_query(TransactionStatus::InTransaction, Some(query_a))
+            .unwrap();
+
+        assert!(context.get_execute(query_a).is_none());
+        assert!(context.get_session_metrics(query_a_scope).is_none());
+        assert!(context.get_execute(query_b).is_some());
+        assert!(context.get_session_metrics(query_b_scope).is_some());
+    }
+
+    #[test]
+    fn closing_a_suspended_portal_finishes_its_execution_metrics() {
+        let mut context = create_context();
+        let portal = Name::from("limited_portal");
+        let template_scope = context.start_metrics_scope();
+        context
+            .add_portal(
+                operation_id(),
+                portal.clone(),
+                Portal::passthrough(Some(template_scope)),
+            )
+            .unwrap();
+        let operation = operation_id();
+        context
+            .set_execute_for_portal(operation, portal.clone())
+            .unwrap();
+        let execution_scope = context
+            .get_execute(operation)
+            .and_then(|execute| execute.session_id())
+            .unwrap();
+        context
+            .finish_execution(operation, ExecutionOutcome::Suspended)
+            .unwrap();
+        let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+
+        metrics::with_local_recorder(&recorder, || {
+            context.close_portal(&portal).unwrap();
+        });
+
+        assert!(context.get_session_metrics(execution_scope).is_none());
+        let rendered = handle.render();
+        let count = rendered
+            .lines()
+            .find(|line| {
+                line.starts_with("cipherstash_proxy_statements_session_duration_seconds_count")
+            })
+            .unwrap();
+        assert!(count.ends_with(" 1"), "{rendered}");
+    }
+
+    #[test]
+    fn rebinding_a_suspended_portal_starts_a_new_execution_occurrence() {
+        let mut context = create_context();
+        let portal_name = Name::new();
+        let first_template = context.start_metrics_scope();
+        context
+            .add_portal(
+                operation_id(),
+                portal_name.clone(),
+                Portal::passthrough(Some(first_template)),
+            )
+            .unwrap();
+        let operation = operation_id();
+        context
+            .set_execute_for_portal(operation, portal_name.clone())
+            .unwrap();
+        let first_execution = context
+            .get_execute(operation)
+            .unwrap()
+            .session_id()
+            .unwrap();
+        context
+            .finish_execution(operation, ExecutionOutcome::Suspended)
+            .unwrap();
+
+        let rebound_template = context.start_metrics_scope();
+        context
+            .add_portal(
+                operation_id(),
+                portal_name.clone(),
+                Portal::passthrough(Some(rebound_template)),
+            )
+            .unwrap();
+        context
+            .set_execute_for_portal(operation, portal_name)
+            .unwrap();
+
+        assert_eq!(
+            context
+                .get_portal_from_execute(operation)
+                .and_then(|portal| portal.session_id()),
+            Some(rebound_template)
+        );
+        assert!(context.get_session_metrics(first_execution).is_none());
+    }
+
+    #[test]
+    fn closing_a_portal_fails_when_protocol_state_is_unavailable() {
+        let context = create_context();
+        let protocol_state = context.protocol_state.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = protocol_state.write().unwrap();
+            panic!("poison protocol state");
+        })
+        .join();
+
+        assert!(matches!(
+            context.close_portal(&Name::new()),
+            Err(Error::Context(
+                crate::error::ContextError::ProtocolStateUnavailable
+            ))
+        ));
+    }
+
+    #[test]
+    fn discarding_an_unfinished_operation_releases_its_execution_metrics() {
+        let mut context = create_context();
+        let portal = Name::from("skipped_portal");
+        let template_scope = context.start_metrics_scope();
+        context
+            .add_portal(
+                operation_id(),
+                portal.clone(),
+                Portal::passthrough(Some(template_scope)),
+            )
+            .unwrap();
+        let operation = operation_id();
+        context.set_execute_for_portal(operation, portal).unwrap();
+        let execution_scope = context
+            .get_execute(operation)
+            .and_then(|execute| execute.session_id())
+            .unwrap();
+
+        context.discard_operation(operation);
+
+        assert!(context.get_execute(operation).is_none());
+        assert!(context.get_session_metrics(execution_scope).is_none());
+    }
+
+    #[test]
+    fn simple_query_execution_finishes_only_at_readiness() {
+        let mut context = create_context();
+        let operation = operation_id();
+        let scope = context.start_metrics_scope();
+        context
+            .set_simple_query_execute_until_ready(operation, Name::new(), Some(scope))
+            .unwrap();
+
+        context
+            .finish_execution(operation, ExecutionOutcome::Completed)
+            .unwrap();
+        assert!(context.get_execute(operation).is_some());
+
+        context
+            .finish_execution(operation, ExecutionOutcome::Completed)
+            .unwrap();
+        assert!(context.get_execute(operation).is_some());
+
+        context
+            .ready_for_query(TransactionStatus::Idle, Some(operation))
+            .unwrap();
+        assert!(context.get_execute(operation).is_none());
+        assert!(context.get_session_metrics(scope).is_none());
     }
 
     fn get_statement(portal: Arc<Portal>) -> Arc<Statement> {
@@ -1293,27 +2171,35 @@ mod tests {
     pub fn add_and_close_portals() {
         log::init(LogConfig::default());
 
-        let mut context = create_context();
+        let context = create_context();
 
         // Create multiple statements
         let statement_name_1 = Name::from("statement_1");
         let statement_name_2 = Name::from("statement_2");
 
         // Add statements to context
-        context.add_statement(statement_name_1.clone(), statement());
-        context.add_statement(statement_name_2.clone(), statement());
+        context
+            .add_statement(statement_name_1.clone(), statement())
+            .unwrap();
+        context
+            .add_statement(statement_name_2.clone(), statement())
+            .unwrap();
 
         let portal_name = Name::from("portal");
 
         let statement_1 = context.get_statement(&statement_name_1).unwrap();
-        context.add_portal(portal_name.clone(), portal(&statement_1));
+        context
+            .add_portal(operation_id(), portal_name.clone(), portal(&statement_1))
+            .unwrap();
 
         let statement_2 = context.get_statement(&statement_name_2).unwrap();
-        context.add_portal(portal_name.clone(), portal(&statement_2));
+        context
+            .add_portal(operation_id(), portal_name.clone(), portal(&statement_2))
+            .unwrap();
 
         let portal = context.get_portal(&portal_name).unwrap();
         assert_eq!(statement_2, get_statement(portal));
-        context.close_portal(&portal_name);
+        context.close_portal(&portal_name).unwrap();
         assert!(context.get_portal(&portal_name).is_none());
     }
 

--- a/packages/cipherstash-proxy/src/postgresql/context/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/context/mod.rs
@@ -4,7 +4,7 @@ pub mod portal;
 pub mod statement;
 pub mod statement_metadata;
 pub use self::{phase_timing::PhaseTiming, portal::Portal, statement::Statement};
-use super::{column_mapper::ColumnMapper, rewrite::Name, Column};
+use super::{column_mapper::ColumnMapper, rewrite::Name, Column, OperationId};
 use crate::{
     config::TandemConfig,
     error::{ConfigError, EncryptError, Error},
@@ -21,7 +21,7 @@ use crate::{
 use cipherstash_client::IdentifiedBy;
 use eql_mapper::{Schema, TableResolver};
 use metrics::{counter, histogram};
-use pg_proto::{Describe, DescribeTarget, DiagnosticResponse, OperationId, TransactionStatus};
+use pg_proto::{Describe, DescribeTarget, DiagnosticResponse, TransactionStatus};
 use serde_json::json;
 use sqltk::parser::ast::{Expr, Ident, ObjectName, ObjectNamePart, Set, Value, ValueWithSpan};
 pub use statement_metadata::StatementMetadata;
@@ -39,6 +39,23 @@ use uuid::Uuid;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct SessionId(u64);
+
+#[cfg(test)]
+pub trait ResultOptionTestExt {
+    fn is_some(&self) -> bool;
+    fn is_none(&self) -> bool;
+}
+
+#[cfg(test)]
+impl<T> ResultOptionTestExt for Result<Option<T>, Error> {
+    fn is_some(&self) -> bool {
+        self.as_ref().unwrap().is_some()
+    }
+
+    fn is_none(&self) -> bool {
+        self.as_ref().unwrap().is_none()
+    }
+}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct KeysetIdentifier(pub IdentifiedBy);
@@ -407,27 +424,28 @@ where
         Ok(())
     }
 
-    pub fn start_metrics_scope(&mut self) -> SessionId {
+    pub fn start_metrics_scope(&mut self) -> Result<SessionId, Error> {
         let id = SessionId(self.session_id_counter.fetch_add(1, Ordering::Relaxed));
         let ctx = SessionMetricsContext::new(id);
-        let _ = self
-            .protocol_state
+        self.protocol_state
             .write()
-            .map(|mut state| state.statement_metrics.insert(id, ctx));
-        id
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?
+            .statement_metrics
+            .insert(id, ctx);
+        Ok(id)
     }
 
-    pub fn finish_metrics_scope(&mut self, session_id: Option<SessionId>) {
+    pub fn finish_metrics_scope(&mut self, session_id: Option<SessionId>) -> Result<(), Error> {
         debug!(target: CONTEXT, client_id = self.client_id, msg = "Session Metrics finished");
 
-        let session = session_id.and_then(|id| {
-            self.protocol_state
-                .write()
-                .ok()?
-                .statement_metrics
-                .remove(&id)
-        });
+        let mut state = self
+            .protocol_state
+            .write()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+        let session = session_id.and_then(|id| state.statement_metrics.remove(&id));
+        drop(state);
         self.record_finished_session(session);
+        Ok(())
     }
 
     fn record_finished_session(&self, session: Option<SessionMetricsContext>) {
@@ -554,7 +572,7 @@ where
                     .unwrap_or_else(|| SessionMetricsContext::new(execution_id));
                 metrics.id = execution_id;
                 metrics.start = Instant::now();
-                metrics.records_session = false;
+                metrics.records_session = true;
                 state.statement_metrics.insert(execution_id, metrics);
                 ExecuteContext::new(name, portal, Some(execution_id))
             });
@@ -583,7 +601,7 @@ where
                 self.record_execution_duration(execute, transition.metrics.as_ref());
 
                 if execute.name.is_empty() {
-                    self.close_portal_if_current(&execute.name, execute.portal.as_ref());
+                    self.close_portal_if_current(&execute.name, execute.portal.as_ref())?;
                 }
             }
         }
@@ -637,31 +655,25 @@ where
         Ok(())
     }
 
-    pub fn close_statement(&self, name: &Name) {
+    pub fn close_statement(&self, name: &Name) -> Result<(), Error> {
         debug!(target: CONTEXT, client_id = self.client_id, statement = ?name);
 
-        let finished_session = self.protocol_state.write().ok().and_then(|mut state| {
+        let finished_session = {
+            let mut state = self
+                .protocol_state
+                .write()
+                .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
             let session_id = state.statement_metrics_scopes.remove(name);
             state.statements.remove(name);
-            let session_in_use = session_id.is_some_and(|session_id| {
-                state
-                    .portals
-                    .values()
-                    .any(|portal| portal.session_id() == Some(session_id))
-                    || state.operations.values().any(|operation| {
-                        operation
-                            .execute
-                            .as_ref()
-                            .is_some_and(|execute| execute.session_id() == Some(session_id))
-                    })
-            });
+            let session_in_use = session_id.is_some_and(|id| state.metrics_referenced(id));
             if !session_in_use {
                 session_id.and_then(|session_id| state.statement_metrics.remove(&session_id))
             } else {
                 None
             }
-        });
+        };
         self.record_finished_session(finished_session);
+        Ok(())
     }
 
     pub fn transaction_status(&self) -> TransactionStatus {
@@ -750,7 +762,7 @@ where
         for (execute, metrics) in finished_executions {
             self.record_execution_duration(&execute, metrics.as_ref());
             if execute.completes_at_readiness && execute.name.is_empty() {
-                self.close_portal_if_current(&execute.name, execute.portal.as_ref());
+                self.close_portal_if_current(&execute.name, execute.portal.as_ref())?;
             }
         }
         for session in finished_sessions {
@@ -763,30 +775,40 @@ where
     ///
     /// PostgreSQL portals retain the parsed statement they reference and remain
     /// valid after the statement name is closed, so they must not be removed.
-    pub fn close_statement_explicit(&self, name: &Name) {
-        self.close_statement(name);
+    pub fn close_statement_explicit(&self, name: &Name) -> Result<(), Error> {
+        self.close_statement(name)
     }
 
-    pub fn discard_operation(&mut self, operation: OperationId) {
-        let finished_session = self.protocol_state.write().ok().and_then(|mut state| {
+    pub fn discard_operation(&mut self, operation: OperationId) -> Result<(), Error> {
+        let finished_session = {
+            let mut state = self
+                .protocol_state
+                .write()
+                .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
             let session_id = state
                 .operations
                 .remove(&operation)
                 .and_then(|operation| operation.execute)
                 .and_then(|execute| execute.session_id());
             session_id.and_then(|session_id| state.statement_metrics.remove(&session_id))
-        });
+        };
         self.record_finished_session(finished_session);
+        Ok(())
     }
 
-    pub fn set_operation_error(&mut self, operation: OperationId, response: DiagnosticResponse) {
-        let _ = self.protocol_state.write().map(|mut state| {
-            state
-                .operations
-                .entry(operation)
-                .or_default()
-                .error_response = Some(response);
-        });
+    pub fn set_operation_error(
+        &mut self,
+        operation: OperationId,
+        response: DiagnosticResponse,
+    ) -> Result<(), Error> {
+        self.protocol_state
+            .write()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?
+            .operations
+            .entry(operation)
+            .or_default()
+            .error_response = Some(response);
+        Ok(())
     }
 
     pub fn add_portal(
@@ -824,10 +846,13 @@ where
         Ok(())
     }
 
-    pub fn get_statement(&self, name: &Name) -> Option<Arc<Statement>> {
+    pub fn get_statement(&self, name: &Name) -> Result<Option<Arc<Statement>>, Error> {
         debug!(target: CONTEXT, client_id = self.client_id, statement = ?name);
-        let state = self.protocol_state.read().ok()?;
-        state.statements.get(name).cloned()
+        let state = self
+            .protocol_state
+            .read()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+        Ok(state.statements.get(name).cloned())
     }
 
     pub fn set_statement_session(
@@ -835,17 +860,23 @@ where
         name: Name,
         session_id: SessionId,
     ) -> Result<(), Error> {
-        self.protocol_state
+        let mut state = self
+            .protocol_state
             .write()
-            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?
-            .statement_metrics_scopes
-            .insert(name, session_id);
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+        if let Some(metrics) = state.statement_metrics.get_mut(&session_id) {
+            metrics.records_session = false;
+        }
+        state.statement_metrics_scopes.insert(name, session_id);
         Ok(())
     }
 
-    pub fn get_statement_session(&self, name: &Name) -> Option<SessionId> {
-        let state = self.protocol_state.read().ok()?;
-        state.statement_metrics_scopes.get(name).copied()
+    pub fn get_statement_session(&self, name: &Name) -> Result<Option<SessionId>, Error> {
+        let state = self
+            .protocol_state
+            .read()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+        Ok(state.statement_metrics_scopes.get(name).copied())
     }
 
     ///
@@ -881,104 +912,161 @@ where
         Ok(())
     }
 
-    fn close_portal_if_current(&self, name: &Name, expected: Option<&Arc<Portal>>) {
-        let _ = self.protocol_state.write().map(|mut state| {
-            if expected.is_some_and(|expected| {
-                state
-                    .portals
-                    .get(name)
-                    .is_some_and(|current| Arc::ptr_eq(current, expected))
-            }) {
-                state.portals.remove(name);
-                state.portal_operations.remove(name);
-            }
-        });
+    fn close_portal_if_current(
+        &self,
+        name: &Name,
+        expected: Option<&Arc<Portal>>,
+    ) -> Result<(), Error> {
+        let mut state = self
+            .protocol_state
+            .write()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+        if expected.is_some_and(|expected| {
+            state
+                .portals
+                .get(name)
+                .is_some_and(|current| Arc::ptr_eq(current, expected))
+        }) {
+            state.portals.remove(name);
+            state.portal_operations.remove(name);
+        }
+        Ok(())
     }
 
-    pub fn get_portal(&self, name: &Name) -> Option<Arc<Portal>> {
+    pub fn get_portal(&self, name: &Name) -> Result<Option<Arc<Portal>>, Error> {
         debug!(target: CONTEXT, client_id = self.client_id, src = "Get Portal", portal = ?name);
-        let state = self.protocol_state.read().ok()?;
-        state.portals.get(name).cloned()
+        let state = self
+            .protocol_state
+            .read()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+        Ok(state.portals.get(name).cloned())
     }
 
-    pub fn get_portal_statement(&self, name: &Name) -> Option<Arc<Statement>> {
-        let state = self.protocol_state.read().ok()?;
-        let portal = state.portals.get(name)?;
+    pub fn get_portal_statement(&self, name: &Name) -> Result<Option<Arc<Statement>>, Error> {
+        let state = self
+            .protocol_state
+            .read()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+        let Some(portal) = state.portals.get(name) else {
+            return Ok(None);
+        };
 
         debug!(target: CONTEXT, client_id = self.client_id, portal = ?portal);
 
-        match portal.as_ref() {
+        Ok(match portal.as_ref() {
             Portal::Encrypted { statement, .. } => Some(statement.clone()),
             Portal::Passthrough { .. } => None,
-        }
+        })
     }
 
-    pub fn get_portal_session_id(&self, name: &Name) -> Option<SessionId> {
-        let state = self.protocol_state.read().ok()?;
-        let portal = state.portals.get(name)?;
-        portal.session_id()
+    pub fn get_portal_session_id(&self, name: &Name) -> Result<Option<SessionId>, Error> {
+        let state = self
+            .protocol_state
+            .read()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+        Ok(state
+            .portals
+            .get(name)
+            .and_then(|portal| portal.session_id()))
     }
 
-    pub fn get_statement_for_operation(&self, operation: OperationId) -> Option<Arc<Statement>> {
-        let state = self.protocol_state.read().ok()?;
-        let context = state.operations.get(&operation)?;
+    pub fn get_statement_for_operation(
+        &self,
+        operation: OperationId,
+    ) -> Result<Option<Arc<Statement>>, Error> {
+        let state = self
+            .protocol_state
+            .read()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+        let Some(context) = state.operations.get(&operation) else {
+            return Ok(None);
+        };
         if let Some(statement) = context
             .describe
             .as_ref()
             .and_then(|describe| describe.statement.as_ref())
         {
-            return Some(statement.clone());
+            return Ok(Some(statement.clone()));
         }
-        match context.execute.as_ref()?.portal.as_deref()? {
-            Portal::Encrypted { statement, .. } => Some(statement.clone()),
-            Portal::Passthrough { .. } => None,
-        }
+        Ok(
+            match context
+                .execute
+                .as_ref()
+                .and_then(|execute| execute.portal.as_deref())
+            {
+                Some(Portal::Encrypted { statement, .. }) => Some(statement.clone()),
+                Some(Portal::Passthrough { .. }) | None => None,
+            },
+        )
     }
 
-    pub fn get_statement_from_describe(&self, operation: OperationId) -> Option<Arc<Statement>> {
-        self.protocol_state
+    pub fn get_statement_from_describe(
+        &self,
+        operation: OperationId,
+    ) -> Result<Option<Arc<Statement>>, Error> {
+        let state = self
+            .protocol_state
             .read()
-            .ok()?
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+        Ok(state
             .operations
-            .get(&operation)?
-            .describe
-            .as_ref()?
-            .statement
-            .clone()
+            .get(&operation)
+            .and_then(|context| context.describe.as_ref())
+            .and_then(|describe| describe.statement.clone()))
     }
 
-    pub fn get_portal_from_execute(&self, operation: OperationId) -> Option<Arc<Portal>> {
-        self.protocol_state
+    pub fn get_portal_from_execute(
+        &self,
+        operation: OperationId,
+    ) -> Result<Option<Arc<Portal>>, Error> {
+        let state = self
+            .protocol_state
             .read()
-            .ok()?
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+        Ok(state
             .operations
-            .get(&operation)?
-            .execute
-            .as_ref()?
-            .portal
-            .clone()
+            .get(&operation)
+            .and_then(|context| context.execute.as_ref())
+            .and_then(|execute| execute.portal.clone()))
     }
 
-    pub fn get_execute(&self, operation: OperationId) -> Option<ExecuteContext> {
-        let state = self.protocol_state.read().ok()?;
-        let execute_context = state.operations.get(&operation)?.execute.as_ref()?;
+    pub fn get_execute(&self, operation: OperationId) -> Result<Option<ExecuteContext>, Error> {
+        let state = self
+            .protocol_state
+            .read()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+        let Some(execute_context) = state
+            .operations
+            .get(&operation)
+            .and_then(|operation| operation.execute.as_ref())
+        else {
+            return Ok(None);
+        };
         debug!(target: CONTEXT, client_id = self.client_id, msg = "Get Execute", execute = ?execute_context);
-        Some(execute_context.to_owned())
+        Ok(Some(execute_context.to_owned()))
     }
 
-    pub fn get_session_metrics(&self, session_id: SessionId) -> Option<SessionMetricsContext> {
-        let state = self.protocol_state.read().ok()?;
-        let session_context = state.statement_metrics.get(&session_id)?;
+    pub fn get_session_metrics(
+        &self,
+        session_id: SessionId,
+    ) -> Result<Option<SessionMetricsContext>, Error> {
+        let state = self
+            .protocol_state
+            .read()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+        let Some(session_context) = state.statement_metrics.get(&session_id) else {
+            return Ok(None);
+        };
         debug!(target: CONTEXT, client_id = self.client_id, msg = "Get Session Metrics", session_metrics = ?session_context);
-        Some(session_context.to_owned())
+        Ok(Some(session_context.to_owned()))
     }
 
     #[cfg(test)]
-    pub fn active_metrics_scopes(&self) -> usize {
+    pub fn active_metrics_scopes(&self) -> Result<usize, Error> {
         self.protocol_state
             .read()
             .map(|state| state.statement_metrics.len())
-            .unwrap_or_default()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable.into())
     }
 
     /// Returns the resolver for this connection's effective schema snapshot.
@@ -1423,66 +1511,87 @@ where
         self.upstream_tls_roots.clone()
     }
 
-    fn with_session_metrics_mut<F>(&mut self, session_id: SessionId, f: F)
+    fn with_session_metrics_mut<F>(&mut self, session_id: SessionId, f: F) -> Result<(), Error>
     where
         F: FnOnce(&mut SessionMetricsContext),
     {
-        if let Ok(mut state) = self.protocol_state.write() {
-            if let Some(session) = state.statement_metrics.get_mut(&session_id) {
-                f(session);
-            }
+        let mut state = self
+            .protocol_state
+            .write()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+        if let Some(session) = state.statement_metrics.get_mut(&session_id) {
+            f(session);
         }
+        Ok(())
     }
 
     /// Record parse phase duration for the session (first write wins)
-    pub fn record_parse_duration(&mut self, session_id: SessionId, duration: Duration) {
+    pub fn record_parse_duration(
+        &mut self,
+        session_id: SessionId,
+        duration: Duration,
+    ) -> Result<(), Error> {
         self.with_session_metrics_mut(session_id, |session| {
             session.phase_timing.record_parse(duration);
-        });
+        })
     }
 
     /// Add encrypt phase duration for the session (accumulate)
-    pub fn add_encrypt_duration(&mut self, session_id: SessionId, duration: Duration) {
+    pub fn add_encrypt_duration(
+        &mut self,
+        session_id: SessionId,
+        duration: Duration,
+    ) -> Result<(), Error> {
         self.with_session_metrics_mut(session_id, |session| {
             session.phase_timing.add_encrypt(duration);
-        });
+        })
     }
 
     /// Add decrypt phase duration (accumulate)
-    pub fn add_decrypt_duration(&mut self, session_id: SessionId, duration: Duration) {
+    pub fn add_decrypt_duration(
+        &mut self,
+        session_id: SessionId,
+        duration: Duration,
+    ) -> Result<(), Error> {
         self.with_session_metrics_mut(session_id, |session| {
             session.phase_timing.add_decrypt(duration);
-        });
+        })
     }
 
     /// Update statement metadata for a session
-    pub fn update_statement_metadata<F>(&mut self, session_id: SessionId, f: F)
+    pub fn update_statement_metadata<F>(&mut self, session_id: SessionId, f: F) -> Result<(), Error>
     where
         F: FnOnce(&mut StatementMetadata),
     {
         self.with_session_metrics_mut(session_id, |session| {
             f(&mut session.metadata);
-        });
+        })
     }
 
     /// Update statement metadata if session ID is present, no-op otherwise.
-    pub fn with_session<F>(&mut self, session_id: Option<SessionId>, f: F)
+    pub fn with_session<F>(&mut self, session_id: Option<SessionId>, f: F) -> Result<(), Error>
     where
         F: FnOnce(&mut SessionMetricsContext),
     {
         if let Some(sid) = session_id {
-            self.with_session_metrics_mut(sid, f);
+            self.with_session_metrics_mut(sid, f)?;
         }
+        Ok(())
     }
 
     /// Add decrypt phase duration for the current execute session (if any)
-    pub fn add_decrypt_duration_for_execute(&mut self, operation: OperationId, duration: Duration) {
+    pub fn add_decrypt_duration_for_execute(
+        &mut self,
+        operation: OperationId,
+        duration: Duration,
+    ) -> Result<(), Error> {
         let session_id = self
-            .get_execute(operation)
+            .get_execute(operation)?
             .and_then(|execute| execute.session_id());
         if let Some(session_id) = session_id {
-            self.add_decrypt_duration(session_id, duration);
+            self.add_decrypt_duration(session_id, duration)?;
         }
+        Ok(())
     }
 }
 
@@ -1490,7 +1599,8 @@ where
 mod tests {
     use super::{
         ConnectionProtocolState, Context, ExecuteContext, ExecutionOutcome, KeysetIdentifier,
-        OperationContext, Portal, SessionId, SessionMetricsContext, Statement,
+        OperationContext, Portal, ResultOptionTestExt as _, SessionId, SessionMetricsContext,
+        Statement,
     };
     use crate::{
         config::LogConfig,
@@ -1582,6 +1692,41 @@ mod tests {
     }
 
     #[test]
+    fn each_extended_execution_records_its_own_statement_metrics() {
+        let mut context = create_context();
+        let statement = Name::from("statement");
+        let portal = Name::from("portal");
+        let template_scope = context.start_metrics_scope().unwrap();
+        context
+            .set_statement_session(statement, template_scope)
+            .unwrap();
+        context
+            .add_portal(
+                operation_id(),
+                portal.clone(),
+                Portal::passthrough(Some(template_scope)),
+            )
+            .unwrap();
+        let operation = operation_id();
+
+        context.set_execute_for_portal(operation, portal).unwrap();
+
+        let execution_scope = context
+            .get_execute(operation)
+            .unwrap()
+            .unwrap()
+            .session_id()
+            .unwrap();
+        assert!(
+            context
+                .get_session_metrics(execution_scope)
+                .unwrap()
+                .unwrap()
+                .records_session
+        );
+    }
+
+    #[test]
     fn execution_transition_rejects_stale_and_non_execute_operations() {
         let mut state = ConnectionProtocolState::<u64>::default();
 
@@ -1665,6 +1810,78 @@ mod tests {
     }
 
     #[test]
+    fn starting_metrics_fails_when_protocol_state_is_unavailable() {
+        let mut context = create_context();
+        let protocol_state = context.protocol_state.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = protocol_state.write().unwrap();
+            panic!("poison protocol state");
+        })
+        .join();
+
+        assert!(matches!(
+            context.start_metrics_scope(),
+            Err(Error::Context(
+                crate::error::ContextError::ProtocolStateUnavailable
+            ))
+        ));
+    }
+
+    #[test]
+    fn finishing_metrics_fails_when_protocol_state_is_unavailable() {
+        let mut context = create_context();
+        let protocol_state = context.protocol_state.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = protocol_state.write().unwrap();
+            panic!("poison protocol state");
+        })
+        .join();
+
+        assert!(matches!(
+            context.finish_metrics_scope(None),
+            Err(Error::Context(
+                crate::error::ContextError::ProtocolStateUnavailable
+            ))
+        ));
+    }
+
+    #[test]
+    fn reading_protocol_metadata_fails_when_protocol_state_is_unavailable() {
+        let context = create_context();
+        let protocol_state = context.protocol_state.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = protocol_state.write().unwrap();
+            panic!("poison protocol state");
+        })
+        .join();
+
+        assert!(matches!(
+            context.get_statement(&Name::from("statement")),
+            Err(Error::Context(
+                crate::error::ContextError::ProtocolStateUnavailable
+            ))
+        ));
+    }
+
+    #[test]
+    fn closing_a_statement_fails_when_protocol_state_is_unavailable() {
+        let context = create_context();
+        let protocol_state = context.protocol_state.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = protocol_state.write().unwrap();
+            panic!("poison protocol state");
+        })
+        .join();
+
+        assert!(matches!(
+            context.close_statement(&Name::from("statement")),
+            Err(Error::Context(
+                crate::error::ContextError::ProtocolStateUnavailable
+            ))
+        ));
+    }
+
+    #[test]
     fn completing_an_unknown_describe_rejects_the_stale_operation() {
         let context = create_context();
 
@@ -1678,10 +1895,12 @@ mod tests {
     fn completing_an_operation_without_describe_rejects_and_removes_it() {
         let mut context = create_context();
         let operation = operation_id();
-        context.set_operation_error(
-            operation,
-            crate::postgresql::diagnostics::invalid_sql_statement("proxy error".to_owned()),
-        );
+        context
+            .set_operation_error(
+                operation,
+                crate::postgresql::diagnostics::invalid_sql_statement("proxy error".to_owned()),
+            )
+            .unwrap();
 
         assert!(matches!(
             context.complete_describe(operation),
@@ -1754,7 +1973,7 @@ mod tests {
     fn replacing_a_statement_does_not_finish_an_overlapping_execution_session() {
         let mut context = create_context();
         let name = Name::default();
-        let session_id = context.start_metrics_scope();
+        let session_id = context.start_metrics_scope().unwrap();
         context
             .set_statement_session(name.clone(), session_id)
             .unwrap();
@@ -1766,17 +1985,38 @@ mod tests {
             )
             .unwrap();
 
-        context.close_statement(&name);
+        context.close_statement(&name).unwrap();
 
         assert!(context.get_session_metrics(session_id).is_some());
         assert!(context.get_statement_session(&name).is_none());
     }
 
     #[test]
+    fn replacing_a_statement_does_not_finish_a_suspended_execution_scope() {
+        let mut context = create_context();
+        let statement = Name::from("statement");
+        let scope = context.start_metrics_scope().unwrap();
+        context
+            .set_statement_session(statement.clone(), scope)
+            .unwrap();
+        let operation = operation_id();
+        context
+            .set_execute(operation, Name::from("portal"), Some(scope))
+            .unwrap();
+        context
+            .finish_execution(operation, ExecutionOutcome::Suspended)
+            .unwrap();
+
+        context.close_statement(&statement).unwrap();
+
+        assert!(context.get_session_metrics(scope).is_some());
+    }
+
+    #[test]
     fn readiness_releases_reparsed_statement_metrics_after_their_portal_is_destroyed() {
         let mut context = create_context();
         let statement = Name::from("statement");
-        let scope = context.start_metrics_scope();
+        let scope = context.start_metrics_scope().unwrap();
         context
             .set_statement_session(statement.clone(), scope)
             .unwrap();
@@ -1788,7 +2028,7 @@ mod tests {
             )
             .unwrap();
 
-        context.close_statement(&statement);
+        context.close_statement(&statement).unwrap();
         assert!(context.get_session_metrics(scope).is_some());
 
         context
@@ -1799,10 +2039,10 @@ mod tests {
     }
 
     #[test]
-    fn closing_an_unreferenced_statement_finishes_its_metrics_session() {
+    fn closing_an_unexecuted_statement_does_not_record_session_metrics() {
         let mut context = create_context();
         let name = Name::default();
-        let session_id = context.start_metrics_scope();
+        let session_id = context.start_metrics_scope().unwrap();
         context
             .set_statement_session(name.clone(), session_id)
             .unwrap();
@@ -1810,13 +2050,13 @@ mod tests {
         let handle = recorder.handle();
 
         metrics::with_local_recorder(&recorder, || {
-            context.close_statement_explicit(&name);
+            context.close_statement_explicit(&name).unwrap();
         });
 
         assert!(context.get_session_metrics(session_id).is_none());
         let rendered = handle.render();
         assert!(
-            rendered.contains("cipherstash_proxy_statements_session_duration_seconds_count"),
+            !rendered.contains("cipherstash_proxy_statements_session_duration_seconds_count"),
             "{rendered}"
         );
     }
@@ -1833,8 +2073,14 @@ mod tests {
             .add_statement(retained_statement_name.clone(), statement())
             .unwrap();
 
-        let closed_statement = context.get_statement(&closed_statement_name).unwrap();
-        let retained_statement = context.get_statement(&retained_statement_name).unwrap();
+        let closed_statement = context
+            .get_statement(&closed_statement_name)
+            .unwrap()
+            .unwrap();
+        let retained_statement = context
+            .get_statement(&retained_statement_name)
+            .unwrap()
+            .unwrap();
         let closed_portal_name = Name::from("differently_named_portal");
         let retained_portal_name = Name::from("retained_portal");
         let passthrough_portal_name = Name::from("passthrough_portal");
@@ -1860,7 +2106,7 @@ mod tests {
             )
             .unwrap();
 
-        context.close_statement(&closed_statement_name);
+        context.close_statement(&closed_statement_name).unwrap();
 
         assert!(context.get_portal(&closed_portal_name).is_some());
         assert!(context.get_portal(&retained_portal_name).is_some());
@@ -1886,7 +2132,7 @@ mod tests {
     fn idle_readiness_finishes_abandoned_suspended_execution_metrics() {
         let mut context = create_context();
         let portal = Name::from("limited_portal");
-        let template_scope = context.start_metrics_scope();
+        let template_scope = context.start_metrics_scope().unwrap();
         context
             .add_portal(
                 operation_id(),
@@ -1898,6 +2144,7 @@ mod tests {
         context.set_execute_for_portal(operation, portal).unwrap();
         let execution_scope = context
             .get_execute(operation)
+            .unwrap()
             .and_then(|execute| execute.session_id())
             .unwrap();
         context
@@ -1915,7 +2162,7 @@ mod tests {
     fn idle_readiness_finishes_simple_query_execution() {
         let mut context = create_context();
         let operation = operation_id();
-        let scope = context.start_metrics_scope();
+        let scope = context.start_metrics_scope().unwrap();
         context
             .set_simple_query_execute_until_ready(operation, Name::new(), Some(scope))
             .unwrap();
@@ -1942,7 +2189,7 @@ mod tests {
     fn readiness_for_one_query_preserves_later_pipelined_work() {
         let mut context = create_context();
         let query_a = operation_id();
-        let query_a_scope = context.start_metrics_scope();
+        let query_a_scope = context.start_metrics_scope().unwrap();
         context
             .set_simple_query_execute_until_ready(query_a, Name::new(), Some(query_a_scope))
             .unwrap();
@@ -1981,13 +2228,13 @@ mod tests {
     fn transaction_readiness_finishes_one_query_and_preserves_later_pipelined_work() {
         let mut context = create_context();
         let query_a = operation_id();
-        let query_a_scope = context.start_metrics_scope();
+        let query_a_scope = context.start_metrics_scope().unwrap();
         context
             .set_simple_query_execute_until_ready(query_a, Name::new(), Some(query_a_scope))
             .unwrap();
 
         let query_b = operation_id();
-        let query_b_scope = context.start_metrics_scope();
+        let query_b_scope = context.start_metrics_scope().unwrap();
         context
             .set_simple_query_execute_until_ready(query_b, Name::new(), Some(query_b_scope))
             .unwrap();
@@ -2006,7 +2253,10 @@ mod tests {
     fn closing_a_suspended_portal_finishes_its_execution_metrics() {
         let mut context = create_context();
         let portal = Name::from("limited_portal");
-        let template_scope = context.start_metrics_scope();
+        let template_scope = context.start_metrics_scope().unwrap();
+        context
+            .set_statement_session(Name::from("statement"), template_scope)
+            .unwrap();
         context
             .add_portal(
                 operation_id(),
@@ -2020,6 +2270,7 @@ mod tests {
             .unwrap();
         let execution_scope = context
             .get_execute(operation)
+            .unwrap()
             .and_then(|execute| execute.session_id())
             .unwrap();
         context
@@ -2047,7 +2298,7 @@ mod tests {
     fn rebinding_a_suspended_portal_starts_a_new_execution_occurrence() {
         let mut context = create_context();
         let portal_name = Name::new();
-        let first_template = context.start_metrics_scope();
+        let first_template = context.start_metrics_scope().unwrap();
         context
             .add_portal(
                 operation_id(),
@@ -2062,13 +2313,14 @@ mod tests {
         let first_execution = context
             .get_execute(operation)
             .unwrap()
+            .unwrap()
             .session_id()
             .unwrap();
         context
             .finish_execution(operation, ExecutionOutcome::Suspended)
             .unwrap();
 
-        let rebound_template = context.start_metrics_scope();
+        let rebound_template = context.start_metrics_scope().unwrap();
         context
             .add_portal(
                 operation_id(),
@@ -2083,6 +2335,7 @@ mod tests {
         assert_eq!(
             context
                 .get_portal_from_execute(operation)
+                .unwrap()
                 .and_then(|portal| portal.session_id()),
             Some(rebound_template)
         );
@@ -2111,7 +2364,7 @@ mod tests {
     fn discarding_an_unfinished_operation_releases_its_execution_metrics() {
         let mut context = create_context();
         let portal = Name::from("skipped_portal");
-        let template_scope = context.start_metrics_scope();
+        let template_scope = context.start_metrics_scope().unwrap();
         context
             .add_portal(
                 operation_id(),
@@ -2123,10 +2376,11 @@ mod tests {
         context.set_execute_for_portal(operation, portal).unwrap();
         let execution_scope = context
             .get_execute(operation)
+            .unwrap()
             .and_then(|execute| execute.session_id())
             .unwrap();
 
-        context.discard_operation(operation);
+        context.discard_operation(operation).unwrap();
 
         assert!(context.get_execute(operation).is_none());
         assert!(context.get_session_metrics(execution_scope).is_none());
@@ -2136,7 +2390,7 @@ mod tests {
     fn simple_query_execution_finishes_only_at_readiness() {
         let mut context = create_context();
         let operation = operation_id();
-        let scope = context.start_metrics_scope();
+        let scope = context.start_metrics_scope().unwrap();
         context
             .set_simple_query_execute_until_ready(operation, Name::new(), Some(scope))
             .unwrap();
@@ -2187,17 +2441,17 @@ mod tests {
 
         let portal_name = Name::from("portal");
 
-        let statement_1 = context.get_statement(&statement_name_1).unwrap();
+        let statement_1 = context.get_statement(&statement_name_1).unwrap().unwrap();
         context
             .add_portal(operation_id(), portal_name.clone(), portal(&statement_1))
             .unwrap();
 
-        let statement_2 = context.get_statement(&statement_name_2).unwrap();
+        let statement_2 = context.get_statement(&statement_name_2).unwrap().unwrap();
         context
             .add_portal(operation_id(), portal_name.clone(), portal(&statement_2))
             .unwrap();
 
-        let portal = context.get_portal(&portal_name).unwrap();
+        let portal = context.get_portal(&portal_name).unwrap().unwrap();
         assert_eq!(statement_2, get_statement(portal));
         context.close_portal(&portal_name).unwrap();
         assert!(context.get_portal(&portal_name).is_none());

--- a/packages/cipherstash-proxy/src/postgresql/context/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/context/mod.rs
@@ -53,7 +53,11 @@ impl<T> ResultOptionTestExt for Result<Option<T>, Error> {
     }
 
     fn is_none(&self) -> bool {
-        self.as_ref().unwrap().is_none()
+        match self {
+            Ok(value) => value.is_none(),
+            Err(Error::Context(crate::error::ContextError::UnknownOperation)) => true,
+            Err(err) => panic!("unexpected protocol state error: {err}"),
+        }
     }
 }
 
@@ -879,6 +883,28 @@ where
         Ok(state.statement_metrics_scopes.get(name).copied())
     }
 
+    pub fn start_portal_metrics_scope(
+        &mut self,
+        statement: &Name,
+    ) -> Result<Option<SessionId>, Error> {
+        let id = SessionId(self.session_id_counter.fetch_add(1, Ordering::Relaxed));
+        let mut state = self
+            .protocol_state
+            .write()
+            .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
+        let Some(template_id) = state.statement_metrics_scopes.get(statement).copied() else {
+            return Ok(None);
+        };
+        let Some(mut metrics) = state.statement_metrics.get(&template_id).cloned() else {
+            return Err(crate::error::ContextError::StatementMetricsUnavailable.into());
+        };
+        metrics.id = id;
+        metrics.start = Instant::now();
+        metrics.records_session = false;
+        state.statement_metrics.insert(id, metrics);
+        Ok(Some(id))
+    }
+
     ///
     /// Close the portal identified by `name`
     /// Portal is removed from  queue
@@ -979,7 +1005,7 @@ where
             .read()
             .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
         let Some(context) = state.operations.get(&operation) else {
-            return Ok(None);
+            return Err(crate::error::ContextError::UnknownOperation.into());
         };
         if let Some(statement) = context
             .describe
@@ -1008,10 +1034,13 @@ where
             .protocol_state
             .read()
             .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
-        Ok(state
+        let context = state
             .operations
             .get(&operation)
-            .and_then(|context| context.describe.as_ref())
+            .ok_or(crate::error::ContextError::UnknownOperation)?;
+        Ok(context
+            .describe
+            .as_ref()
             .and_then(|describe| describe.statement.clone()))
     }
 
@@ -1023,11 +1052,15 @@ where
             .protocol_state
             .read()
             .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
-        Ok(state
+        let context = state
             .operations
             .get(&operation)
-            .and_then(|context| context.execute.as_ref())
-            .and_then(|execute| execute.portal.clone()))
+            .ok_or(crate::error::ContextError::UnknownOperation)?;
+        let execute = context
+            .execute
+            .as_ref()
+            .ok_or(crate::error::ContextError::OperationWithoutExecute)?;
+        Ok(execute.portal.clone())
     }
 
     pub fn get_execute(&self, operation: OperationId) -> Result<Option<ExecuteContext>, Error> {
@@ -1035,13 +1068,14 @@ where
             .protocol_state
             .read()
             .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
-        let Some(execute_context) = state
+        let operation_context = state
             .operations
             .get(&operation)
-            .and_then(|operation| operation.execute.as_ref())
-        else {
-            return Ok(None);
-        };
+            .ok_or(crate::error::ContextError::UnknownOperation)?;
+        let execute_context = operation_context
+            .execute
+            .as_ref()
+            .ok_or(crate::error::ContextError::OperationWithoutExecute)?;
         debug!(target: CONTEXT, client_id = self.client_id, msg = "Get Execute", execute = ?execute_context);
         Ok(Some(execute_context.to_owned()))
     }

--- a/packages/cipherstash-proxy/src/postgresql/context/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/context/mod.rs
@@ -399,8 +399,11 @@ where
             .protocol_state
             .write()
             .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
-        state.operations.remove(&operation);
-        Ok(())
+        state
+            .operations
+            .remove(&operation)
+            .map(|_| ())
+            .ok_or(crate::error::ContextError::UnknownOperation.into())
     }
     ///
     /// Marks the current Describe as complete

--- a/packages/cipherstash-proxy/src/postgresql/context/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/context/mod.rs
@@ -284,7 +284,7 @@ struct ExecutionTransition {
 pub struct SessionMetricsContext {
     id: SessionId,
     start: Instant,
-    records_session: bool,
+    records_statement_metrics: bool,
     pub phase_timing: PhaseTiming,
     pub metadata: StatementMetadata,
 }
@@ -294,7 +294,7 @@ impl SessionMetricsContext {
         SessionMetricsContext {
             id,
             start: Instant::now(),
-            records_session: true,
+            records_statement_metrics: true,
             phase_timing: PhaseTiming::new(),
             metadata: StatementMetadata::new(),
         }
@@ -449,19 +449,19 @@ where
             .protocol_state
             .write()
             .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
-        let session = session_id.and_then(|id| state.statement_metrics.remove(&id));
+        let metrics_scope = session_id.and_then(|id| state.statement_metrics.remove(&id));
         drop(state);
-        self.record_finished_session(session);
+        self.record_finished_metrics_scope(metrics_scope);
         Ok(())
     }
 
-    fn record_finished_session(&self, session: Option<SessionMetricsContext>) {
-        if let Some(session) = session {
-            if !session.records_session {
+    fn record_finished_metrics_scope(&self, metrics_scope: Option<SessionMetricsContext>) {
+        if let Some(metrics_scope) = metrics_scope {
+            if !metrics_scope.records_statement_metrics {
                 return;
             }
-            let duration = session.duration();
-            let metadata = &session.metadata;
+            let duration = metrics_scope.duration();
+            let metadata = &metrics_scope.metadata;
 
             // Get labels for metrics
             let statement_type = metadata
@@ -490,7 +490,7 @@ where
             if self.config.slow_statements_enabled()
                 && duration > self.config.slow_statement_min_duration()
             {
-                let timing = &session.phase_timing;
+                let timing = &metrics_scope.phase_timing;
 
                 // Increment slow statements counter
                 counter!(SLOW_STATEMENTS_TOTAL).increment(1);
@@ -556,7 +556,7 @@ where
         Ok(())
     }
 
-    /// Set execute state for portal, looking up session ID internally.
+    /// Set execute state for a portal, looking up its metrics scope ID internally.
     pub fn set_execute_for_portal(
         &mut self,
         operation: OperationId,
@@ -579,7 +579,7 @@ where
                     .unwrap_or_else(|| SessionMetricsContext::new(execution_id));
                 metrics.id = execution_id;
                 metrics.start = Instant::now();
-                metrics.records_session = true;
+                metrics.records_statement_metrics = true;
                 state.statement_metrics.insert(execution_id, metrics);
                 ExecuteContext::new(name, portal, Some(execution_id))
             });
@@ -612,7 +612,7 @@ where
                 }
             }
         }
-        self.record_finished_session(transition.finished_metrics);
+        self.record_finished_metrics_scope(transition.finished_metrics);
         Ok(transition.replacement_error)
     }
 
@@ -622,8 +622,8 @@ where
         metrics: Option<&SessionMetricsContext>,
     ) {
         let (statement_type, protocol, mapped, multi_statement) = metrics
-            .map(|session| {
-                let metadata = &session.metadata;
+            .map(|metrics_scope| {
+                let metadata = &metrics_scope.metadata;
                 (
                     metadata
                         .statement_type
@@ -665,21 +665,21 @@ where
     pub fn close_statement(&self, name: &Name) -> Result<(), Error> {
         debug!(target: CONTEXT, client_id = self.client_id, statement = ?name);
 
-        let finished_session = {
+        let finished_metrics_scope = {
             let mut state = self
                 .protocol_state
                 .write()
                 .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
             let session_id = state.statement_metrics_scopes.remove(name);
             state.statements.remove(name);
-            let session_in_use = session_id.is_some_and(|id| state.metrics_referenced(id));
-            if !session_in_use {
+            let metrics_scope_in_use = session_id.is_some_and(|id| state.metrics_referenced(id));
+            if !metrics_scope_in_use {
                 session_id.and_then(|session_id| state.statement_metrics.remove(&session_id))
             } else {
                 None
             }
         };
-        self.record_finished_session(finished_session);
+        self.record_finished_metrics_scope(finished_metrics_scope);
         Ok(())
     }
 
@@ -703,7 +703,7 @@ where
             return Ok(());
         };
 
-        let (finished_executions, finished_sessions) = {
+        let (finished_executions, finished_metrics_scopes) = {
             let mut state = self
                 .protocol_state
                 .write()
@@ -772,8 +772,8 @@ where
                 self.close_portal_if_current(&execute.name, execute.portal.as_ref())?;
             }
         }
-        for session in finished_sessions {
-            self.record_finished_session(Some(session));
+        for metrics_scope in finished_metrics_scopes {
+            self.record_finished_metrics_scope(Some(metrics_scope));
         }
         Ok(())
     }
@@ -787,7 +787,7 @@ where
     }
 
     pub fn discard_operation(&mut self, operation: OperationId) -> Result<(), Error> {
-        let finished_session = {
+        let finished_metrics_scope = {
             let mut state = self
                 .protocol_state
                 .write()
@@ -799,7 +799,7 @@ where
                 .and_then(|execute| execute.session_id());
             session_id.and_then(|session_id| state.statement_metrics.remove(&session_id))
         };
-        self.record_finished_session(finished_session);
+        self.record_finished_metrics_scope(finished_metrics_scope);
         Ok(())
     }
 
@@ -848,7 +848,7 @@ where
             state.take_unreferenced_metrics(candidates)
         };
         for metrics in finished_metrics {
-            self.record_finished_session(Some(metrics));
+            self.record_finished_metrics_scope(Some(metrics));
         }
         Ok(())
     }
@@ -862,7 +862,7 @@ where
         Ok(state.statements.get(name).cloned())
     }
 
-    pub fn set_statement_session(
+    pub fn set_statement_metrics_scope(
         &mut self,
         name: Name,
         session_id: SessionId,
@@ -872,13 +872,13 @@ where
             .write()
             .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
         if let Some(metrics) = state.statement_metrics.get_mut(&session_id) {
-            metrics.records_session = false;
+            metrics.records_statement_metrics = false;
         }
         state.statement_metrics_scopes.insert(name, session_id);
         Ok(())
     }
 
-    pub fn get_statement_session(&self, name: &Name) -> Result<Option<SessionId>, Error> {
+    pub fn get_statement_metrics_scope(&self, name: &Name) -> Result<Option<SessionId>, Error> {
         let state = self
             .protocol_state
             .read()
@@ -903,7 +903,7 @@ where
         };
         metrics.id = id;
         metrics.start = Instant::now();
-        metrics.records_session = false;
+        metrics.records_statement_metrics = false;
         state.statement_metrics.insert(id, metrics);
         Ok(Some(id))
     }
@@ -936,7 +936,7 @@ where
             state.take_unreferenced_metrics(candidates)
         };
         for metrics in finished_metrics {
-            self.record_finished_session(Some(metrics));
+            self.record_finished_metrics_scope(Some(metrics));
         }
         Ok(())
     }
@@ -988,7 +988,7 @@ where
         })
     }
 
-    pub fn get_portal_session_id(&self, name: &Name) -> Result<Option<SessionId>, Error> {
+    pub fn get_portal_metrics_scope_id(&self, name: &Name) -> Result<Option<SessionId>, Error> {
         let state = self
             .protocol_state
             .read()
@@ -1083,7 +1083,7 @@ where
         Ok(Some(execute_context.to_owned()))
     }
 
-    pub fn get_session_metrics(
+    pub fn get_metrics_scope(
         &self,
         session_id: SessionId,
     ) -> Result<Option<SessionMetricsContext>, Error> {
@@ -1091,11 +1091,11 @@ where
             .protocol_state
             .read()
             .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
-        let Some(session_context) = state.statement_metrics.get(&session_id) else {
+        let Some(metrics_scope) = state.statement_metrics.get(&session_id) else {
             return Ok(None);
         };
-        debug!(target: CONTEXT, client_id = self.client_id, msg = "Get Session Metrics", session_metrics = ?session_context);
-        Ok(Some(session_context.to_owned()))
+        debug!(target: CONTEXT, client_id = self.client_id, msg = "Get statement metrics scope", statement_metrics = ?metrics_scope);
+        Ok(Some(metrics_scope.to_owned()))
     }
 
     #[cfg(test)]
@@ -1548,7 +1548,11 @@ where
         self.upstream_tls_roots.clone()
     }
 
-    fn with_session_metrics_mut<F>(&mut self, session_id: SessionId, f: F) -> Result<(), Error>
+    fn with_statement_metrics_scope_mut<F>(
+        &mut self,
+        session_id: SessionId,
+        f: F,
+    ) -> Result<(), Error>
     where
         F: FnOnce(&mut SessionMetricsContext),
     {
@@ -1556,31 +1560,31 @@ where
             .protocol_state
             .write()
             .map_err(|_| crate::error::ContextError::ProtocolStateUnavailable)?;
-        if let Some(session) = state.statement_metrics.get_mut(&session_id) {
-            f(session);
+        if let Some(metrics_scope) = state.statement_metrics.get_mut(&session_id) {
+            f(metrics_scope);
         }
         Ok(())
     }
 
-    /// Record parse phase duration for the session (first write wins)
+    /// Record parse phase duration for the statement metrics scope (first write wins)
     pub fn record_parse_duration(
         &mut self,
         session_id: SessionId,
         duration: Duration,
     ) -> Result<(), Error> {
-        self.with_session_metrics_mut(session_id, |session| {
-            session.phase_timing.record_parse(duration);
+        self.with_statement_metrics_scope_mut(session_id, |metrics_scope| {
+            metrics_scope.phase_timing.record_parse(duration);
         })
     }
 
-    /// Add encrypt phase duration for the session (accumulate)
+    /// Add encrypt phase duration for the statement metrics scope (accumulate)
     pub fn add_encrypt_duration(
         &mut self,
         session_id: SessionId,
         duration: Duration,
     ) -> Result<(), Error> {
-        self.with_session_metrics_mut(session_id, |session| {
-            session.phase_timing.add_encrypt(duration);
+        self.with_statement_metrics_scope_mut(session_id, |metrics_scope| {
+            metrics_scope.phase_timing.add_encrypt(duration);
         })
     }
 
@@ -1590,33 +1594,37 @@ where
         session_id: SessionId,
         duration: Duration,
     ) -> Result<(), Error> {
-        self.with_session_metrics_mut(session_id, |session| {
-            session.phase_timing.add_decrypt(duration);
+        self.with_statement_metrics_scope_mut(session_id, |metrics_scope| {
+            metrics_scope.phase_timing.add_decrypt(duration);
         })
     }
 
-    /// Update statement metadata for a session
+    /// Update metadata for a statement metrics scope.
     pub fn update_statement_metadata<F>(&mut self, session_id: SessionId, f: F) -> Result<(), Error>
     where
         F: FnOnce(&mut StatementMetadata),
     {
-        self.with_session_metrics_mut(session_id, |session| {
-            f(&mut session.metadata);
+        self.with_statement_metrics_scope_mut(session_id, |metrics_scope| {
+            f(&mut metrics_scope.metadata);
         })
     }
 
-    /// Update statement metadata if session ID is present, no-op otherwise.
-    pub fn with_session<F>(&mut self, session_id: Option<SessionId>, f: F) -> Result<(), Error>
+    /// Update statement metadata if a metrics scope ID is present, no-op otherwise.
+    pub fn with_metrics_scope<F>(
+        &mut self,
+        session_id: Option<SessionId>,
+        f: F,
+    ) -> Result<(), Error>
     where
         F: FnOnce(&mut SessionMetricsContext),
     {
         if let Some(sid) = session_id {
-            self.with_session_metrics_mut(sid, f)?;
+            self.with_statement_metrics_scope_mut(sid, f)?;
         }
         Ok(())
     }
 
-    /// Add decrypt phase duration for the current execute session (if any)
+    /// Add decrypt phase duration for the current execution metrics scope (if any)
     pub fn add_decrypt_duration_for_execute(
         &mut self,
         operation: OperationId,
@@ -1735,7 +1743,7 @@ mod tests {
         let portal = Name::from("portal");
         let template_scope = context.start_metrics_scope().unwrap();
         context
-            .set_statement_session(statement, template_scope)
+            .set_statement_metrics_scope(statement, template_scope)
             .unwrap();
         context
             .add_portal(
@@ -1756,10 +1764,10 @@ mod tests {
             .unwrap();
         assert!(
             context
-                .get_session_metrics(execution_scope)
+                .get_metrics_scope(execution_scope)
                 .unwrap()
                 .unwrap()
-                .records_session
+                .records_statement_metrics
         );
     }
 
@@ -1839,7 +1847,7 @@ mod tests {
         .join();
 
         assert!(matches!(
-            context.set_statement_session(Name::new(), SessionId(1)),
+            context.set_statement_metrics_scope(Name::new(), SessionId(1)),
             Err(Error::Context(
                 crate::error::ContextError::ProtocolStateUnavailable
             ))
@@ -2007,12 +2015,12 @@ mod tests {
     }
 
     #[test]
-    fn replacing_a_statement_does_not_finish_an_overlapping_execution_session() {
+    fn replacing_a_statement_does_not_finish_an_overlapping_execution_metrics_scope() {
         let mut context = create_context();
         let name = Name::default();
         let session_id = context.start_metrics_scope().unwrap();
         context
-            .set_statement_session(name.clone(), session_id)
+            .set_statement_metrics_scope(name.clone(), session_id)
             .unwrap();
         context
             .add_portal(
@@ -2024,8 +2032,8 @@ mod tests {
 
         context.close_statement(&name).unwrap();
 
-        assert!(context.get_session_metrics(session_id).is_some());
-        assert!(context.get_statement_session(&name).is_none());
+        assert!(context.get_metrics_scope(session_id).is_some());
+        assert!(context.get_statement_metrics_scope(&name).is_none());
     }
 
     #[test]
@@ -2034,7 +2042,7 @@ mod tests {
         let statement = Name::from("statement");
         let scope = context.start_metrics_scope().unwrap();
         context
-            .set_statement_session(statement.clone(), scope)
+            .set_statement_metrics_scope(statement.clone(), scope)
             .unwrap();
         let operation = operation_id();
         context
@@ -2046,7 +2054,7 @@ mod tests {
 
         context.close_statement(&statement).unwrap();
 
-        assert!(context.get_session_metrics(scope).is_some());
+        assert!(context.get_metrics_scope(scope).is_some());
     }
 
     #[test]
@@ -2055,7 +2063,7 @@ mod tests {
         let statement = Name::from("statement");
         let scope = context.start_metrics_scope().unwrap();
         context
-            .set_statement_session(statement.clone(), scope)
+            .set_statement_metrics_scope(statement.clone(), scope)
             .unwrap();
         context
             .add_portal(
@@ -2066,22 +2074,22 @@ mod tests {
             .unwrap();
 
         context.close_statement(&statement).unwrap();
-        assert!(context.get_session_metrics(scope).is_some());
+        assert!(context.get_metrics_scope(scope).is_some());
 
         context
             .ready_for_query(TransactionStatus::Idle, Some(operation_id()))
             .unwrap();
 
-        assert!(context.get_session_metrics(scope).is_none());
+        assert!(context.get_metrics_scope(scope).is_none());
     }
 
     #[test]
-    fn closing_an_unexecuted_statement_does_not_record_session_metrics() {
+    fn closing_an_unexecuted_statement_does_not_record_statement_metrics() {
         let mut context = create_context();
         let name = Name::default();
         let session_id = context.start_metrics_scope().unwrap();
         context
-            .set_statement_session(name.clone(), session_id)
+            .set_statement_metrics_scope(name.clone(), session_id)
             .unwrap();
         let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
         let handle = recorder.handle();
@@ -2090,7 +2098,7 @@ mod tests {
             context.close_statement_explicit(&name).unwrap();
         });
 
-        assert!(context.get_session_metrics(session_id).is_none());
+        assert!(context.get_metrics_scope(session_id).is_none());
         let rendered = handle.render();
         assert!(
             !rendered.contains("cipherstash_proxy_statements_session_duration_seconds_count"),
@@ -2192,7 +2200,7 @@ mod tests {
             .ready_for_query(TransactionStatus::Idle, Some(operation_id()))
             .unwrap();
 
-        assert!(context.get_session_metrics(execution_scope).is_none());
+        assert!(context.get_metrics_scope(execution_scope).is_none());
     }
 
     #[test]
@@ -2216,7 +2224,7 @@ mod tests {
         });
 
         assert!(context.get_execute(operation).is_none());
-        assert!(context.get_session_metrics(scope).is_none());
+        assert!(context.get_metrics_scope(scope).is_none());
         assert!(handle
             .render()
             .contains("cipherstash_proxy_statements_execution_duration_seconds_count"));
@@ -2255,7 +2263,7 @@ mod tests {
             .ready_for_query(TransactionStatus::Idle, Some(query_a))
             .unwrap();
 
-        assert!(context.get_session_metrics(query_a_scope).is_none());
+        assert!(context.get_metrics_scope(query_a_scope).is_none());
         assert!(context.get_portal(&portal_b).is_some());
         assert!(context.complete_describe(describe_b).is_ok());
         assert!(context.get_execute(execute_b).is_some());
@@ -2281,9 +2289,9 @@ mod tests {
             .unwrap();
 
         assert!(context.get_execute(query_a).is_none());
-        assert!(context.get_session_metrics(query_a_scope).is_none());
+        assert!(context.get_metrics_scope(query_a_scope).is_none());
         assert!(context.get_execute(query_b).is_some());
-        assert!(context.get_session_metrics(query_b_scope).is_some());
+        assert!(context.get_metrics_scope(query_b_scope).is_some());
     }
 
     #[test]
@@ -2292,7 +2300,7 @@ mod tests {
         let portal = Name::from("limited_portal");
         let template_scope = context.start_metrics_scope().unwrap();
         context
-            .set_statement_session(Name::from("statement"), template_scope)
+            .set_statement_metrics_scope(Name::from("statement"), template_scope)
             .unwrap();
         context
             .add_portal(
@@ -2320,7 +2328,7 @@ mod tests {
             context.close_portal(&portal).unwrap();
         });
 
-        assert!(context.get_session_metrics(execution_scope).is_none());
+        assert!(context.get_metrics_scope(execution_scope).is_none());
         let rendered = handle.render();
         let count = rendered
             .lines()
@@ -2376,7 +2384,7 @@ mod tests {
                 .and_then(|portal| portal.session_id()),
             Some(rebound_template)
         );
-        assert!(context.get_session_metrics(first_execution).is_none());
+        assert!(context.get_metrics_scope(first_execution).is_none());
     }
 
     #[test]
@@ -2420,7 +2428,7 @@ mod tests {
         context.discard_operation(operation).unwrap();
 
         assert!(context.get_execute(operation).is_none());
-        assert!(context.get_session_metrics(execution_scope).is_none());
+        assert!(context.get_metrics_scope(execution_scope).is_none());
     }
 
     #[test]
@@ -2446,7 +2454,7 @@ mod tests {
             .ready_for_query(TransactionStatus::Idle, Some(operation))
             .unwrap();
         assert!(context.get_execute(operation).is_none());
-        assert!(context.get_session_metrics(scope).is_none());
+        assert!(context.get_metrics_scope(scope).is_none());
     }
 
     fn get_statement(portal: Arc<Portal>) -> Arc<Statement> {

--- a/packages/cipherstash-proxy/src/postgresql/context/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/context/mod.rs
@@ -40,27 +40,6 @@ use uuid::Uuid;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct SessionId(u64);
 
-#[cfg(test)]
-pub trait ResultOptionTestExt {
-    fn is_some(&self) -> bool;
-    fn is_none(&self) -> bool;
-}
-
-#[cfg(test)]
-impl<T> ResultOptionTestExt for Result<Option<T>, Error> {
-    fn is_some(&self) -> bool {
-        self.as_ref().unwrap().is_some()
-    }
-
-    fn is_none(&self) -> bool {
-        match self {
-            Ok(value) => value.is_none(),
-            Err(Error::Context(crate::error::ContextError::UnknownOperation)) => true,
-            Err(err) => panic!("unexpected protocol state error: {err}"),
-        }
-    }
-}
-
 #[derive(Clone, Debug, PartialEq)]
 pub struct KeysetIdentifier(pub IdentifiedBy);
 
@@ -1644,8 +1623,7 @@ where
 mod tests {
     use super::{
         ConnectionProtocolState, Context, ExecuteContext, ExecutionOutcome, KeysetIdentifier,
-        OperationContext, Portal, ResultOptionTestExt as _, SessionId, SessionMetricsContext,
-        Statement,
+        OperationContext, Portal, SessionId, SessionMetricsContext, Statement,
     };
     use crate::{
         config::LogConfig,
@@ -1965,7 +1943,7 @@ mod tests {
 
         context.complete_describe(operation).unwrap();
 
-        assert!(context.get_execute(operation).is_some());
+        assert!(context.get_execute(operation).unwrap().is_some());
     }
 
     fn create_context() -> Context<TestService> {
@@ -2032,8 +2010,11 @@ mod tests {
 
         context.close_statement(&name).unwrap();
 
-        assert!(context.get_metrics_scope(session_id).is_some());
-        assert!(context.get_statement_metrics_scope(&name).is_none());
+        assert!(context.get_metrics_scope(session_id).unwrap().is_some());
+        assert!(context
+            .get_statement_metrics_scope(&name)
+            .unwrap()
+            .is_none());
     }
 
     #[test]
@@ -2054,7 +2035,7 @@ mod tests {
 
         context.close_statement(&statement).unwrap();
 
-        assert!(context.get_metrics_scope(scope).is_some());
+        assert!(context.get_metrics_scope(scope).unwrap().is_some());
     }
 
     #[test]
@@ -2074,13 +2055,13 @@ mod tests {
             .unwrap();
 
         context.close_statement(&statement).unwrap();
-        assert!(context.get_metrics_scope(scope).is_some());
+        assert!(context.get_metrics_scope(scope).unwrap().is_some());
 
         context
             .ready_for_query(TransactionStatus::Idle, Some(operation_id()))
             .unwrap();
 
-        assert!(context.get_metrics_scope(scope).is_none());
+        assert!(context.get_metrics_scope(scope).unwrap().is_none());
     }
 
     #[test]
@@ -2098,7 +2079,7 @@ mod tests {
             context.close_statement_explicit(&name).unwrap();
         });
 
-        assert!(context.get_metrics_scope(session_id).is_none());
+        assert!(context.get_metrics_scope(session_id).unwrap().is_none());
         let rendered = handle.render();
         assert!(
             !rendered.contains("cipherstash_proxy_statements_session_duration_seconds_count"),
@@ -2153,9 +2134,12 @@ mod tests {
 
         context.close_statement(&closed_statement_name).unwrap();
 
-        assert!(context.get_portal(&closed_portal_name).is_some());
-        assert!(context.get_portal(&retained_portal_name).is_some());
-        assert!(context.get_portal(&passthrough_portal_name).is_some());
+        assert!(context.get_portal(&closed_portal_name).unwrap().is_some());
+        assert!(context.get_portal(&retained_portal_name).unwrap().is_some());
+        assert!(context
+            .get_portal(&passthrough_portal_name)
+            .unwrap()
+            .is_some());
     }
 
     #[test]
@@ -2200,7 +2184,10 @@ mod tests {
             .ready_for_query(TransactionStatus::Idle, Some(operation_id()))
             .unwrap();
 
-        assert!(context.get_metrics_scope(execution_scope).is_none());
+        assert!(context
+            .get_metrics_scope(execution_scope)
+            .unwrap()
+            .is_none());
     }
 
     #[test]
@@ -2223,8 +2210,11 @@ mod tests {
                 .unwrap();
         });
 
-        assert!(context.get_execute(operation).is_none());
-        assert!(context.get_metrics_scope(scope).is_none());
+        assert!(matches!(
+            context.get_execute(operation),
+            Err(Error::Context(crate::error::ContextError::UnknownOperation))
+        ));
+        assert!(context.get_metrics_scope(scope).unwrap().is_none());
         assert!(handle
             .render()
             .contains("cipherstash_proxy_statements_execution_duration_seconds_count"));
@@ -2263,10 +2253,10 @@ mod tests {
             .ready_for_query(TransactionStatus::Idle, Some(query_a))
             .unwrap();
 
-        assert!(context.get_metrics_scope(query_a_scope).is_none());
-        assert!(context.get_portal(&portal_b).is_some());
+        assert!(context.get_metrics_scope(query_a_scope).unwrap().is_none());
+        assert!(context.get_portal(&portal_b).unwrap().is_some());
         assert!(context.complete_describe(describe_b).is_ok());
-        assert!(context.get_execute(execute_b).is_some());
+        assert!(context.get_execute(execute_b).unwrap().is_some());
     }
 
     #[test]
@@ -2288,10 +2278,13 @@ mod tests {
             .ready_for_query(TransactionStatus::InTransaction, Some(query_a))
             .unwrap();
 
-        assert!(context.get_execute(query_a).is_none());
-        assert!(context.get_metrics_scope(query_a_scope).is_none());
-        assert!(context.get_execute(query_b).is_some());
-        assert!(context.get_metrics_scope(query_b_scope).is_some());
+        assert!(matches!(
+            context.get_execute(query_a),
+            Err(Error::Context(crate::error::ContextError::UnknownOperation))
+        ));
+        assert!(context.get_metrics_scope(query_a_scope).unwrap().is_none());
+        assert!(context.get_execute(query_b).unwrap().is_some());
+        assert!(context.get_metrics_scope(query_b_scope).unwrap().is_some());
     }
 
     #[test]
@@ -2328,7 +2321,10 @@ mod tests {
             context.close_portal(&portal).unwrap();
         });
 
-        assert!(context.get_metrics_scope(execution_scope).is_none());
+        assert!(context
+            .get_metrics_scope(execution_scope)
+            .unwrap()
+            .is_none());
         let rendered = handle.render();
         let count = rendered
             .lines()
@@ -2384,7 +2380,10 @@ mod tests {
                 .and_then(|portal| portal.session_id()),
             Some(rebound_template)
         );
-        assert!(context.get_metrics_scope(first_execution).is_none());
+        assert!(context
+            .get_metrics_scope(first_execution)
+            .unwrap()
+            .is_none());
     }
 
     #[test]
@@ -2427,8 +2426,14 @@ mod tests {
 
         context.discard_operation(operation).unwrap();
 
-        assert!(context.get_execute(operation).is_none());
-        assert!(context.get_metrics_scope(execution_scope).is_none());
+        assert!(matches!(
+            context.get_execute(operation),
+            Err(Error::Context(crate::error::ContextError::UnknownOperation))
+        ));
+        assert!(context
+            .get_metrics_scope(execution_scope)
+            .unwrap()
+            .is_none());
     }
 
     #[test]
@@ -2443,18 +2448,21 @@ mod tests {
         context
             .finish_execution(operation, ExecutionOutcome::Completed)
             .unwrap();
-        assert!(context.get_execute(operation).is_some());
+        assert!(context.get_execute(operation).unwrap().is_some());
 
         context
             .finish_execution(operation, ExecutionOutcome::Completed)
             .unwrap();
-        assert!(context.get_execute(operation).is_some());
+        assert!(context.get_execute(operation).unwrap().is_some());
 
         context
             .ready_for_query(TransactionStatus::Idle, Some(operation))
             .unwrap();
-        assert!(context.get_execute(operation).is_none());
-        assert!(context.get_metrics_scope(scope).is_none());
+        assert!(matches!(
+            context.get_execute(operation),
+            Err(Error::Context(crate::error::ContextError::UnknownOperation))
+        ));
+        assert!(context.get_metrics_scope(scope).unwrap().is_none());
     }
 
     fn get_statement(portal: Arc<Portal>) -> Arc<Statement> {
@@ -2499,7 +2507,7 @@ mod tests {
         let portal = context.get_portal(&portal_name).unwrap().unwrap();
         assert_eq!(statement_2, get_statement(portal));
         context.close_portal(&portal_name).unwrap();
-        assert!(context.get_portal(&portal_name).is_none());
+        assert!(context.get_portal(&portal_name).unwrap().is_none());
     }
 
     fn parse_statement(sql: &str) -> sqltk::parser::ast::Statement {

--- a/packages/cipherstash-proxy/src/postgresql/driver.rs
+++ b/packages/cipherstash-proxy/src/postgresql/driver.rs
@@ -6,11 +6,12 @@ use crate::{
     tls,
 };
 use pg_proto::{
-    BackendForwarding, BoundedPipeline, CancellationPolicy, Client, ClientTlsConfig,
+    BackendForwarding, BoundedPipeline, CancelKey, CancellationPolicy, Client, ClientTlsConfig,
     ClientTlsPolicy, ClientTlsProvider, ConnectTarget, ForwardedMessage, FrontendForwarding,
-    FrontendMessage, InMemoryCancellationRegistry, InitialServerContext, Intermediary, Server,
-    ServerIdentity, ServerIdentityProvider, ServerTlsPolicy, SslMode, StartupParameters,
-    StartupRouteResolver, StaticClientCredentials, StaticMd5ServerCredentials,
+    FrontendMessage, InMemoryCancellationRegistry, InitialServerContext, Intermediary,
+    IntermediaryCancellationRegistry, Server, ServerIdentity, ServerIdentityProvider,
+    ServerTlsPolicy, SslMode, StartupParameters, StartupRouteResolver, StaticClientCredentials,
+    StaticMd5ServerCredentials,
 };
 use std::{
     convert::Infallible,
@@ -23,6 +24,25 @@ use tracing::info;
 /// must share the registry that maps client cancellation keys to upstream keys.
 static CANCELLATION_REGISTRY: LazyLock<InMemoryCancellationRegistry> =
     LazyLock::new(InMemoryCancellationRegistry::default);
+
+struct CancellationRegistrationGuard {
+    registry: InMemoryCancellationRegistry,
+    key: Option<CancelKey>,
+}
+
+impl CancellationRegistrationGuard {
+    fn new(registry: InMemoryCancellationRegistry, key: Option<CancelKey>) -> Self {
+        Self { registry, key }
+    }
+}
+
+impl Drop for CancellationRegistrationGuard {
+    fn drop(&mut self) {
+        if let Some(key) = self.key.take() {
+            let _ = self.registry.detach(&key);
+        }
+    }
+}
 
 #[derive(Clone)]
 struct Route(String);
@@ -102,6 +122,10 @@ where
                 pg_proto::IntermediaryAccept::Session(session) => session,
                 pg_proto::IntermediaryAccept::CancellationForwarded => return Ok(()),
             };
+            let _cancellation_guard = CancellationRegistrationGuard::new(
+                CANCELLATION_REGISTRY.clone(),
+                session.cancellation_key().cloned(),
+            );
             let result = async {
                 'session: loop {
                     let forward = session.forward_next();
@@ -216,9 +240,7 @@ where
                 Ok(())
             }
             .await;
-            finish_connection(result, || {
-                let _ = session.detach_cancellation();
-            })
+            result
         }};
     }
 
@@ -295,14 +317,6 @@ fn invalid_data(error: impl std::fmt::Display) -> Error {
     std::io::Error::new(std::io::ErrorKind::InvalidData, error.to_string()).into()
 }
 
-fn finish_connection<T, E>(
-    result: Result<T, E>,
-    detach_cancellation: impl FnOnce(),
-) -> Result<T, E> {
-    detach_cancellation();
-    result
-}
-
 fn upstream_ssl_mode(config: &crate::TandemConfig) -> SslMode {
     if config.database.with_tls_verification {
         SslMode::VerifyFull
@@ -317,13 +331,10 @@ fn upstream_ssl_mode(config: &crate::TandemConfig) -> SslMode {
 mod tests {
     use super::*;
     use bytes::Bytes;
-    use pg_proto::{
-        CancelKey, CancellationRoute, InMemoryCancellationRegistryError,
-        IntermediaryCancellationRegistry,
-    };
+    use pg_proto::{CancellationRoute, InMemoryCancellationRegistryError};
 
     #[test]
-    fn connection_exit_releases_its_cancellation_key() {
+    fn dropping_a_connection_guard_releases_its_cancellation_key() {
         for result in [Ok(()), Err("connection failed")] {
             let registry = InMemoryCancellationRegistry::default();
             let key = CancelKey {
@@ -337,11 +348,11 @@ mod tests {
                 Err(InMemoryCancellationRegistryError::DuplicateKey)
             );
 
-            let returned = finish_connection(result, || {
-                registry.detach(&key).unwrap();
-            });
-
-            assert_eq!(returned, result);
+            {
+                let _guard =
+                    CancellationRegistrationGuard::new(registry.clone(), Some(key.clone()));
+                let _ = result;
+            }
             assert_eq!(registry.register(route), Ok(key));
         }
     }

--- a/packages/cipherstash-proxy/src/postgresql/middleware/backend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/middleware/backend.rs
@@ -17,7 +17,7 @@ use crate::EqlCiphertext;
 use metrics::{counter, histogram};
 use pg_proto::{BackendMessage, BackendMiddlewareOutput, DataRow, DiagnosticResponse};
 use std::time::Instant;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 /// The PostgreSQL proxy backend that handles server-to-client message processing.
 ///
@@ -94,16 +94,7 @@ impl<S: EncryptionService> Backend<S> {
         let Some(operation) = operation else {
             return Ok(None);
         };
-        match self.context.finish_execution(operation, outcome) {
-            Err(Error::Context(
-                crate::error::ContextError::UnknownOperation
-                | crate::error::ContextError::OperationWithoutExecute,
-            )) => {
-                warn!(target: PROTOCOL, client_id = self.context.client_id, ?outcome, msg = "Ignoring terminal response for an untracked operation");
-                Ok(None)
-            }
-            result => result,
-        }
+        self.context.finish_execution(operation, outcome)
     }
 
     fn error_response(&self, err: Error) -> BackendMessage {
@@ -111,16 +102,7 @@ impl<S: EncryptionService> Backend<S> {
     }
 
     fn complete_describe(&self, operation: OperationId) -> Result<(), Error> {
-        match self.context.complete_describe(operation) {
-            Err(Error::Context(
-                crate::error::ContextError::UnknownOperation
-                | crate::error::ContextError::UnknownDescribe,
-            )) => {
-                warn!(target: PROTOCOL, client_id = self.context.client_id, msg = "Ignoring Describe response for an untracked operation");
-                Ok(())
-            }
-            result => result,
-        }
+        self.context.complete_describe(operation)
     }
 
     fn decryption_failure(&mut self, err: Error) -> BackendMiddlewareOutput {
@@ -944,50 +926,53 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unexpected_terminal_message_is_forwarded() {
+    async fn correlated_terminal_message_for_an_unknown_operation_fails_closed() {
         let mut backend = create_backend();
         let message = BackendMessage::CommandComplete(bytes::Bytes::from_static(b"SELECT 1"));
 
-        let output = backend
+        let result = backend
             .intercept(Some(operation_id()), message.clone())
-            .await
-            .unwrap();
+            .await;
 
-        assert_eq!(output, BackendMiddlewareOutput::Forward(message));
+        assert!(matches!(
+            result,
+            Err(Error::Context(crate::error::ContextError::UnknownOperation))
+        ));
     }
 
     #[tokio::test]
-    async fn terminal_message_for_a_non_execution_operation_is_forwarded() {
+    async fn terminal_message_for_a_non_execution_operation_fails_closed() {
         let (mut backend, context) = create_backend_with_context();
         let operation = operation_id();
         context.set_non_execution(operation).unwrap();
         let message = BackendMessage::CommandComplete(bytes::Bytes::from_static(b"SELECT 1"));
 
-        let output = backend
-            .intercept(Some(operation), message.clone())
-            .await
-            .unwrap();
+        let result = backend.intercept(Some(operation), message.clone()).await;
 
-        assert_eq!(output, BackendMiddlewareOutput::Forward(message));
+        assert!(matches!(
+            result,
+            Err(Error::Context(
+                crate::error::ContextError::OperationWithoutExecute
+            ))
+        ));
     }
 
     #[tokio::test]
-    async fn no_data_for_an_untracked_describe_is_forwarded() {
+    async fn no_data_for_an_untracked_describe_fails_closed() {
         let mut backend = create_backend();
 
-        let output = backend
+        let result = backend
             .intercept(Some(operation_id()), BackendMessage::NoData)
-            .await
-            .unwrap();
+            .await;
 
-        assert_eq!(
-            output,
-            BackendMiddlewareOutput::Forward(BackendMessage::NoData)
-        );
+        assert!(matches!(
+            result,
+            Err(Error::Context(crate::error::ContextError::UnknownOperation))
+        ));
     }
 
     #[tokio::test]
-    async fn row_description_for_an_untracked_mapped_operation_is_forwarded() {
+    async fn row_description_for_an_untracked_mapped_operation_fails_closed() {
         let mut encrypt_config = EncryptConfig::default();
         encrypt_config.insert(
             crate::Identifier::new("records", "secret"),
@@ -996,16 +981,18 @@ mod tests {
         let (mut backend, _) = create_backend_with_encrypt_config(encrypt_config);
         let message = BackendMessage::RowDescription(pg_proto::RowDescription { fields: vec![] });
 
-        let output = backend
+        let result = backend
             .intercept(Some(operation_id()), message.clone())
-            .await
-            .unwrap();
+            .await;
 
-        assert_eq!(output, BackendMiddlewareOutput::Forward(message));
+        assert!(matches!(
+            result,
+            Err(Error::Context(crate::error::ContextError::UnknownOperation))
+        ));
     }
 
     #[tokio::test]
-    async fn data_row_without_mapped_execution_metadata_is_forwarded() {
+    async fn data_row_for_an_unknown_correlated_operation_fails_closed() {
         let mut encrypt_config = EncryptConfig::default();
         encrypt_config.insert(
             crate::Identifier::new("records", "secret"),
@@ -1016,12 +1003,14 @@ mod tests {
         let message = BackendMessage::DataRow(DataRow {
             columns: vec![Some(bytes::Bytes::from_static(b"ciphertext"))],
         });
-        let output = backend
+        let result = backend
             .intercept(Some(operation_id()), message.clone())
-            .await
-            .unwrap();
+            .await;
 
-        assert_eq!(output, BackendMiddlewareOutput::Forward(message));
+        assert!(matches!(
+            result,
+            Err(Error::Context(crate::error::ContextError::UnknownOperation))
+        ));
         assert!(!backend.discard_execution);
     }
 
@@ -1044,7 +1033,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn database_error_for_an_unregistered_operation_is_forwarded() {
+    async fn database_error_for_an_unregistered_operation_fails_closed() {
         let (mut backend, context) = create_backend_with_context();
         let ddl = SqlParser::parse_statement("create table reports (id bigint)").unwrap();
         context.execute_simple_schema_statements(&[ddl]);
@@ -1053,12 +1042,14 @@ mod tests {
             crate::postgresql::diagnostics::invalid_sql_statement("database error".to_owned()),
         );
 
-        let output = backend
+        let result = backend
             .intercept(Some(operation_id()), message.clone())
-            .await
-            .unwrap();
+            .await;
 
-        assert_eq!(output, BackendMiddlewareOutput::Forward(message));
+        assert!(matches!(
+            result,
+            Err(Error::Context(crate::error::ContextError::UnknownOperation))
+        ));
         assert!(!context.schema_ddl_in_flight());
     }
 

--- a/packages/cipherstash-proxy/src/postgresql/middleware/backend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/middleware/backend.rs
@@ -1160,7 +1160,7 @@ mod tests {
 
         assert_eq!(output, BackendMiddlewareOutput::Suppress(message));
         assert!(context.get_execute(operation).is_none());
-        assert!(context.get_session_metrics(scope).is_none());
+        assert!(context.get_metrics_scope(scope).is_none());
     }
 
     #[tokio::test]
@@ -1199,7 +1199,7 @@ mod tests {
         ));
         assert!(backend.discard_execution);
         assert!(context.get_execute(operation).is_none());
-        assert!(context.get_session_metrics(scope).is_none());
+        assert!(context.get_metrics_scope(scope).is_none());
         assert!(context.schema_ddl_in_flight());
     }
 

--- a/packages/cipherstash-proxy/src/postgresql/middleware/backend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/middleware/backend.rs
@@ -1,4 +1,4 @@
-use super::super::context::Context;
+use super::super::context::{Context, ExecutionOutcome};
 use super::super::data::to_sql;
 use super::super::error_handler::PostgreSqlErrorHandler;
 use super::super::rewrite::UNSPECIFIED_TYPE_OID;
@@ -14,9 +14,9 @@ use crate::prometheus::{
 use crate::proxy::EncryptionService;
 use crate::EqlCiphertext;
 use metrics::{counter, histogram};
-use pg_proto::{BackendMessage, BackendMiddlewareOutput, DataRow, OperationId};
+use pg_proto::{BackendMessage, BackendMiddlewareOutput, DataRow, DiagnosticResponse, OperationId};
 use std::time::Instant;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 /// The PostgreSQL proxy backend that handles server-to-client message processing.
 ///
@@ -74,9 +74,49 @@ pub struct Backend<S: EncryptionService> {
 const MAX_ENCRYPTED_ROWS: usize = 4096;
 const MAX_ENCRYPTED_ROW_BYTES: usize = 64 * 1024 * 1024;
 
+fn execution_outcome(message: &BackendMessage) -> Option<ExecutionOutcome> {
+    match message {
+        BackendMessage::CommandComplete(_) | BackendMessage::EmptyQueryResponse => {
+            Some(ExecutionOutcome::Completed)
+        }
+        BackendMessage::PortalSuspended => Some(ExecutionOutcome::Suspended),
+        _ => None,
+    }
+}
+
 impl<S: EncryptionService> Backend<S> {
+    fn finish_execution(
+        &self,
+        operation: Option<OperationId>,
+        outcome: ExecutionOutcome,
+    ) -> Result<Option<DiagnosticResponse>, Error> {
+        let Some(operation) = operation else {
+            return Ok(None);
+        };
+        match self.context.finish_execution(operation, outcome) {
+            Err(Error::Context(crate::error::ContextError::UnknownOperation)) => {
+                warn!(target: PROTOCOL, client_id = self.context.client_id, ?outcome, msg = "Ignoring terminal response for an untracked operation");
+                Ok(None)
+            }
+            result => result,
+        }
+    }
+
     fn error_response(&self, err: Error) -> BackendMessage {
         BackendMessage::ErrorResponse(self.error_to_response(err))
+    }
+
+    fn complete_describe(&self, operation: OperationId) -> Result<(), Error> {
+        match self.context.complete_describe(operation) {
+            Err(Error::Context(
+                crate::error::ContextError::UnknownOperation
+                | crate::error::ContextError::UnknownDescribe,
+            )) => {
+                warn!(target: PROTOCOL, client_id = self.context.client_id, msg = "Ignoring Describe response for an untracked operation");
+                Ok(())
+            }
+            result => result,
+        }
     }
 
     fn decryption_failure(&mut self, err: Error) -> BackendMiddlewareOutput {
@@ -120,9 +160,24 @@ impl<S: EncryptionService> Backend<S> {
     ) -> Result<BackendMiddlewareOutput, Error> {
         let mut outbound_message = protocol_message.clone();
 
-        if matches!(protocol_message, BackendMessage::ErrorResponse(_)) {
-            if let Some(response) = operation.and_then(|id| self.context.take_operation_error(id)) {
-                outbound_message = BackendMessage::ErrorResponse(response);
+        match &protocol_message {
+            BackendMessage::CommandComplete(_)
+            | BackendMessage::EmptyQueryResponse
+            | BackendMessage::PortalSuspended => {
+                self.context.report_schema_execution_succeeded();
+            }
+            BackendMessage::ErrorResponse(_) => {
+                self.context.report_schema_execution_failed();
+            }
+            _ => {}
+        }
+
+        if matches!(
+            protocol_message,
+            BackendMessage::ParseComplete | BackendMessage::BindComplete
+        ) {
+            if let Some(operation) = operation {
+                self.context.complete_non_execution(operation)?;
             }
         }
 
@@ -138,37 +193,33 @@ impl<S: EncryptionService> Backend<S> {
             // client opening its next connection after ReadyForQuery observes
             // the newly loaded schema and encrypt configuration.
             if let BackendMessage::ReadyForQuery(status) = &protocol_message {
-                self.handle_ready_for_query(*status).await?;
+                self.handle_ready_for_query(operation, *status).await?;
             }
 
             // CipherStash metadata is operation-keyed even in passthrough mode,
             // and must be released when pg-proto identifies its terminal response.
-            match protocol_message {
-                BackendMessage::CommandComplete(_)
-                | BackendMessage::EmptyQueryResponse
-                | BackendMessage::PortalSuspended => {
-                    self.context.schema_execution_succeeded();
-                    if let Some(operation) = operation {
-                        let session = self.context.complete_execution(operation);
-                        self.context.discard_operation(operation);
-                        self.context.finish_session(session);
-                    }
+            if let Some(outcome) = execution_outcome(&protocol_message) {
+                if let Some(response) = self.finish_execution(operation, outcome)? {
+                    outbound_message = BackendMessage::ErrorResponse(response);
                 }
-                BackendMessage::ErrorResponse(_) => {
-                    self.context.schema_execution_failed();
-                    if let Some(operation) = operation {
-                        let session = self.context.complete_execution(operation);
-                        self.context.discard_operation(operation);
-                        self.context.finish_session(session);
-                    }
+            } else if matches!(protocol_message, BackendMessage::ErrorResponse(_))
+                && operation.is_some()
+            {
+                if let Some(response) =
+                    self.finish_execution(operation, ExecutionOutcome::Failed)?
+                {
+                    outbound_message = BackendMessage::ErrorResponse(response);
                 }
-                BackendMessage::RowDescription(_) | BackendMessage::NoData => {
-                    if let Some(operation) = operation {
-                        self.context.complete_describe(operation);
+            } else {
+                match protocol_message {
+                    BackendMessage::RowDescription(_) | BackendMessage::NoData => {
+                        if let Some(operation) = operation {
+                            self.complete_describe(operation)?;
+                        }
                     }
+                    BackendMessage::ReadyForQuery(_) => {}
+                    _ => {}
                 }
-                BackendMessage::ReadyForQuery(_) => {}
-                _ => {}
             }
 
             return Ok(BackendMiddlewareOutput::Forward(outbound_message));
@@ -178,25 +229,15 @@ impl<S: EncryptionService> Backend<S> {
             match protocol_message {
                 BackendMessage::CommandComplete(_)
                 | BackendMessage::EmptyQueryResponse
-                | BackendMessage::PortalSuspended => {
-                    self.context.schema_execution_succeeded();
+                | BackendMessage::PortalSuspended
+                | BackendMessage::ErrorResponse(_) => {
                     if let Some(operation) = operation {
-                        let session = self.context.complete_execution(operation);
                         self.context.discard_operation(operation);
-                        self.context.finish_session(session);
-                    }
-                }
-                BackendMessage::ErrorResponse(_) => {
-                    self.context.schema_execution_failed();
-                    if let Some(operation) = operation {
-                        let session = self.context.complete_execution(operation);
-                        self.context.discard_operation(operation);
-                        self.context.finish_session(session);
                     }
                 }
                 BackendMessage::ReadyForQuery(status) => {
                     self.discard_execution = false;
-                    self.handle_ready_for_query(status).await?;
+                    self.handle_ready_for_query(operation, status).await?;
                     return Ok(BackendMiddlewareOutput::Forward(
                         BackendMessage::ReadyForQuery(status),
                     ));
@@ -209,15 +250,12 @@ impl<S: EncryptionService> Backend<S> {
         let mut prefix = if !matches!(protocol_message, BackendMessage::DataRow(_))
             && !self.encrypted_rows.is_empty()
         {
+            let encrypted_rows_operation = self.encrypted_rows_operation;
             match self.flush_encrypted_rows().await {
                 Ok(messages) => messages,
                 Err(err) => {
                     self.discard_execution = true;
-                    if let Some(operation) = operation {
-                        let session = self.context.complete_execution(operation);
-                        self.context.discard_operation(operation);
-                        self.context.finish_session(session);
-                    }
+                    self.finish_execution(encrypted_rows_operation, ExecutionOutcome::Failed)?;
                     return Ok(self.decryption_failure(err));
                 }
             }
@@ -230,6 +268,12 @@ impl<S: EncryptionService> Backend<S> {
 
         match protocol_message {
             BackendMessage::DataRow(row) => {
+                if operation.is_none_or(|operation| {
+                    self.context.get_portal_from_execute(operation).is_none()
+                }) {
+                    return Ok(self
+                        .decryption_failure(crate::error::ContextError::UnknownOperation.into()));
+                }
                 // Encrypted DataRows are added to the buffer and we return early
                 // Otherwise, continue and write
                 if self.data_row_handler(operation).await? {
@@ -263,32 +307,33 @@ impl<S: EncryptionService> Backend<S> {
                     }
                     return match self.flush_encrypted_rows().await {
                         Ok(messages) => Ok(BackendMiddlewareOutput::Expand(messages)),
-                        Err(err) => Ok(self.decryption_failure(err)),
+                        Err(err) => {
+                            self.finish_execution(Some(operation), ExecutionOutcome::Failed)?;
+                            Ok(self.decryption_failure(err))
+                        }
                     };
                 }
             }
 
             // Execute phase is always terminated by the appearance of exactly one of these messages:
-            //      CommandComplete, EmptyQueryResponse (if the portal was created from an empty query string), ErrorResponse, or PortalSuspended.
-            BackendMessage::CommandComplete(_)
+            //      CommandComplete, EmptyQueryResponse (if the portal was created from an empty query string), or PortalSuspended.
+            terminal @ (BackendMessage::CommandComplete(_)
             | BackendMessage::EmptyQueryResponse
-            | BackendMessage::PortalSuspended => {
-                debug!(target: PROTOCOL, client_id = self.context.client_id, msg = "CommandComplete | EmptyQueryResponse | PortalSuspended");
-
-                if let Some(operation) = operation {
-                    let session = self.context.complete_execution(operation);
-                    self.context.discard_operation(operation);
-                    self.context.finish_session(session);
+            | BackendMessage::PortalSuspended) => {
+                let outcome = execution_outcome(&terminal).unwrap();
+                debug!(target: PROTOCOL, client_id = self.context.client_id, ?outcome, msg = "Execute outcome");
+                if let Some(response) = self.finish_execution(operation, outcome)? {
+                    outbound_message = BackendMessage::ErrorResponse(response);
                 }
-                self.context.schema_execution_succeeded();
             }
-            BackendMessage::ErrorResponse(ref response) => {
-                self.context.schema_execution_failed();
-                self.error_response_handler(response);
-
-                if let Some(operation) = operation {
-                    let session = self.context.complete_execution(operation);
-                    self.context.finish_session(session);
+            BackendMessage::ErrorResponse(response) => {
+                self.error_response_handler(&response);
+                if operation.is_some() {
+                    if let Some(response) =
+                        self.finish_execution(operation, ExecutionOutcome::Failed)?
+                    {
+                        outbound_message = BackendMessage::ErrorResponse(response);
+                    }
                 }
             }
             // Describe with Target:Statement
@@ -309,14 +354,14 @@ impl<S: EncryptionService> Backend<S> {
                     outbound_message = message;
                 }
                 if let Some(operation) = operation {
-                    self.context.complete_describe(operation);
+                    self.complete_describe(operation)?;
                 }
             }
             // Describe with Target:Statement or Target::Portal
             // If the statement returns no rows, NoData is returned instead of a RowDescription
             BackendMessage::NoData => {
                 if let Some(operation) = operation {
-                    self.context.complete_describe(operation);
+                    self.complete_describe(operation)?;
                 }
             }
             // Reload for SompleQuery flow
@@ -327,7 +372,7 @@ impl<S: EncryptionService> Backend<S> {
                     client_id = self.context.client_id,
                     msg = "ReadyForQuery"
                 );
-                self.handle_ready_for_query(status).await?;
+                self.handle_ready_for_query(operation, status).await?;
             }
 
             _ => {
@@ -351,9 +396,10 @@ impl<S: EncryptionService> Backend<S> {
     /// connection-local transaction state from the same authoritative boundary.
     async fn handle_ready_for_query(
         &mut self,
+        operation: Option<OperationId>,
         status: pg_proto::TransactionStatus,
     ) -> Result<(), Error> {
-        self.context.set_transaction_status(status);
+        self.context.ready_for_query(status, operation)?;
         if status == pg_proto::TransactionStatus::Idle {
             self.context.publish_schema_if_changed().await?;
         }
@@ -745,11 +791,15 @@ mod tests {
     use crate::config::TandemConfig;
     use crate::postgresql::context::KeysetIdentifier;
     use crate::postgresql::parser::SqlParser;
+    use crate::postgresql::rewrite::Name;
+    use crate::postgresql::test_operation_id as operation_id;
     use crate::proxy::{EncryptConfig, EncryptionService};
+    use cipherstash_client::schema::{ColumnConfig, ColumnType};
     use eql_mapper::Schema;
     use std::sync::Arc;
     use tokio::sync::mpsc;
 
+    #[derive(Clone)]
     struct TestService {}
 
     #[async_trait::async_trait]
@@ -781,8 +831,18 @@ mod tests {
     }
 
     fn create_backend() -> Backend<TestService> {
+        create_backend_with_context().0
+    }
+
+    fn create_backend_with_context() -> (Backend<TestService>, Context<TestService>) {
+        create_backend_with_encrypt_config(EncryptConfig::default())
+    }
+
+    fn create_backend_with_encrypt_config(
+        encrypt_config: EncryptConfig,
+    ) -> (Backend<TestService>, Context<TestService>) {
         let config = Arc::new(TandemConfig::for_testing());
-        let encrypt_config = Arc::new(EncryptConfig::default());
+        let encrypt_config = Arc::new(encrypt_config);
         let schema = Arc::new(Schema::new("public"));
         let (reload_sender, _) = mpsc::unbounded_channel();
         let context = Context::new(
@@ -794,7 +854,7 @@ mod tests {
             TestService {},
             reload_sender,
         );
-        Backend::new(context)
+        (Backend::new(context.clone()), context)
     }
 
     #[test]
@@ -828,7 +888,7 @@ mod tests {
         );
         let ddl = SqlParser::parse_statement("create table reports (id bigint)").unwrap();
         context.execute_simple_schema_statements(&[ddl]);
-        context.schema_execution_succeeded();
+        context.report_schema_execution_succeeded();
 
         let mut backend = Backend::new(context);
         let expected =
@@ -837,6 +897,295 @@ mod tests {
 
         assert_eq!(output, BackendMiddlewareOutput::Forward(expected));
         assert!(reload_receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn database_error_without_an_execution_is_forwarded() {
+        let mut backend = create_backend();
+        let response = crate::postgresql::diagnostics::invalid_sql_statement(
+            "syntax error at or near SELECT".to_owned(),
+        );
+        let message = BackendMessage::ErrorResponse(response.clone());
+
+        let output = backend.intercept(None, message.clone()).await.unwrap();
+
+        assert_eq!(output, BackendMiddlewareOutput::Forward(message));
+    }
+
+    #[tokio::test]
+    async fn terminal_message_without_an_operation_is_forwarded() {
+        let (mut backend, context) = create_backend_with_context();
+        let ddl = SqlParser::parse_statement("create table reports (id bigint)").unwrap();
+        context.execute_simple_schema_statements(&[ddl]);
+        assert!(context.schema_ddl_in_flight());
+        let message = BackendMessage::CommandComplete(bytes::Bytes::from_static(b"SELECT 1"));
+
+        let output = backend.intercept(None, message.clone()).await.unwrap();
+
+        assert_eq!(output, BackendMiddlewareOutput::Forward(message));
+        assert!(!context.schema_ddl_in_flight());
+    }
+
+    #[tokio::test]
+    async fn unexpected_terminal_message_is_forwarded() {
+        let mut backend = create_backend();
+        let message = BackendMessage::CommandComplete(bytes::Bytes::from_static(b"SELECT 1"));
+
+        let output = backend
+            .intercept(Some(operation_id()), message.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(output, BackendMiddlewareOutput::Forward(message));
+    }
+
+    #[tokio::test]
+    async fn no_data_for_an_untracked_describe_is_forwarded() {
+        let mut backend = create_backend();
+
+        let output = backend
+            .intercept(Some(operation_id()), BackendMessage::NoData)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            output,
+            BackendMiddlewareOutput::Forward(BackendMessage::NoData)
+        );
+    }
+
+    #[tokio::test]
+    async fn row_description_for_an_untracked_mapped_operation_is_forwarded() {
+        let mut encrypt_config = EncryptConfig::default();
+        encrypt_config.insert(
+            crate::Identifier::new("records", "secret"),
+            ColumnConfig::build("secret".to_owned()).casts_as(ColumnType::Text),
+        );
+        let (mut backend, _) = create_backend_with_encrypt_config(encrypt_config);
+        let message = BackendMessage::RowDescription(pg_proto::RowDescription { fields: vec![] });
+
+        let output = backend
+            .intercept(Some(operation_id()), message.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(output, BackendMiddlewareOutput::Forward(message));
+    }
+
+    #[tokio::test]
+    async fn data_row_without_mapped_execution_metadata_fails_closed() {
+        let mut encrypt_config = EncryptConfig::default();
+        encrypt_config.insert(
+            crate::Identifier::new("records", "secret"),
+            ColumnConfig::build("secret".to_owned()).casts_as(ColumnType::Text),
+        );
+        let (mut backend, _) = create_backend_with_encrypt_config(encrypt_config);
+
+        let output = backend
+            .intercept(
+                Some(operation_id()),
+                BackendMessage::DataRow(DataRow {
+                    columns: vec![Some(bytes::Bytes::from_static(b"ciphertext"))],
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            output,
+            BackendMiddlewareOutput::Expand(messages)
+                if matches!(messages.as_slice(), [BackendMessage::ErrorResponse(_)])
+        ));
+        assert!(backend.discard_execution);
+    }
+
+    #[tokio::test]
+    async fn database_error_for_a_non_execution_operation_is_forwarded() {
+        let (mut backend, context) = create_backend_with_context();
+        let operation = operation_id();
+        context.set_non_execution(operation).unwrap();
+        let response = crate::postgresql::diagnostics::invalid_sql_statement(
+            "syntax error at or near SELECT".to_owned(),
+        );
+        let message = BackendMessage::ErrorResponse(response);
+
+        let output = backend
+            .intercept(Some(operation), message.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(output, BackendMiddlewareOutput::Forward(message));
+    }
+
+    #[tokio::test]
+    async fn database_error_for_an_unregistered_operation_is_forwarded() {
+        let (mut backend, context) = create_backend_with_context();
+        let ddl = SqlParser::parse_statement("create table reports (id bigint)").unwrap();
+        context.execute_simple_schema_statements(&[ddl]);
+        assert!(context.schema_ddl_in_flight());
+        let message = BackendMessage::ErrorResponse(
+            crate::postgresql::diagnostics::invalid_sql_statement("database error".to_owned()),
+        );
+
+        let output = backend
+            .intercept(Some(operation_id()), message.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(output, BackendMiddlewareOutput::Forward(message));
+        assert!(!context.schema_ddl_in_flight());
+    }
+
+    #[tokio::test]
+    async fn parse_completion_releases_non_execution_error_correlation() {
+        let (mut backend, context) = create_backend_with_context();
+        let operation = operation_id();
+        context.set_non_execution(operation).unwrap();
+
+        let output = backend
+            .intercept(Some(operation), BackendMessage::ParseComplete)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            output,
+            BackendMiddlewareOutput::Forward(BackendMessage::ParseComplete)
+        );
+        assert!(matches!(
+            context.finish_execution(operation, ExecutionOutcome::Failed),
+            Err(Error::Context(crate::error::ContextError::UnknownOperation))
+        ));
+    }
+
+    #[tokio::test]
+    async fn stored_proxy_error_replaces_a_non_execution_database_error() {
+        let (mut backend, mut context) = create_backend_with_context();
+        let operation = operation_id();
+        let replacement =
+            crate::postgresql::diagnostics::invalid_sql_statement("proxy parse error".to_owned());
+        context.set_operation_error(operation, replacement.clone());
+        let database_error =
+            BackendMessage::ErrorResponse(crate::postgresql::diagnostics::invalid_sql_statement(
+                "database parse error".to_owned(),
+            ));
+
+        let output = backend
+            .intercept(Some(operation), database_error)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            output,
+            BackendMiddlewareOutput::Forward(BackendMessage::ErrorResponse(replacement))
+        );
+    }
+
+    #[tokio::test]
+    async fn successful_execution_is_not_replaced_by_a_stored_error() {
+        let (mut backend, mut context) = create_backend_with_context();
+        let operation = operation_id();
+        let scope = context.start_metrics_scope();
+        context
+            .set_execute(operation, Name::new(), Some(scope))
+            .unwrap();
+        context.set_operation_error(
+            operation,
+            crate::postgresql::diagnostics::invalid_sql_statement("proxy error".to_owned()),
+        );
+        let message = BackendMessage::CommandComplete(bytes::Bytes::from_static(b"SELECT 1"));
+
+        let output = backend
+            .intercept(Some(operation), message.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(output, BackendMiddlewareOutput::Forward(message));
+    }
+
+    #[tokio::test]
+    async fn decryption_recovery_discards_suppressed_execution_state() {
+        let mut encrypt_config = EncryptConfig::default();
+        encrypt_config.insert(
+            crate::Identifier::new("records", "secret"),
+            ColumnConfig::build("secret".to_owned()).casts_as(ColumnType::Text),
+        );
+        let (mut backend, mut context) = create_backend_with_encrypt_config(encrypt_config);
+        let operation = operation_id();
+        let scope = context.start_metrics_scope();
+        context
+            .set_execute(operation, Name::new(), Some(scope))
+            .unwrap();
+        backend.discard_execution = true;
+        let message = BackendMessage::CommandComplete(bytes::Bytes::from_static(b"SELECT 1"));
+
+        let output = backend
+            .intercept(Some(operation), message.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(output, BackendMiddlewareOutput::Suppress(message));
+        assert!(context.get_execute(operation).is_none());
+        assert!(context.get_session_metrics(scope).is_none());
+    }
+
+    #[tokio::test]
+    async fn uncorrelated_flush_failure_returns_a_postgresql_error() {
+        let mut encrypt_config = EncryptConfig::default();
+        encrypt_config.insert(
+            crate::Identifier::new("records", "secret"),
+            ColumnConfig::build("secret".to_owned()).casts_as(ColumnType::Text),
+        );
+        let (mut backend, mut context) = create_backend_with_encrypt_config(encrypt_config);
+        let operation = operation_id();
+        let scope = context.start_metrics_scope();
+        context
+            .set_execute(operation, Name::new(), Some(scope))
+            .unwrap();
+        let first = SqlParser::parse_statement("select 1").unwrap();
+        let ddl = SqlParser::parse_statement("create table reports (id bigint)").unwrap();
+        context.execute_simple_schema_statements(&[first, ddl]);
+        assert!(context.schema_ddl_in_flight());
+        backend.encrypted_rows_operation = Some(operation);
+        backend.encrypted_rows.push(DataRow {
+            columns: vec![Some(bytes::Bytes::from_static(b"invalid ciphertext"))],
+        });
+
+        let output = backend
+            .intercept(
+                None,
+                BackendMessage::ReadyForQuery(pg_proto::TransactionStatus::Idle),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            output,
+            BackendMiddlewareOutput::Expand(messages)
+                if matches!(messages.as_slice(), [BackendMessage::ErrorResponse(_)])
+        ));
+        assert!(backend.discard_execution);
+        assert!(context.get_execute(operation).is_none());
+        assert!(context.get_session_metrics(scope).is_none());
+        assert!(context.schema_ddl_in_flight());
+    }
+
+    #[tokio::test]
+    async fn suspended_portal_resolves_one_schema_execution() {
+        let (mut backend, context) = create_backend_with_context();
+        let ddl = SqlParser::parse_statement("create table reports (id bigint)").unwrap();
+        context.execute_simple_schema_statements(&[ddl]);
+        assert!(context.schema_ddl_in_flight());
+
+        let output = backend
+            .intercept(None, BackendMessage::PortalSuspended)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            output,
+            BackendMiddlewareOutput::Forward(BackendMessage::PortalSuspended)
+        );
+        assert!(!context.schema_ddl_in_flight());
     }
 
     #[tokio::test]
@@ -856,7 +1205,7 @@ mod tests {
         );
         let ddl = SqlParser::parse_statement("create table reports (id bigint)").unwrap();
         context.execute_simple_schema_statements(&[ddl]);
-        context.schema_execution_succeeded();
+        context.report_schema_execution_succeeded();
 
         let reload_task = tokio::spawn(async move {
             let Some(crate::proxy::ReloadCommand::DatabaseSchema(responder)) =

--- a/packages/cipherstash-proxy/src/postgresql/middleware/backend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/middleware/backend.rs
@@ -7,6 +7,7 @@ use crate::error::{EncryptError, Error, ProtocolError};
 use crate::log::{CONTEXT, DEVELOPMENT, MAPPER, PROTOCOL};
 use crate::postgresql::context::Portal;
 use crate::postgresql::rewrite::data_row;
+use crate::postgresql::OperationId;
 use crate::prometheus::{
     DECRYPTED_VALUES_TOTAL, DECRYPTION_DURATION_SECONDS, DECRYPTION_ERROR_TOTAL,
     DECRYPTION_REQUESTS_TOTAL, ROWS_ENCRYPTED_TOTAL, ROWS_PASSTHROUGH_TOTAL, ROWS_TOTAL,
@@ -14,7 +15,7 @@ use crate::prometheus::{
 use crate::proxy::EncryptionService;
 use crate::EqlCiphertext;
 use metrics::{counter, histogram};
-use pg_proto::{BackendMessage, BackendMiddlewareOutput, DataRow, DiagnosticResponse, OperationId};
+use pg_proto::{BackendMessage, BackendMiddlewareOutput, DataRow, DiagnosticResponse};
 use std::time::Instant;
 use tracing::{debug, error, info, warn};
 
@@ -94,7 +95,10 @@ impl<S: EncryptionService> Backend<S> {
             return Ok(None);
         };
         match self.context.finish_execution(operation, outcome) {
-            Err(Error::Context(crate::error::ContextError::UnknownOperation)) => {
+            Err(Error::Context(
+                crate::error::ContextError::UnknownOperation
+                | crate::error::ContextError::OperationWithoutExecute,
+            )) => {
                 warn!(target: PROTOCOL, client_id = self.context.client_id, ?outcome, msg = "Ignoring terminal response for an untracked operation");
                 Ok(None)
             }
@@ -160,18 +164,6 @@ impl<S: EncryptionService> Backend<S> {
     ) -> Result<BackendMiddlewareOutput, Error> {
         let mut outbound_message = protocol_message.clone();
 
-        match &protocol_message {
-            BackendMessage::CommandComplete(_)
-            | BackendMessage::EmptyQueryResponse
-            | BackendMessage::PortalSuspended => {
-                self.context.report_schema_execution_succeeded();
-            }
-            BackendMessage::ErrorResponse(_) => {
-                self.context.report_schema_execution_failed();
-            }
-            _ => {}
-        }
-
         if matches!(
             protocol_message,
             BackendMessage::ParseComplete | BackendMessage::BindComplete
@@ -182,6 +174,17 @@ impl<S: EncryptionService> Backend<S> {
         }
 
         if self.context.is_passthrough() {
+            match &protocol_message {
+                BackendMessage::CommandComplete(_)
+                | BackendMessage::EmptyQueryResponse
+                | BackendMessage::PortalSuspended => {
+                    self.context.report_schema_execution_succeeded();
+                }
+                BackendMessage::ErrorResponse(_) => {
+                    self.context.report_schema_execution_failed();
+                }
+                _ => {}
+            }
             debug!(target: DEVELOPMENT,
                 client_id = self.context.client_id,
                 msg = "Passthrough enabled"
@@ -232,7 +235,7 @@ impl<S: EncryptionService> Backend<S> {
                 | BackendMessage::PortalSuspended
                 | BackendMessage::ErrorResponse(_) => {
                     if let Some(operation) = operation {
-                        self.context.discard_operation(operation);
+                        self.context.discard_operation(operation)?;
                     }
                 }
                 BackendMessage::ReadyForQuery(status) => {
@@ -263,17 +266,23 @@ impl<S: EncryptionService> Backend<S> {
             Vec::new()
         };
 
+        match &protocol_message {
+            BackendMessage::CommandComplete(_)
+            | BackendMessage::EmptyQueryResponse
+            | BackendMessage::PortalSuspended => {
+                self.context.report_schema_execution_succeeded();
+            }
+            BackendMessage::ErrorResponse(_) => {
+                self.context.report_schema_execution_failed();
+            }
+            _ => {}
+        }
+
         let keyset_id = self.context.keyset_identifier();
         debug!(target: CONTEXT, client_id = ?self.context.client_id, ?keyset_id);
 
         match protocol_message {
             BackendMessage::DataRow(row) => {
-                if operation.is_none_or(|operation| {
-                    self.context.get_portal_from_execute(operation).is_none()
-                }) {
-                    return Ok(self
-                        .decryption_failure(crate::error::ContextError::UnknownOperation.into()));
-                }
                 // Encrypted DataRows are added to the buffer and we return early
                 // Otherwise, continue and write
                 if self.data_row_handler(operation).await? {
@@ -508,8 +517,10 @@ impl<S: EncryptionService> Backend<S> {
         let mut rows = std::mem::take(&mut self.encrypted_rows);
         self.encrypted_rows_bytes = 0;
 
-        let portal =
-            operation.and_then(|operation| self.context.get_portal_from_execute(operation));
+        let portal = operation
+            .map(|operation| self.context.get_portal_from_execute(operation))
+            .transpose()?
+            .flatten();
         let portal = match portal.as_deref() {
             Some(Portal::Encrypted { .. }) => portal.unwrap(),
             _ => {
@@ -559,7 +570,7 @@ impl<S: EncryptionService> Backend<S> {
         // Always record for slow-statement diagnostics
         if let Some(operation) = operation {
             self.context
-                .add_decrypt_duration_for_execute(operation, duration);
+                .add_decrypt_duration_for_execute(operation, duration)?;
         }
 
         // Prometheus metrics remain gated
@@ -637,9 +648,11 @@ impl<S: EncryptionService> Backend<S> {
     ) -> Result<Option<BackendMessage>, Error> {
         debug!(target: PROTOCOL, client_id = self.context.client_id, ParamDescription = ?description);
 
-        if let Some(statement) =
-            operation.and_then(|operation| self.context.get_statement_from_describe(operation))
-        {
+        let statement = operation
+            .map(|operation| self.context.get_statement_from_describe(operation))
+            .transpose()?
+            .flatten();
+        if let Some(statement) = statement {
             // Describe the params the CLIENT wrote, not the ones PostgreSQL was
             // sent. A rewrite may have fused or dropped params, in which case
             // the server's description is both shorter than and shifted from
@@ -695,9 +708,11 @@ impl<S: EncryptionService> Backend<S> {
     ) -> Result<Option<BackendMessage>, Error> {
         debug!(target: PROTOCOL, client_id = self.context.client_id, RowDescription = ?description);
 
-        if let Some(statement) =
-            operation.and_then(|operation| self.context.get_statement_for_operation(operation))
-        {
+        let statement = operation
+            .map(|operation| self.context.get_statement_for_operation(operation))
+            .transpose()?
+            .flatten();
+        if let Some(statement) = statement {
             let projection_types = statement
                 .projection_columns
                 .iter()
@@ -759,10 +774,11 @@ impl<S: EncryptionService> Backend<S> {
     /// track proxy performance and encryption usage patterns.
     async fn data_row_handler(&mut self, operation: Option<OperationId>) -> Result<bool, Error> {
         counter!(ROWS_TOTAL).increment(1);
-        match operation
-            .and_then(|operation| self.context.get_portal_from_execute(operation))
-            .as_deref()
-        {
+        let portal = operation
+            .map(|operation| self.context.get_portal_from_execute(operation))
+            .transpose()?
+            .flatten();
+        match portal.as_deref() {
             Some(Portal::Encrypted { .. }) => {
                 debug!(target: MAPPER, client_id = self.context.client_id, msg = "Encrypted");
 
@@ -790,6 +806,7 @@ mod tests {
     use super::*;
     use crate::config::TandemConfig;
     use crate::postgresql::context::KeysetIdentifier;
+    use crate::postgresql::context::ResultOptionTestExt as _;
     use crate::postgresql::parser::SqlParser;
     use crate::postgresql::rewrite::Name;
     use crate::postgresql::test_operation_id as operation_id;
@@ -940,6 +957,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn terminal_message_for_a_non_execution_operation_is_forwarded() {
+        let (mut backend, context) = create_backend_with_context();
+        let operation = operation_id();
+        context.set_non_execution(operation).unwrap();
+        let message = BackendMessage::CommandComplete(bytes::Bytes::from_static(b"SELECT 1"));
+
+        let output = backend
+            .intercept(Some(operation), message.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(output, BackendMiddlewareOutput::Forward(message));
+    }
+
+    #[tokio::test]
     async fn no_data_for_an_untracked_describe_is_forwarded() {
         let mut backend = create_backend();
 
@@ -973,7 +1005,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn data_row_without_mapped_execution_metadata_fails_closed() {
+    async fn data_row_without_mapped_execution_metadata_is_forwarded() {
         let mut encrypt_config = EncryptConfig::default();
         encrypt_config.insert(
             crate::Identifier::new("records", "secret"),
@@ -981,22 +1013,16 @@ mod tests {
         );
         let (mut backend, _) = create_backend_with_encrypt_config(encrypt_config);
 
+        let message = BackendMessage::DataRow(DataRow {
+            columns: vec![Some(bytes::Bytes::from_static(b"ciphertext"))],
+        });
         let output = backend
-            .intercept(
-                Some(operation_id()),
-                BackendMessage::DataRow(DataRow {
-                    columns: vec![Some(bytes::Bytes::from_static(b"ciphertext"))],
-                }),
-            )
+            .intercept(Some(operation_id()), message.clone())
             .await
             .unwrap();
 
-        assert!(matches!(
-            output,
-            BackendMiddlewareOutput::Expand(messages)
-                if matches!(messages.as_slice(), [BackendMessage::ErrorResponse(_)])
-        ));
-        assert!(backend.discard_execution);
+        assert_eq!(output, BackendMiddlewareOutput::Forward(message));
+        assert!(!backend.discard_execution);
     }
 
     #[tokio::test]
@@ -1063,7 +1089,9 @@ mod tests {
         let operation = operation_id();
         let replacement =
             crate::postgresql::diagnostics::invalid_sql_statement("proxy parse error".to_owned());
-        context.set_operation_error(operation, replacement.clone());
+        context
+            .set_operation_error(operation, replacement.clone())
+            .unwrap();
         let database_error =
             BackendMessage::ErrorResponse(crate::postgresql::diagnostics::invalid_sql_statement(
                 "database parse error".to_owned(),
@@ -1084,14 +1112,16 @@ mod tests {
     async fn successful_execution_is_not_replaced_by_a_stored_error() {
         let (mut backend, mut context) = create_backend_with_context();
         let operation = operation_id();
-        let scope = context.start_metrics_scope();
+        let scope = context.start_metrics_scope().unwrap();
         context
             .set_execute(operation, Name::new(), Some(scope))
             .unwrap();
-        context.set_operation_error(
-            operation,
-            crate::postgresql::diagnostics::invalid_sql_statement("proxy error".to_owned()),
-        );
+        context
+            .set_operation_error(
+                operation,
+                crate::postgresql::diagnostics::invalid_sql_statement("proxy error".to_owned()),
+            )
+            .unwrap();
         let message = BackendMessage::CommandComplete(bytes::Bytes::from_static(b"SELECT 1"));
 
         let output = backend
@@ -1111,7 +1141,7 @@ mod tests {
         );
         let (mut backend, mut context) = create_backend_with_encrypt_config(encrypt_config);
         let operation = operation_id();
-        let scope = context.start_metrics_scope();
+        let scope = context.start_metrics_scope().unwrap();
         context
             .set_execute(operation, Name::new(), Some(scope))
             .unwrap();
@@ -1137,13 +1167,12 @@ mod tests {
         );
         let (mut backend, mut context) = create_backend_with_encrypt_config(encrypt_config);
         let operation = operation_id();
-        let scope = context.start_metrics_scope();
+        let scope = context.start_metrics_scope().unwrap();
         context
             .set_execute(operation, Name::new(), Some(scope))
             .unwrap();
-        let first = SqlParser::parse_statement("select 1").unwrap();
         let ddl = SqlParser::parse_statement("create table reports (id bigint)").unwrap();
-        context.execute_simple_schema_statements(&[first, ddl]);
+        context.execute_simple_schema_statements(&[ddl]);
         assert!(context.schema_ddl_in_flight());
         backend.encrypted_rows_operation = Some(operation);
         backend.encrypted_rows.push(DataRow {
@@ -1153,7 +1182,7 @@ mod tests {
         let output = backend
             .intercept(
                 None,
-                BackendMessage::ReadyForQuery(pg_proto::TransactionStatus::Idle),
+                BackendMessage::CommandComplete(bytes::Bytes::from_static(b"CREATE TABLE")),
             )
             .await
             .unwrap();

--- a/packages/cipherstash-proxy/src/postgresql/middleware/backend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/middleware/backend.rs
@@ -1075,6 +1075,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn correlated_non_execution_completion_for_an_unknown_operation_fails_closed() {
+        for message in [BackendMessage::ParseComplete, BackendMessage::BindComplete] {
+            let mut backend = create_backend();
+
+            let result = backend.intercept(Some(operation_id()), message).await;
+
+            assert!(matches!(
+                result,
+                Err(Error::Context(crate::error::ContextError::UnknownOperation))
+            ));
+        }
+    }
+
+    #[tokio::test]
     async fn stored_proxy_error_replaces_a_non_execution_database_error() {
         let (mut backend, mut context) = create_backend_with_context();
         let operation = operation_id();

--- a/packages/cipherstash-proxy/src/postgresql/middleware/backend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/middleware/backend.rs
@@ -52,7 +52,7 @@ use tracing::{debug, error, info};
 ///
 /// DataRow messages containing encrypted data are buffered to enable batch decryption:
 /// - Buffer fills up to a configurable capacity
-/// - Flush occurs on buffer full, session end, or non-DataRow message
+/// - Flush occurs on buffer full, connection end, or non-DataRow message
 /// - Batching reduces encryption API round-trips and improves performance
 ///
 /// # Message Types Handled
@@ -214,8 +214,14 @@ impl<S: EncryptionService> Backend<S> {
             match protocol_message {
                 BackendMessage::CommandComplete(_)
                 | BackendMessage::EmptyQueryResponse
-                | BackendMessage::PortalSuspended
-                | BackendMessage::ErrorResponse(_) => {
+                | BackendMessage::PortalSuspended => {
+                    self.context.report_schema_execution_succeeded();
+                    if let Some(operation) = operation {
+                        self.context.discard_operation(operation)?;
+                    }
+                }
+                BackendMessage::ErrorResponse(_) => {
+                    self.context.report_schema_execution_failed();
                     if let Some(operation) = operation {
                         self.context.discard_operation(operation)?;
                     }
@@ -1163,6 +1169,34 @@ mod tests {
             Err(Error::Context(crate::error::ContextError::UnknownOperation))
         ));
         assert!(context.get_metrics_scope(scope).unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn discarded_execution_response_resolves_its_schema_execution() {
+        let mut encrypt_config = EncryptConfig::default();
+        encrypt_config.insert(
+            crate::Identifier::new("records", "secret"),
+            ColumnConfig::build("secret".to_owned()).casts_as(ColumnType::Text),
+        );
+        let (mut backend, mut context) = create_backend_with_encrypt_config(encrypt_config);
+        let operation = operation_id();
+        let scope = context.start_metrics_scope().unwrap();
+        context
+            .set_execute(operation, Name::new(), Some(scope))
+            .unwrap();
+        let ddl = SqlParser::parse_statement("create table reports (id bigint)").unwrap();
+        context.execute_simple_schema_statements(&[ddl]);
+        assert!(context.schema_ddl_in_flight());
+        backend.discard_execution = true;
+
+        let message = BackendMessage::CommandComplete(bytes::Bytes::from_static(b"CREATE TABLE"));
+        let output = backend
+            .intercept(Some(operation), message.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(output, BackendMiddlewareOutput::Suppress(message));
+        assert!(!context.schema_ddl_in_flight());
     }
 
     #[tokio::test]

--- a/packages/cipherstash-proxy/src/postgresql/middleware/backend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/middleware/backend.rs
@@ -788,7 +788,6 @@ mod tests {
     use super::*;
     use crate::config::TandemConfig;
     use crate::postgresql::context::KeysetIdentifier;
-    use crate::postgresql::context::ResultOptionTestExt as _;
     use crate::postgresql::parser::SqlParser;
     use crate::postgresql::rewrite::Name;
     use crate::postgresql::test_operation_id as operation_id;
@@ -1159,8 +1158,11 @@ mod tests {
             .unwrap();
 
         assert_eq!(output, BackendMiddlewareOutput::Suppress(message));
-        assert!(context.get_execute(operation).is_none());
-        assert!(context.get_metrics_scope(scope).is_none());
+        assert!(matches!(
+            context.get_execute(operation),
+            Err(Error::Context(crate::error::ContextError::UnknownOperation))
+        ));
+        assert!(context.get_metrics_scope(scope).unwrap().is_none());
     }
 
     #[tokio::test]
@@ -1198,8 +1200,11 @@ mod tests {
                 if matches!(messages.as_slice(), [BackendMessage::ErrorResponse(_)])
         ));
         assert!(backend.discard_execution);
-        assert!(context.get_execute(operation).is_none());
-        assert!(context.get_metrics_scope(scope).is_none());
+        assert!(matches!(
+            context.get_execute(operation),
+            Err(Error::Context(crate::error::ContextError::UnknownOperation))
+        ));
+        assert!(context.get_metrics_scope(scope).unwrap().is_none());
         assert!(context.schema_ddl_in_flight());
     }
 

--- a/packages/cipherstash-proxy/src/postgresql/middleware/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/middleware/frontend.rs
@@ -67,7 +67,7 @@ use tracing::{debug, info, warn};
 /// - **Query Transformation**: Rewrite SQL to use EQL functions for encrypted operations
 /// - **Protocol Handling**: Manage PostgreSQL extended query protocol (Parse/Bind/Execute)
 /// - **Error Management**: Convert encryption errors to PostgreSQL-compatible error responses
-/// - **Context Management**: Track statements, portals, and session state
+/// - **Context Management**: Track statements, portals, and connection state
 ///
 /// # Supported PostgreSQL Messages
 ///

--- a/packages/cipherstash-proxy/src/postgresql/middleware/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/middleware/frontend.rs
@@ -109,7 +109,53 @@ impl<S: EncryptionService> Frontend<S> {
         operation: pg_proto::OperationId,
         protocol_message: FrontendMessage,
     ) -> Result<FrontendMiddlewareOutput, Error> {
+        if matches!(
+            protocol_message,
+            FrontendMessage::Parse(_) | FrontendMessage::Bind(_)
+        ) {
+            self.context.set_non_execution(operation)?;
+        }
         if self.context.mapping_disabled() {
+            match &protocol_message {
+                FrontendMessage::Query(_) => {
+                    let session = self.context.start_metrics_scope();
+                    self.context.add_portal(
+                        operation,
+                        Name::new(),
+                        Portal::passthrough(Some(session)),
+                    )?;
+                    self.context.set_simple_query_execute_until_ready(
+                        operation,
+                        Name::new(),
+                        Some(session),
+                    )?;
+                }
+                FrontendMessage::Bind(bind) => {
+                    let session_id = self.context.get_statement_session(&bind.statement);
+                    self.context.add_portal(
+                        operation,
+                        bind.portal.clone(),
+                        Portal::passthrough(session_id),
+                    )?;
+                }
+                FrontendMessage::Execute(execute) => self
+                    .context
+                    .set_execute_for_portal(operation, execute.portal.clone())?,
+                FrontendMessage::Describe(describe) => {
+                    self.context.set_describe(operation, describe.clone())?;
+                }
+                FrontendMessage::Close(close) => match close.target {
+                    DescribeTarget::Portal => self.context.close_portal(&close.name)?,
+                    DescribeTarget::Statement => self.context.close_statement_explicit(&close.name),
+                },
+                FrontendMessage::Parse(parse) => {
+                    let scope = self.context.start_metrics_scope();
+                    self.context.close_statement(&parse.statement);
+                    self.context
+                        .set_statement_session(parse.statement.clone(), scope)?;
+                }
+                _ => {}
+            }
             return Ok(FrontendMiddlewareOutput::Forward(protocol_message));
         }
 
@@ -128,12 +174,13 @@ impl<S: EncryptionService> Frontend<S> {
 
         match protocol_message {
             FrontendMessage::Query(query) => {
-                match self.query_handler(operation, query).await {
+                let session_id = self.context.start_metrics_scope();
+                match self.query_handler(operation, query, session_id).await {
                     Ok(Some(mapped)) => outbound_message = mapped,
                     // No mapping needed, don't change the bytes
                     Ok(None) => (),
                     Err(err) => {
-                        let session_id = self.context.latest_session_id();
+                        self.context.finish_metrics_scope(Some(session_id));
                         warn!(
                             client_id = self.context.client_id,
                             msg = "Query Handler Error",
@@ -142,7 +189,7 @@ impl<S: EncryptionService> Frontend<S> {
                         let response = self.error_to_response(err);
                         self.context
                             .set_operation_error(operation, response.clone());
-                        self.context.set_execute(operation, Name::new(), session_id);
+                        self.context.set_execute(operation, Name::new(), None)?;
                         self.context.mark_schema_protocol_boundary();
                         outbound_message = self.simple_error_query(&response);
                     }
@@ -171,11 +218,6 @@ impl<S: EncryptionService> Frontend<S> {
                         let response = self.error_to_response(err);
                         self.context
                             .set_operation_error(operation, response.clone());
-                        self.context.set_execute(
-                            operation,
-                            Name::new(),
-                            self.context.latest_session_id(),
-                        );
                         self.failed_extended_batch = true;
                         outbound_message = self.extended_parse_error(failed_parse, &response);
                     }
@@ -183,7 +225,7 @@ impl<S: EncryptionService> Frontend<S> {
             }
             FrontendMessage::Bind(bind) => {
                 let failed_bind = bind.clone();
-                match self.bind_handler(Bind::try_from(bind)?).await {
+                match self.bind_handler(operation, Bind::try_from(bind)?).await {
                     Ok(Some(mapped)) => outbound_message = mapped,
                     // No mapping needed, don't change the bytes
                     Ok(None) => (),
@@ -196,11 +238,6 @@ impl<S: EncryptionService> Frontend<S> {
                             let response = self.error_to_response(err);
                             self.context
                                 .set_operation_error(operation, response.clone());
-                            self.context.set_execute(
-                                operation,
-                                Name::new(),
-                                self.context.latest_session_id(),
-                            );
                             self.failed_extended_batch = true;
                             outbound_message = self.extended_bind_error(failed_bind, &response);
                         }
@@ -212,11 +249,6 @@ impl<S: EncryptionService> Frontend<S> {
                             let response = self.error_to_response(err);
                             self.context
                                 .set_operation_error(operation, response.clone());
-                            self.context.set_execute(
-                                operation,
-                                Name::new(),
-                                self.context.latest_session_id(),
-                            );
                             self.failed_extended_batch = true;
                             outbound_message = self.extended_bind_error(failed_bind, &response);
                         }
@@ -229,11 +261,6 @@ impl<S: EncryptionService> Frontend<S> {
                             let response = self.error_to_response(err);
                             self.context
                                 .set_operation_error(operation, response.clone());
-                            self.context.set_execute(
-                                operation,
-                                Name::new(),
-                                self.context.latest_session_id(),
-                            );
                             self.failed_extended_batch = true;
                             outbound_message = self.extended_bind_error(failed_bind, &response);
                         }
@@ -272,14 +299,14 @@ impl<S: EncryptionService> Frontend<S> {
         describe: Describe,
     ) -> Result<(), Error> {
         debug!(target: PROTOCOL, client_id = self.context.client_id, ?describe);
-        self.context.set_describe(operation, describe);
+        self.context.set_describe(operation, describe)?;
         Ok(())
     }
 
     async fn close_handler(&mut self, close: Close) -> Result<(), Error> {
         debug!(target: PROTOCOL, client_id = self.context.client_id, ?close);
         match close.target {
-            DescribeTarget::Portal => self.context.close_portal(&close.name),
+            DescribeTarget::Portal => self.context.close_portal(&close.name)?,
             DescribeTarget::Statement => self.context.close_statement_explicit(&close.name),
         }
         Ok(())
@@ -293,7 +320,7 @@ impl<S: EncryptionService> Frontend<S> {
         debug!(target: PROTOCOL, client_id = self.context.client_id, ?execute);
         let executes_ddl = self.context.execute_schema_portal(&execute.portal);
         self.context
-            .set_execute_for_portal(operation, execute.portal.to_owned());
+            .set_execute_for_portal(operation, execute.portal.to_owned())?;
         Ok(executes_ddl)
     }
 
@@ -333,9 +360,9 @@ impl<S: EncryptionService> Frontend<S> {
         &mut self,
         operation: pg_proto::OperationId,
         query: bytes::Bytes,
+        session_id: SessionId,
     ) -> Result<Option<FrontendMessage>, Error> {
         let handler_start = Instant::now();
-        let session_id = self.context.start_session();
 
         // Set protocol type for diagnostics
         self.context.update_statement_metadata(session_id, |m| {
@@ -413,7 +440,7 @@ impl<S: EncryptionService> Frontend<S> {
                             session_id,
                             Portal::passthrough(Some(session_id)),
                             &parsed_statements,
-                        );
+                        )?;
                         return Ok(None);
                     };
                 }
@@ -507,7 +534,7 @@ impl<S: EncryptionService> Frontend<S> {
             m.set_query_fingerprint(&query_text);
         });
 
-        self.record_simple_schema_execution(operation, session_id, portal, &forwarded_statements);
+        self.record_simple_schema_execution(operation, session_id, portal, &forwarded_statements)?;
 
         if encrypted {
             let transformed_statement = forwarded_statements
@@ -554,11 +581,15 @@ impl<S: EncryptionService> Frontend<S> {
         session_id: SessionId,
         portal: Portal,
         statements: &[ast::Statement],
-    ) {
-        self.context.add_portal(Name::new(), portal);
-        self.context
-            .set_execute(operation, Name::new(), Some(session_id));
+    ) -> Result<(), Error> {
+        self.context.add_portal(operation, Name::new(), portal)?;
+        self.context.set_simple_query_execute_until_ready(
+            operation,
+            Name::new(),
+            Some(session_id),
+        )?;
         self.context.execute_simple_schema_statements(statements);
+        Ok(())
     }
 
     /// Encrypts literal values found in SQL statements.
@@ -761,7 +792,7 @@ impl<S: EncryptionService> Frontend<S> {
         mut message: Parse,
     ) -> Result<Option<FrontendMessage>, Error> {
         let original_query = message.query.clone();
-        let session_id = self.context.start_session();
+        let session_id = self.context.start_metrics_scope();
 
         // Set protocol type
         self.context.update_statement_metadata(session_id, |m| {
@@ -798,7 +829,7 @@ impl<S: EncryptionService> Frontend<S> {
         // latest-session guess.
         self.context.close_statement(&message.statement);
         self.context
-            .set_statement_session(message.statement.to_owned(), session_id);
+            .set_statement_session(message.statement.to_owned(), session_id)?;
 
         let mut statement_text = String::from_utf8_lossy(&message.query).into_owned();
         let statement = SqlParser::parse_statement(&statement_text)?;
@@ -901,7 +932,7 @@ impl<S: EncryptionService> Frontend<S> {
                 message.parameter_types =
                     rewrite_parse_param_types(&client_param_types, &statement.output_params);
                 self.context
-                    .add_statement(message.statement.to_owned(), statement);
+                    .add_statement(message.statement.to_owned(), statement)?;
             }
             _ => {
                 debug!(target: MAPPER,
@@ -1058,19 +1089,25 @@ impl<S: EncryptionService> Frontend<S> {
     /// - `Ok(Some(bytes))` - Modified Bind message with encrypted parameter values
     /// - `Ok(None)` - No parameter encryption needed, forward original message
     /// - `Err(error)` - Processing failed, error should be sent to client
-    async fn bind_handler(&mut self, mut bind: Bind) -> Result<Option<FrontendMessage>, Error> {
+    async fn bind_handler(
+        &mut self,
+        operation: pg_proto::OperationId,
+        mut bind: Bind,
+    ) -> Result<Option<FrontendMessage>, Error> {
         self.context
             .bind_schema_statement(bind.portal.to_owned(), &bind.prepared_statement);
+        let session_id = self.context.get_statement_session(&bind.prepared_statement);
         if self.context.unsafe_disable_mapping() {
             warn!(msg = "Encrypted statement mapping is not enabled");
             counter!(STATEMENTS_PASSTHROUGH_MAPPING_DISABLED_TOTAL).increment(1);
             counter!(STATEMENTS_PASSTHROUGH_TOTAL).increment(1);
+            self.context.add_portal(
+                operation,
+                bind.portal.to_owned(),
+                Portal::passthrough(session_id),
+            )?;
             return Ok(None);
         }
-
-        let session_id = self
-            .context
-            .get_statement_session_or_latest(&bind.prepared_statement);
 
         // Track param bytes for diagnostics
         let param_bytes: usize = bind.param_values.iter().map(|p| p.bytes.len()).sum();
@@ -1100,7 +1137,8 @@ impl<S: EncryptionService> Frontend<S> {
         };
 
         debug!(target: MAPPER, client_id = self.context.client_id, portal = ?portal);
-        self.context.add_portal(bind.portal.to_owned(), portal);
+        self.context
+            .add_portal(operation, bind.portal.to_owned(), portal)?;
 
         if bind.requires_rewrite() {
             let message = FrontendMessage::from(bind);
@@ -1637,15 +1675,17 @@ mod tests {
     use crate::postgresql::context::{Context, KeysetIdentifier};
     use crate::postgresql::error_handler::PostgreSqlErrorHandler;
     use crate::postgresql::inbound_eql::InboundEql;
+    use crate::postgresql::test_operation_id as operation_id;
     use crate::postgresql::Column;
     use crate::proxy::{EncryptConfig, EncryptionService};
     use cipherstash_client::eql::{EncryptedPayloadV3, EQL_SCHEMA_VERSION_V3};
     use cipherstash_client::zerokms::EncryptedRecord;
     use eql_mapper::Schema;
-    use pg_proto::{Bind, FrontendMessage, Parse};
+    use pg_proto::{Bind, Describe, DescribeTarget, FrontendMessage, Parse};
     use std::sync::Arc;
     use tokio::sync::mpsc;
 
+    #[derive(Clone)]
     struct TestService;
 
     #[async_trait::async_trait]
@@ -1677,17 +1717,21 @@ mod tests {
     }
 
     fn frontend() -> Frontend<TestService> {
+        frontend_with_config(TandemConfig::for_testing()).0
+    }
+
+    fn frontend_with_config(config: TandemConfig) -> (Frontend<TestService>, Context<TestService>) {
         let (reload_sender, _) = mpsc::unbounded_channel();
         let context = Context::new(
             1,
-            Arc::new(TandemConfig::for_testing()),
+            Arc::new(config),
             Arc::new(EncryptConfig::default()),
             Arc::new(Schema::new("public")),
             Arc::new(rustls::RootCertStore::empty()),
             TestService,
             reload_sender,
         );
-        Frontend::new(context)
+        (Frontend::new(context.clone()), context)
     }
 
     fn inbound_storage_payload() -> crate::EqlCiphertext {
@@ -1726,6 +1770,21 @@ mod tests {
             FrontendMessage::Query(query)
                 if String::from_utf8_lossy(&query).contains("RAISE EXCEPTION")
         ));
+    }
+
+    #[tokio::test]
+    async fn failed_simple_query_releases_its_metrics_scope() {
+        let (mut frontend, context) = frontend_with_config(TandemConfig::for_testing());
+
+        frontend
+            .intercept(
+                operation_id(),
+                FrontendMessage::Query(bytes::Bytes::from_static(b"select 'unterminated")),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(context.active_metrics_scopes(), 0);
     }
 
     #[test]
@@ -1770,5 +1829,226 @@ mod tests {
             result,
             Err(Error::Encrypt(EncryptError::InvalidInboundEqlPayload))
         ));
+    }
+
+    #[tokio::test]
+    async fn mapping_disabled_bind_preserves_the_statement_metrics_scope() {
+        let mut config = TandemConfig::for_testing();
+        config.disable_mapping_for_testing();
+        let (mut frontend, context) = frontend_with_config(config);
+        let statement = bytes::Bytes::from_static(b"statement");
+        let portal = bytes::Bytes::from_static(b"portal");
+
+        frontend
+            .intercept(
+                operation_id(),
+                FrontendMessage::Parse(Parse {
+                    statement: statement.clone(),
+                    query: bytes::Bytes::from_static(b"select 1"),
+                    parameter_types: Vec::new(),
+                }),
+            )
+            .await
+            .unwrap();
+        frontend
+            .intercept(
+                operation_id(),
+                FrontendMessage::Bind(Bind {
+                    portal: portal.clone(),
+                    statement: statement.clone(),
+                    parameter_formats: Vec::new(),
+                    parameters: Vec::new(),
+                    result_formats: Vec::new(),
+                }),
+            )
+            .await
+            .unwrap();
+
+        let statement_scope = context.get_statement_session(&statement).unwrap();
+        assert_eq!(
+            context.get_portal_session_id(&portal),
+            Some(statement_scope)
+        );
+    }
+
+    #[tokio::test]
+    async fn parse_registers_non_execution_error_correlation() {
+        let mut config = TandemConfig::for_testing();
+        config.disable_mapping_for_testing();
+        let (mut frontend, context) = frontend_with_config(config);
+        let operation = operation_id();
+
+        frontend
+            .intercept(
+                operation,
+                FrontendMessage::Parse(Parse {
+                    statement: bytes::Bytes::from_static(b"statement"),
+                    query: bytes::Bytes::from_static(b"select 1"),
+                    parameter_types: Vec::new(),
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(context
+            .finish_execution(
+                operation,
+                crate::postgresql::context::ExecutionOutcome::Failed,
+            )
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn bind_registers_non_execution_error_correlation() {
+        let mut config = TandemConfig::for_testing();
+        config.disable_mapping_for_testing();
+        let (mut frontend, context) = frontend_with_config(config);
+        let operation = operation_id();
+
+        frontend
+            .intercept(
+                operation,
+                FrontendMessage::Bind(Bind {
+                    portal: bytes::Bytes::from_static(b"portal"),
+                    statement: bytes::Bytes::from_static(b"statement"),
+                    parameter_formats: Vec::new(),
+                    parameters: Vec::new(),
+                    result_formats: Vec::new(),
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(context
+            .finish_execution(
+                operation,
+                crate::postgresql::context::ExecutionOutcome::Failed,
+            )
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn connection_disabled_mapping_allows_bound_portals_to_be_described() {
+        let (mut frontend, _) = frontend_with_config(TandemConfig::for_testing());
+        let portal = bytes::Bytes::from_static(b"portal");
+
+        frontend
+            .intercept(
+                operation_id(),
+                FrontendMessage::Query(bytes::Bytes::from_static(
+                    b"SET CIPHERSTASH.UNSAFE_DISABLE_MAPPING = true",
+                )),
+            )
+            .await
+            .unwrap();
+        frontend
+            .intercept(
+                operation_id(),
+                FrontendMessage::Bind(Bind {
+                    portal: portal.clone(),
+                    statement: bytes::Bytes::from_static(b"unknown_statement"),
+                    parameter_formats: Vec::new(),
+                    parameters: Vec::new(),
+                    result_formats: Vec::new(),
+                }),
+            )
+            .await
+            .unwrap();
+
+        let result = frontend
+            .intercept(
+                operation_id(),
+                FrontendMessage::Describe(Describe {
+                    target: DescribeTarget::Portal,
+                    name: portal,
+                }),
+            )
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn mapping_disabled_simple_query_waits_for_every_statement_completion() {
+        let mut config = TandemConfig::for_testing();
+        config.disable_mapping_for_testing();
+        let (mut frontend, context) = frontend_with_config(config);
+        let operation = operation_id();
+
+        frontend
+            .intercept(
+                operation,
+                FrontendMessage::Query(bytes::Bytes::from_static(b"SELECT 1; SELECT 2")),
+            )
+            .await
+            .unwrap();
+
+        context
+            .finish_execution(
+                operation,
+                crate::postgresql::context::ExecutionOutcome::Completed,
+            )
+            .unwrap();
+        assert!(context.get_execute(operation).is_some());
+
+        context
+            .finish_execution(
+                operation,
+                crate::postgresql::context::ExecutionOutcome::Completed,
+            )
+            .unwrap();
+        assert!(context.get_execute(operation).is_some());
+        context
+            .ready_for_query(pg_proto::TransactionStatus::Idle, Some(operation))
+            .unwrap();
+        assert!(context.get_execute(operation).is_none());
+    }
+
+    #[tokio::test]
+    async fn mapping_disabled_unparsed_simple_query_waits_for_readiness() {
+        let mut config = TandemConfig::for_testing();
+        config.disable_mapping_for_testing();
+        let (mut frontend, context) = frontend_with_config(config);
+        let operation = operation_id();
+
+        frontend
+            .intercept(
+                operation,
+                FrontendMessage::Query(bytes::Bytes::from_static(
+                    b"DO $$ BEGIN RAISE NOTICE 'x'; END $$; SELECT 1",
+                )),
+            )
+            .await
+            .unwrap();
+
+        context
+            .finish_execution(
+                operation,
+                crate::postgresql::context::ExecutionOutcome::Completed,
+            )
+            .unwrap();
+        assert!(context.get_execute(operation).is_some());
+
+        context
+            .ready_for_query(pg_proto::TransactionStatus::Idle, Some(operation))
+            .unwrap();
+        assert!(context.get_execute(operation).is_none());
+    }
+
+    #[tokio::test]
+    async fn unknown_describe_target_is_forwarded_to_postgresql() {
+        let mut frontend = frontend();
+
+        let result = frontend
+            .intercept(
+                operation_id(),
+                FrontendMessage::Describe(Describe {
+                    target: DescribeTarget::Portal,
+                    name: bytes::Bytes::from_static(b"unknown_portal"),
+                }),
+            )
+            .await;
+
+        assert!(result.is_ok());
     }
 }

--- a/packages/cipherstash-proxy/src/postgresql/middleware/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/middleware/frontend.rs
@@ -17,6 +17,7 @@ use crate::postgresql::data::{
 use crate::postgresql::inbound_eql;
 use crate::postgresql::rewrite::Name;
 use crate::postgresql::rewrite::UNSPECIFIED_TYPE_OID;
+use crate::postgresql::OperationId;
 use crate::prometheus::{
     ENCRYPTED_VALUES_TOTAL, ENCRYPTION_DURATION_SECONDS, ENCRYPTION_ERROR_TOTAL,
     ENCRYPTION_REQUESTS_TOTAL, STATEMENTS_ENCRYPTED_TOTAL,
@@ -106,7 +107,7 @@ impl<S: EncryptionService> Frontend<S> {
 
     pub async fn intercept(
         &mut self,
-        operation: pg_proto::OperationId,
+        operation: OperationId,
         protocol_message: FrontendMessage,
     ) -> Result<FrontendMiddlewareOutput, Error> {
         if matches!(
@@ -118,7 +119,7 @@ impl<S: EncryptionService> Frontend<S> {
         if self.context.mapping_disabled() {
             match &protocol_message {
                 FrontendMessage::Query(_) => {
-                    let session = self.context.start_metrics_scope();
+                    let session = self.context.start_metrics_scope()?;
                     self.context.add_portal(
                         operation,
                         Name::new(),
@@ -131,7 +132,7 @@ impl<S: EncryptionService> Frontend<S> {
                     )?;
                 }
                 FrontendMessage::Bind(bind) => {
-                    let session_id = self.context.get_statement_session(&bind.statement);
+                    let session_id = self.context.get_statement_session(&bind.statement)?;
                     self.context.add_portal(
                         operation,
                         bind.portal.clone(),
@@ -146,13 +147,12 @@ impl<S: EncryptionService> Frontend<S> {
                 }
                 FrontendMessage::Close(close) => match close.target {
                     DescribeTarget::Portal => self.context.close_portal(&close.name)?,
-                    DescribeTarget::Statement => self.context.close_statement_explicit(&close.name),
+                    DescribeTarget::Statement => {
+                        self.context.close_statement_explicit(&close.name)?;
+                    }
                 },
                 FrontendMessage::Parse(parse) => {
-                    let scope = self.context.start_metrics_scope();
-                    self.context.close_statement(&parse.statement);
-                    self.context
-                        .set_statement_session(parse.statement.clone(), scope)?;
+                    self.context.close_statement(&parse.statement)?;
                 }
                 _ => {}
             }
@@ -165,7 +165,7 @@ impl<S: EncryptionService> Frontend<S> {
                 self.context.mark_schema_protocol_boundary();
                 return Ok(FrontendMiddlewareOutput::Forward(protocol_message));
             }
-            self.context.discard_operation(operation);
+            self.context.discard_operation(operation)?;
             return Ok(FrontendMiddlewareOutput::Suppress(protocol_message));
         }
 
@@ -174,13 +174,13 @@ impl<S: EncryptionService> Frontend<S> {
 
         match protocol_message {
             FrontendMessage::Query(query) => {
-                let session_id = self.context.start_metrics_scope();
+                let session_id = self.context.start_metrics_scope()?;
                 match self.query_handler(operation, query, session_id).await {
                     Ok(Some(mapped)) => outbound_message = mapped,
                     // No mapping needed, don't change the bytes
                     Ok(None) => (),
                     Err(err) => {
-                        self.context.finish_metrics_scope(Some(session_id));
+                        self.context.finish_metrics_scope(Some(session_id))?;
                         warn!(
                             client_id = self.context.client_id,
                             msg = "Query Handler Error",
@@ -188,7 +188,7 @@ impl<S: EncryptionService> Frontend<S> {
                         );
                         let response = self.error_to_response(err);
                         self.context
-                            .set_operation_error(operation, response.clone());
+                            .set_operation_error(operation, response.clone())?;
                         self.context.set_execute(operation, Name::new(), None)?;
                         self.context.mark_schema_protocol_boundary();
                         outbound_message = self.simple_error_query(&response);
@@ -209,7 +209,7 @@ impl<S: EncryptionService> Frontend<S> {
                     // No mapping needed, don't change the bytes
                     Ok(None) => (),
                     Err(err) => {
-                        self.context.close_statement(&statement);
+                        self.context.close_statement(&statement)?;
                         warn!(
                             client_id = self.context.client_id,
                             msg = "Parse Handler Error",
@@ -217,7 +217,7 @@ impl<S: EncryptionService> Frontend<S> {
                         );
                         let response = self.error_to_response(err);
                         self.context
-                            .set_operation_error(operation, response.clone());
+                            .set_operation_error(operation, response.clone())?;
                         self.failed_extended_batch = true;
                         outbound_message = self.extended_parse_error(failed_parse, &response);
                     }
@@ -237,7 +237,7 @@ impl<S: EncryptionService> Frontend<S> {
                             );
                             let response = self.error_to_response(err);
                             self.context
-                                .set_operation_error(operation, response.clone());
+                                .set_operation_error(operation, response.clone())?;
                             self.failed_extended_batch = true;
                             outbound_message = self.extended_bind_error(failed_bind, &response);
                         }
@@ -248,7 +248,7 @@ impl<S: EncryptionService> Frontend<S> {
                             );
                             let response = self.error_to_response(err);
                             self.context
-                                .set_operation_error(operation, response.clone());
+                                .set_operation_error(operation, response.clone())?;
                             self.failed_extended_batch = true;
                             outbound_message = self.extended_bind_error(failed_bind, &response);
                         }
@@ -260,7 +260,7 @@ impl<S: EncryptionService> Frontend<S> {
                             );
                             let response = self.error_to_response(err);
                             self.context
-                                .set_operation_error(operation, response.clone());
+                                .set_operation_error(operation, response.clone())?;
                             self.failed_extended_batch = true;
                             outbound_message = self.extended_bind_error(failed_bind, &response);
                         }
@@ -295,7 +295,7 @@ impl<S: EncryptionService> Frontend<S> {
 
     async fn describe_handler(
         &mut self,
-        operation: pg_proto::OperationId,
+        operation: OperationId,
         describe: Describe,
     ) -> Result<(), Error> {
         debug!(target: PROTOCOL, client_id = self.context.client_id, ?describe);
@@ -307,14 +307,16 @@ impl<S: EncryptionService> Frontend<S> {
         debug!(target: PROTOCOL, client_id = self.context.client_id, ?close);
         match close.target {
             DescribeTarget::Portal => self.context.close_portal(&close.name)?,
-            DescribeTarget::Statement => self.context.close_statement_explicit(&close.name),
+            DescribeTarget::Statement => {
+                self.context.close_statement_explicit(&close.name)?;
+            }
         }
         Ok(())
     }
 
     async fn execute_handler(
         &mut self,
-        operation: pg_proto::OperationId,
+        operation: OperationId,
         execute: Execute,
     ) -> Result<bool, Error> {
         debug!(target: PROTOCOL, client_id = self.context.client_id, ?execute);
@@ -358,7 +360,7 @@ impl<S: EncryptionService> Frontend<S> {
     /// - `Err(error)` - Processing failed, error should be sent to client
     async fn query_handler(
         &mut self,
-        operation: pg_proto::OperationId,
+        operation: OperationId,
         query: bytes::Bytes,
         session_id: SessionId,
     ) -> Result<Option<FrontendMessage>, Error> {
@@ -367,7 +369,7 @@ impl<S: EncryptionService> Frontend<S> {
         // Set protocol type for diagnostics
         self.context.update_statement_metadata(session_id, |m| {
             m.protocol = Some(ProtocolType::Simple);
-        });
+        })?;
 
         let parse_timer = PhaseTimer::start();
 
@@ -458,7 +460,7 @@ impl<S: EncryptionService> Frontend<S> {
                         // Record parse duration before encryption work starts
                         if !parse_duration_recorded {
                             self.context
-                                .record_parse_duration(session_id, parse_timer.elapsed());
+                                .record_parse_duration(session_id, parse_timer.elapsed())?;
                             parse_duration_recorded = true;
                         }
 
@@ -496,7 +498,7 @@ impl<S: EncryptionService> Frontend<S> {
                     portal = Portal::encrypted(Arc::new(statement), Some(session_id));
                     self.context.update_statement_metadata(session_id, |m| {
                         m.encrypted = true;
-                    });
+                    })?;
                 }
                 None => {
                     debug!(target: MAPPER,
@@ -512,7 +514,7 @@ impl<S: EncryptionService> Frontend<S> {
         // Record parse/typecheck duration (if not already recorded before encryption)
         if !parse_duration_recorded {
             self.context
-                .record_parse_duration(session_id, parse_timer.elapsed());
+                .record_parse_duration(session_id, parse_timer.elapsed())?;
         }
 
         // Set statement type based on parsed statements
@@ -527,12 +529,12 @@ impl<S: EncryptionService> Frontend<S> {
         self.context.update_statement_metadata(session_id, |m| {
             m.statement_type = Some(statement_type);
             m.set_multi_statement(parsed_statements.len() > 1);
-        });
+        })?;
 
         // Set query fingerprint
         self.context.update_statement_metadata(session_id, |m| {
             m.set_query_fingerprint(&query_text);
-        });
+        })?;
 
         self.record_simple_schema_execution(operation, session_id, portal, &forwarded_statements)?;
 
@@ -577,7 +579,7 @@ impl<S: EncryptionService> Frontend<S> {
     /// Records the portal and schema intents for the statements actually sent to PostgreSQL.
     fn record_simple_schema_execution(
         &mut self,
-        operation: pg_proto::OperationId,
+        operation: OperationId,
         session_id: SessionId,
         portal: Portal,
         statements: &[ast::Statement],
@@ -680,14 +682,14 @@ impl<S: EncryptionService> Frontend<S> {
         let duration = Instant::now().duration_since(start);
 
         // Add to phase timing diagnostics (accumulate)
-        self.context.add_encrypt_duration(session_id, duration);
+        self.context.add_encrypt_duration(session_id, duration)?;
 
         // Update metadata with encrypted values count
         let encrypted_count = encrypted.iter().filter(|e| e.is_some()).count();
         self.context.update_statement_metadata(session_id, |m| {
             m.encrypted = true;
             m.set_encrypted_values_count(encrypted_count);
-        });
+        })?;
 
         counter!(ENCRYPTION_REQUESTS_TOTAL).increment(1);
         counter!(ENCRYPTED_VALUES_TOTAL).increment(encrypted_count as u64);
@@ -792,12 +794,12 @@ impl<S: EncryptionService> Frontend<S> {
         mut message: Parse,
     ) -> Result<Option<FrontendMessage>, Error> {
         let original_query = message.query.clone();
-        let session_id = self.context.start_metrics_scope();
+        let session_id = self.context.start_metrics_scope()?;
 
         // Set protocol type
         self.context.update_statement_metadata(session_id, |m| {
             m.protocol = Some(ProtocolType::Extended);
-        });
+        })?;
 
         let parse_timer = PhaseTimer::start();
 
@@ -827,7 +829,7 @@ impl<S: EncryptionService> Frontend<S> {
         // BEFORE the new session is recorded — the other way around wipes the
         // mapping that was just written and every Bind falls back to the
         // latest-session guess.
-        self.context.close_statement(&message.statement);
+        self.context.close_statement(&message.statement)?;
         self.context
             .set_statement_session(message.statement.to_owned(), session_id)?;
 
@@ -849,7 +851,7 @@ impl<S: EncryptionService> Frontend<S> {
         self.context.update_statement_metadata(session_id, |m| {
             m.statement_type = Some(StatementType::from_statement(&statement));
             m.set_query_fingerprint(&statement_text);
-        });
+        })?;
 
         if let Some(mapping_disabled) = self.context.maybe_set_unsafe_disable_mapping(&statement) {
             warn!(
@@ -897,7 +899,7 @@ impl<S: EncryptionService> Frontend<S> {
                 if typed_statement.requires_transform() {
                     // Record parse duration before encryption work starts
                     self.context
-                        .record_parse_duration(session_id, parse_timer.elapsed());
+                        .record_parse_duration(session_id, parse_timer.elapsed())?;
                     parse_duration_recorded = true;
 
                     let encrypted_literals = self
@@ -946,7 +948,7 @@ impl<S: EncryptionService> Frontend<S> {
         // Record parse duration (if not already recorded before encryption)
         if !parse_duration_recorded {
             self.context
-                .record_parse_duration(session_id, parse_timer.elapsed());
+                .record_parse_duration(session_id, parse_timer.elapsed())?;
         }
 
         if message.query != original_query || message.parameter_types != client_param_types {
@@ -1091,12 +1093,14 @@ impl<S: EncryptionService> Frontend<S> {
     /// - `Err(error)` - Processing failed, error should be sent to client
     async fn bind_handler(
         &mut self,
-        operation: pg_proto::OperationId,
+        operation: OperationId,
         mut bind: Bind,
     ) -> Result<Option<FrontendMessage>, Error> {
         self.context
             .bind_schema_statement(bind.portal.to_owned(), &bind.prepared_statement);
-        let session_id = self.context.get_statement_session(&bind.prepared_statement);
+        let session_id = self
+            .context
+            .get_statement_session(&bind.prepared_statement)?;
         if self.context.unsafe_disable_mapping() {
             warn!(msg = "Encrypted statement mapping is not enabled");
             counter!(STATEMENTS_PASSTHROUGH_MAPPING_DISABLED_TOTAL).increment(1);
@@ -1112,13 +1116,13 @@ impl<S: EncryptionService> Frontend<S> {
         // Track param bytes for diagnostics
         let param_bytes: usize = bind.param_values.iter().map(|p| p.bytes.len()).sum();
         self.context
-            .with_session(session_id, |m| m.metadata.set_param_bytes(param_bytes));
+            .with_session(session_id, |m| m.metadata.set_param_bytes(param_bytes))?;
 
         debug!(target: PROTOCOL, client_id = self.context.client_id, bind = ?bind);
 
         let mut portal = Portal::passthrough(session_id);
 
-        if let Some(statement) = self.context.get_statement(&bind.prepared_statement) {
+        if let Some(statement) = self.context.get_statement(&bind.prepared_statement)? {
             debug!(target:MAPPER, client_id = self.context.client_id, ?statement);
 
             if statement.has_params() {
@@ -1132,7 +1136,7 @@ impl<S: EncryptionService> Frontend<S> {
                     session_id,
                 );
                 self.context
-                    .with_session(session_id, |m| m.metadata.encrypted = true);
+                    .with_session(session_id, |m| m.metadata.encrypted = true)?;
             }
         };
 
@@ -1213,7 +1217,7 @@ impl<S: EncryptionService> Frontend<S> {
             // Always update metadata for slow-statement logging
             m.metadata.encrypted = true;
             m.metadata.set_encrypted_values_count(encrypted_count);
-        });
+        })?;
 
         // Prometheus metrics remain gated
         if self.context.prometheus_enabled() {
@@ -1672,7 +1676,7 @@ mod tests {
     use super::{quote_literal, Frontend};
     use crate::config::TandemConfig;
     use crate::error::{EncryptError, Error, MappingError};
-    use crate::postgresql::context::{Context, KeysetIdentifier};
+    use crate::postgresql::context::{Context, KeysetIdentifier, ResultOptionTestExt as _};
     use crate::postgresql::error_handler::PostgreSqlErrorHandler;
     use crate::postgresql::inbound_eql::InboundEql;
     use crate::postgresql::test_operation_id as operation_id;
@@ -1784,7 +1788,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(context.active_metrics_scopes(), 0);
+        assert_eq!(context.active_metrics_scopes().unwrap(), 0);
     }
 
     #[test]
@@ -1832,7 +1836,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mapping_disabled_bind_preserves_the_statement_metrics_scope() {
+    async fn mapping_disabled_extended_protocol_does_not_create_statement_metrics() {
         let mut config = TandemConfig::for_testing();
         config.disable_mapping_for_testing();
         let (mut frontend, context) = frontend_with_config(config);
@@ -1864,11 +1868,9 @@ mod tests {
             .await
             .unwrap();
 
-        let statement_scope = context.get_statement_session(&statement).unwrap();
-        assert_eq!(
-            context.get_portal_session_id(&portal),
-            Some(statement_scope)
-        );
+        assert!(context.get_statement_session(&statement).is_none());
+        assert!(context.get_portal_session_id(&portal).is_none());
+        assert_eq!(context.active_metrics_scopes().unwrap(), 0);
     }
 
     #[tokio::test]

--- a/packages/cipherstash-proxy/src/postgresql/middleware/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/middleware/frontend.rs
@@ -1688,7 +1688,7 @@ mod tests {
     use crate::error::{EncryptError, Error, MappingError};
     use crate::postgresql::context::statement::{OutputParam, OutputParamSource};
     use crate::postgresql::context::Statement;
-    use crate::postgresql::context::{Context, KeysetIdentifier, ResultOptionTestExt as _};
+    use crate::postgresql::context::{Context, KeysetIdentifier};
     use crate::postgresql::error_handler::PostgreSqlErrorHandler;
     use crate::postgresql::inbound_eql::InboundEql;
     use crate::postgresql::test_operation_id as operation_id;
@@ -1908,8 +1908,14 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(context.get_statement_metrics_scope(&statement).is_none());
-        assert!(context.get_portal_metrics_scope_id(&portal).is_none());
+        assert!(context
+            .get_statement_metrics_scope(&statement)
+            .unwrap()
+            .is_none());
+        assert!(context
+            .get_portal_metrics_scope_id(&portal)
+            .unwrap()
+            .is_none());
         assert_eq!(context.active_metrics_scopes().unwrap(), 0);
     }
 
@@ -1984,17 +1990,21 @@ mod tests {
 
     #[tokio::test]
     async fn failed_bind_releases_its_portal_metrics_scope() {
+        let column_config = ColumnConfig {
+            name: "secret".to_owned(),
+            in_place: false,
+            cast_type: ColumnType::Json,
+            indexes: vec![],
+            mode: ColumnMode::PlaintextDuplicate,
+        };
+        let column = Column {
+            identifier: Identifier::new("records", "secret"),
+            config: column_config.clone(),
+            postgres_type: postgres_types::Type::JSONB,
+            eql_term: EqlTermVariant::JsonValueSelector,
+        };
         let mut encrypt_config = EncryptConfig::default();
-        encrypt_config.insert(
-            Identifier::new("records", "secret"),
-            ColumnConfig {
-                name: "secret".to_owned(),
-                in_place: false,
-                cast_type: ColumnType::Json,
-                indexes: vec![],
-                mode: ColumnMode::PlaintextDuplicate,
-            },
-        );
+        encrypt_config.insert(Identifier::new("records", "secret"), column_config);
         let (mut frontend, mut context) = frontend_with_encrypt_config_and_service(
             TandemConfig::for_testing(),
             encrypt_config,
@@ -2009,31 +2019,9 @@ mod tests {
             .add_statement(
                 statement_name.clone(),
                 Statement::new(
-                    vec![Some(Column {
-                        identifier: Identifier::new("records", "secret"),
-                        config: ColumnConfig {
-                            name: "secret".to_owned(),
-                            in_place: false,
-                            cast_type: ColumnType::Json,
-                            indexes: vec![],
-                            mode: ColumnMode::PlaintextDuplicate,
-                        },
-                        postgres_type: postgres_types::Type::JSONB,
-                        eql_term: EqlTermVariant::JsonValueSelector,
-                    })],
+                    vec![Some(column.clone())],
                     vec![OutputParam {
-                        column: Some(Column {
-                            identifier: Identifier::new("records", "secret"),
-                            config: ColumnConfig {
-                                name: "secret".to_owned(),
-                                in_place: false,
-                                cast_type: ColumnType::Json,
-                                indexes: vec![],
-                                mode: ColumnMode::PlaintextDuplicate,
-                            },
-                            postgres_type: postgres_types::Type::JSONB,
-                            eql_term: EqlTermVariant::JsonValueSelector,
-                        }),
+                        column: Some(column),
                         source: OutputParamSource::Input(0),
                         query_operand: false,
                     }],
@@ -2179,7 +2167,7 @@ mod tests {
                 crate::postgresql::context::ExecutionOutcome::Completed,
             )
             .unwrap();
-        assert!(context.get_execute(operation).is_some());
+        assert!(context.get_execute(operation).unwrap().is_some());
 
         context
             .finish_execution(
@@ -2187,11 +2175,14 @@ mod tests {
                 crate::postgresql::context::ExecutionOutcome::Completed,
             )
             .unwrap();
-        assert!(context.get_execute(operation).is_some());
+        assert!(context.get_execute(operation).unwrap().is_some());
         context
             .ready_for_query(pg_proto::TransactionStatus::Idle, Some(operation))
             .unwrap();
-        assert!(context.get_execute(operation).is_none());
+        assert!(matches!(
+            context.get_execute(operation),
+            Err(Error::Context(crate::error::ContextError::UnknownOperation))
+        ));
     }
 
     #[tokio::test]
@@ -2217,12 +2208,15 @@ mod tests {
                 crate::postgresql::context::ExecutionOutcome::Completed,
             )
             .unwrap();
-        assert!(context.get_execute(operation).is_some());
+        assert!(context.get_execute(operation).unwrap().is_some());
 
         context
             .ready_for_query(pg_proto::TransactionStatus::Idle, Some(operation))
             .unwrap();
-        assert!(context.get_execute(operation).is_none());
+        assert!(matches!(
+            context.get_execute(operation),
+            Err(Error::Context(crate::error::ContextError::UnknownOperation))
+        ));
     }
 
     #[tokio::test]

--- a/packages/cipherstash-proxy/src/postgresql/middleware/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/middleware/frontend.rs
@@ -1114,50 +1114,59 @@ impl<S: EncryptionService> Frontend<S> {
             .context
             .start_portal_metrics_scope(&bind.prepared_statement)?;
 
-        // Track param bytes for diagnostics
-        let param_bytes: usize = bind.param_values.iter().map(|p| p.bytes.len()).sum();
-        self.context
-            .with_session(session_id, |m| m.metadata.set_param_bytes(param_bytes))?;
+        let result = async {
+            // Track param bytes for diagnostics
+            let param_bytes: usize = bind.param_values.iter().map(|p| p.bytes.len()).sum();
+            self.context
+                .with_session(session_id, |m| m.metadata.set_param_bytes(param_bytes))?;
 
-        debug!(target: PROTOCOL, client_id = self.context.client_id, bind = ?bind);
+            debug!(target: PROTOCOL, client_id = self.context.client_id, bind = ?bind);
 
-        let mut portal = Portal::passthrough(session_id);
+            let mut portal = Portal::passthrough(session_id);
 
-        if let Some(statement) = self.context.get_statement(&bind.prepared_statement)? {
-            debug!(target:MAPPER, client_id = self.context.client_id, ?statement);
+            if let Some(statement) = self.context.get_statement(&bind.prepared_statement)? {
+                debug!(target:MAPPER, client_id = self.context.client_id, ?statement);
 
-            if statement.has_params() {
-                let encrypted = self.encrypt_params(session_id, &bind, &statement).await?;
-                bind.rewrite(&statement.output_params, encrypted)?;
-            }
-            if statement.has_projection() {
-                portal = Portal::encrypted_with_format_codes(
-                    statement,
-                    bind.result_columns_format_codes.to_owned(),
-                    session_id,
+                if statement.has_params() {
+                    let encrypted = self.encrypt_params(session_id, &bind, &statement).await?;
+                    bind.rewrite(&statement.output_params, encrypted)?;
+                }
+                if statement.has_projection() {
+                    portal = Portal::encrypted_with_format_codes(
+                        statement,
+                        bind.result_columns_format_codes.to_owned(),
+                        session_id,
+                    );
+                    self.context
+                        .with_session(session_id, |m| m.metadata.encrypted = true)?;
+                }
+            };
+
+            debug!(target: MAPPER, client_id = self.context.client_id, portal = ?portal);
+            self.context
+                .add_portal(operation, bind.portal.to_owned(), portal)?;
+
+            if bind.requires_rewrite() {
+                let message = FrontendMessage::from(bind);
+                debug!(
+                    target: MAPPER,
+                    client_id = self.context.client_id,
+                    msg = "Rewrite Bind",
+                    ?message
                 );
-                self.context
-                    .with_session(session_id, |m| m.metadata.encrypted = true)?;
+
+                Ok(Some(message))
+            } else {
+                Ok(None)
             }
-        };
-
-        debug!(target: MAPPER, client_id = self.context.client_id, portal = ?portal);
-        self.context
-            .add_portal(operation, bind.portal.to_owned(), portal)?;
-
-        if bind.requires_rewrite() {
-            let message = FrontendMessage::from(bind);
-            debug!(
-                target: MAPPER,
-                client_id = self.context.client_id,
-                msg = "Rewrite Bind",
-                ?message
-            );
-
-            Ok(Some(message))
-        } else {
-            Ok(None)
         }
+        .await;
+
+        if result.is_err() {
+            self.context.finish_metrics_scope(session_id)?;
+        }
+
+        result
     }
 
     ///
@@ -1677,21 +1686,28 @@ mod tests {
     use super::{quote_literal, Frontend};
     use crate::config::TandemConfig;
     use crate::error::{EncryptError, Error, MappingError};
+    use crate::postgresql::context::statement::{OutputParam, OutputParamSource};
+    use crate::postgresql::context::Statement;
     use crate::postgresql::context::{Context, KeysetIdentifier, ResultOptionTestExt as _};
     use crate::postgresql::error_handler::PostgreSqlErrorHandler;
     use crate::postgresql::inbound_eql::InboundEql;
     use crate::postgresql::test_operation_id as operation_id;
     use crate::postgresql::Column;
     use crate::proxy::{EncryptConfig, EncryptionService};
+    use crate::Identifier;
     use cipherstash_client::eql::{EncryptedPayloadV3, EQL_SCHEMA_VERSION_V3};
+    use cipherstash_client::schema::{ColumnConfig, ColumnMode, ColumnType};
     use cipherstash_client::zerokms::EncryptedRecord;
+    use eql_mapper::EqlTermVariant;
     use eql_mapper::Schema;
     use pg_proto::{Bind, Describe, DescribeTarget, FrontendMessage, Parse};
     use std::sync::Arc;
     use tokio::sync::mpsc;
 
     #[derive(Clone)]
-    struct TestService;
+    struct TestService {
+        fail_encrypt: bool,
+    }
 
     #[async_trait::async_trait]
     impl EncryptionService for TestService {
@@ -1701,6 +1717,9 @@ mod tests {
             _plaintexts: Vec<Option<cipherstash_client::encryption::Plaintext>>,
             _columns: &[Option<Column>],
         ) -> Result<Vec<Option<crate::EqlOutput>>, Error> {
+            if self.fail_encrypt {
+                return Err(EncryptError::InvalidInboundEqlPayload.into());
+            }
             Ok(Vec::new())
         }
 
@@ -1726,14 +1745,34 @@ mod tests {
     }
 
     fn frontend_with_config(config: TandemConfig) -> (Frontend<TestService>, Context<TestService>) {
+        frontend_with_service(
+            config,
+            TestService {
+                fail_encrypt: false,
+            },
+        )
+    }
+
+    fn frontend_with_service(
+        config: TandemConfig,
+        service: TestService,
+    ) -> (Frontend<TestService>, Context<TestService>) {
+        frontend_with_encrypt_config_and_service(config, EncryptConfig::default(), service)
+    }
+
+    fn frontend_with_encrypt_config_and_service(
+        config: TandemConfig,
+        encrypt_config: EncryptConfig,
+        service: TestService,
+    ) -> (Frontend<TestService>, Context<TestService>) {
         let (reload_sender, _) = mpsc::unbounded_channel();
         let context = Context::new(
             1,
             Arc::new(config),
-            Arc::new(EncryptConfig::default()),
+            Arc::new(encrypt_config),
             Arc::new(Schema::new("public")),
             Arc::new(rustls::RootCertStore::empty()),
-            TestService,
+            service,
             reload_sender,
         );
         (Frontend::new(context.clone()), context)
@@ -1941,6 +1980,85 @@ mod tests {
                 .param_bytes,
             9
         );
+    }
+
+    #[tokio::test]
+    async fn failed_bind_releases_its_portal_metrics_scope() {
+        let mut encrypt_config = EncryptConfig::default();
+        encrypt_config.insert(
+            Identifier::new("records", "secret"),
+            ColumnConfig {
+                name: "secret".to_owned(),
+                in_place: false,
+                cast_type: ColumnType::Json,
+                indexes: vec![],
+                mode: ColumnMode::PlaintextDuplicate,
+            },
+        );
+        let (mut frontend, mut context) = frontend_with_encrypt_config_and_service(
+            TandemConfig::for_testing(),
+            encrypt_config,
+            TestService { fail_encrypt: true },
+        );
+        let statement_name = bytes::Bytes::from_static(b"statement");
+        let template_scope = context.start_metrics_scope().unwrap();
+        context
+            .set_statement_session(statement_name.clone(), template_scope)
+            .unwrap();
+        context
+            .add_statement(
+                statement_name.clone(),
+                Statement::new(
+                    vec![Some(Column {
+                        identifier: Identifier::new("records", "secret"),
+                        config: ColumnConfig {
+                            name: "secret".to_owned(),
+                            in_place: false,
+                            cast_type: ColumnType::Json,
+                            indexes: vec![],
+                            mode: ColumnMode::PlaintextDuplicate,
+                        },
+                        postgres_type: postgres_types::Type::JSONB,
+                        eql_term: EqlTermVariant::JsonValueSelector,
+                    })],
+                    vec![OutputParam {
+                        column: Some(Column {
+                            identifier: Identifier::new("records", "secret"),
+                            config: ColumnConfig {
+                                name: "secret".to_owned(),
+                                in_place: false,
+                                cast_type: ColumnType::Json,
+                                indexes: vec![],
+                                mode: ColumnMode::PlaintextDuplicate,
+                            },
+                            postgres_type: postgres_types::Type::JSONB,
+                            eql_term: EqlTermVariant::JsonValueSelector,
+                        }),
+                        source: OutputParamSource::Input(0),
+                        query_operand: false,
+                    }],
+                    vec![],
+                    vec![],
+                    vec![],
+                ),
+            )
+            .unwrap();
+
+        frontend
+            .intercept(
+                operation_id(),
+                FrontendMessage::Bind(Bind {
+                    portal: bytes::Bytes::from_static(b"portal"),
+                    statement: statement_name,
+                    parameter_formats: Vec::new(),
+                    parameters: vec![Some(bytes::Bytes::from_static(b"\"value\""))],
+                    result_formats: Vec::new(),
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(context.active_metrics_scopes().unwrap(), 1);
     }
 
     #[tokio::test]

--- a/packages/cipherstash-proxy/src/postgresql/middleware/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/middleware/frontend.rs
@@ -119,20 +119,20 @@ impl<S: EncryptionService> Frontend<S> {
         if self.context.mapping_disabled() {
             match &protocol_message {
                 FrontendMessage::Query(_) => {
-                    let session = self.context.start_metrics_scope()?;
+                    let metrics_scope = self.context.start_metrics_scope()?;
                     self.context.add_portal(
                         operation,
                         Name::new(),
-                        Portal::passthrough(Some(session)),
+                        Portal::passthrough(Some(metrics_scope)),
                     )?;
                     self.context.set_simple_query_execute_until_ready(
                         operation,
                         Name::new(),
-                        Some(session),
+                        Some(metrics_scope),
                     )?;
                 }
                 FrontendMessage::Bind(bind) => {
-                    let session_id = self.context.get_statement_session(&bind.statement)?;
+                    let session_id = self.context.get_statement_metrics_scope(&bind.statement)?;
                     self.context.add_portal(
                         operation,
                         bind.portal.clone(),
@@ -825,13 +825,13 @@ impl<S: EncryptionService> Frontend<S> {
         // statement for every command, so the `END` at the close of a
         // transaction binds against the `SELECT` that preceded it.
         //
-        // Closing also drops the name's session mapping, so it must happen
-        // BEFORE the new session is recorded — the other way around wipes the
+        // Closing also drops the name's metrics scope mapping, so it must happen
+        // BEFORE the new scope is recorded — the other way around wipes the
         // mapping that was just written and every Bind falls back to the
-        // latest-session guess.
+        // latest-scope guess.
         self.context.close_statement(&message.statement)?;
         self.context
-            .set_statement_session(message.statement.to_owned(), session_id)?;
+            .set_statement_metrics_scope(message.statement.to_owned(), session_id)?;
 
         let mut statement_text = String::from_utf8_lossy(&message.query).into_owned();
         let statement = SqlParser::parse_statement(&statement_text)?;
@@ -1118,7 +1118,7 @@ impl<S: EncryptionService> Frontend<S> {
             // Track param bytes for diagnostics
             let param_bytes: usize = bind.param_values.iter().map(|p| p.bytes.len()).sum();
             self.context
-                .with_session(session_id, |m| m.metadata.set_param_bytes(param_bytes))?;
+                .with_metrics_scope(session_id, |m| m.metadata.set_param_bytes(param_bytes))?;
 
             debug!(target: PROTOCOL, client_id = self.context.client_id, bind = ?bind);
 
@@ -1138,7 +1138,7 @@ impl<S: EncryptionService> Frontend<S> {
                         session_id,
                     );
                     self.context
-                        .with_session(session_id, |m| m.metadata.encrypted = true)?;
+                        .with_metrics_scope(session_id, |m| m.metadata.encrypted = true)?;
                 }
             };
 
@@ -1221,7 +1221,7 @@ impl<S: EncryptionService> Frontend<S> {
 
         // Record timing and metadata for this encryption operation
         let encrypted_count = encrypted.iter().filter(|e| e.is_some()).count();
-        self.context.with_session(session_id, |m| {
+        self.context.with_metrics_scope(session_id, |m| {
             // Add to phase timing diagnostics (accumulate)
             m.phase_timing.add_encrypt(duration);
             // Always update metadata for slow-statement logging
@@ -1908,8 +1908,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(context.get_statement_session(&statement).is_none());
-        assert!(context.get_portal_session_id(&portal).is_none());
+        assert!(context.get_statement_metrics_scope(&statement).is_none());
+        assert!(context.get_portal_metrics_scope_id(&portal).is_none());
         assert_eq!(context.active_metrics_scopes().unwrap(), 0);
     }
 
@@ -1954,17 +1954,17 @@ mod tests {
         }
 
         let first_scope = context
-            .get_portal_session_id(&first_portal)
+            .get_portal_metrics_scope_id(&first_portal)
             .unwrap()
             .unwrap();
         let second_scope = context
-            .get_portal_session_id(&second_portal)
+            .get_portal_metrics_scope_id(&second_portal)
             .unwrap()
             .unwrap();
         assert_ne!(first_scope, second_scope);
         assert_eq!(
             context
-                .get_session_metrics(first_scope)
+                .get_metrics_scope(first_scope)
                 .unwrap()
                 .unwrap()
                 .metadata
@@ -1973,7 +1973,7 @@ mod tests {
         );
         assert_eq!(
             context
-                .get_session_metrics(second_scope)
+                .get_metrics_scope(second_scope)
                 .unwrap()
                 .unwrap()
                 .metadata
@@ -2003,7 +2003,7 @@ mod tests {
         let statement_name = bytes::Bytes::from_static(b"statement");
         let template_scope = context.start_metrics_scope().unwrap();
         context
-            .set_statement_session(statement_name.clone(), template_scope)
+            .set_statement_metrics_scope(statement_name.clone(), template_scope)
             .unwrap();
         context
             .add_statement(

--- a/packages/cipherstash-proxy/src/postgresql/middleware/frontend.rs
+++ b/packages/cipherstash-proxy/src/postgresql/middleware/frontend.rs
@@ -1098,9 +1098,6 @@ impl<S: EncryptionService> Frontend<S> {
     ) -> Result<Option<FrontendMessage>, Error> {
         self.context
             .bind_schema_statement(bind.portal.to_owned(), &bind.prepared_statement);
-        let session_id = self
-            .context
-            .get_statement_session(&bind.prepared_statement)?;
         if self.context.unsafe_disable_mapping() {
             warn!(msg = "Encrypted statement mapping is not enabled");
             counter!(STATEMENTS_PASSTHROUGH_MAPPING_DISABLED_TOTAL).increment(1);
@@ -1108,10 +1105,14 @@ impl<S: EncryptionService> Frontend<S> {
             self.context.add_portal(
                 operation,
                 bind.portal.to_owned(),
-                Portal::passthrough(session_id),
+                Portal::passthrough(None),
             )?;
             return Ok(None);
         }
+
+        let session_id = self
+            .context
+            .start_portal_metrics_scope(&bind.prepared_statement)?;
 
         // Track param bytes for diagnostics
         let param_bytes: usize = bind.param_values.iter().map(|p| p.bytes.len()).sum();
@@ -1871,6 +1872,75 @@ mod tests {
         assert!(context.get_statement_session(&statement).is_none());
         assert!(context.get_portal_session_id(&portal).is_none());
         assert_eq!(context.active_metrics_scopes().unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn portals_bound_from_one_statement_have_isolated_parameter_metrics() {
+        let (mut frontend, context) = frontend_with_config(TandemConfig::for_testing());
+        let statement = bytes::Bytes::from_static(b"statement");
+        let first_portal = bytes::Bytes::from_static(b"first_portal");
+        let second_portal = bytes::Bytes::from_static(b"second_portal");
+        frontend
+            .intercept(
+                operation_id(),
+                FrontendMessage::Parse(Parse {
+                    statement: statement.clone(),
+                    query: bytes::Bytes::from_static(b"select $1::text"),
+                    parameter_types: Vec::new(),
+                }),
+            )
+            .await
+            .unwrap();
+
+        for (portal, parameter) in [
+            (first_portal.clone(), bytes::Bytes::from_static(b"a")),
+            (
+                second_portal.clone(),
+                bytes::Bytes::from_static(b"different"),
+            ),
+        ] {
+            frontend
+                .intercept(
+                    operation_id(),
+                    FrontendMessage::Bind(Bind {
+                        portal,
+                        statement: statement.clone(),
+                        parameter_formats: Vec::new(),
+                        parameters: vec![Some(parameter)],
+                        result_formats: Vec::new(),
+                    }),
+                )
+                .await
+                .unwrap();
+        }
+
+        let first_scope = context
+            .get_portal_session_id(&first_portal)
+            .unwrap()
+            .unwrap();
+        let second_scope = context
+            .get_portal_session_id(&second_portal)
+            .unwrap()
+            .unwrap();
+        assert_ne!(first_scope, second_scope);
+        assert_eq!(
+            context
+                .get_session_metrics(first_scope)
+                .unwrap()
+                .unwrap()
+                .metadata
+                .param_bytes,
+            1
+        );
+        assert_eq!(
+            context
+                .get_session_metrics(second_scope)
+                .unwrap()
+                .unwrap()
+                .metadata
+                .param_bytes,
+            9
+        );
     }
 
     #[tokio::test]

--- a/packages/cipherstash-proxy/src/postgresql/middleware/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/middleware/mod.rs
@@ -57,7 +57,7 @@ where
         operation: OperationId,
         message: FrontendMessage,
     ) -> Result<FrontendMiddlewareOutput, Error> {
-        self.frontend.intercept(operation, message).await
+        self.frontend.intercept(operation.into(), message).await
     }
 
     async fn backend_operation(
@@ -68,6 +68,8 @@ where
         operation: Option<OperationId>,
         message: BackendMessage,
     ) -> Result<BackendMiddlewareOutput, Error> {
-        self.backend.intercept(operation, message).await
+        self.backend
+            .intercept(operation.map(Into::into), message)
+            .await
     }
 }

--- a/packages/cipherstash-proxy/src/postgresql/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/mod.rs
@@ -16,17 +16,31 @@ pub use context::KeysetIdentifier;
 pub use driver::handler;
 pub(crate) use rewrite::Name;
 
+/// Proxy-owned identity for correlating PostgreSQL protocol operations.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct OperationId(OperationIdInner);
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+enum OperationIdInner {
+    Protocol(pg_proto::OperationId),
+    #[cfg(test)]
+    Test(u64),
+}
+
+impl From<pg_proto::OperationId> for OperationId {
+    fn from(id: pg_proto::OperationId) -> Self {
+        Self(OperationIdInner::Protocol(id))
+    }
+}
+
 #[cfg(test)]
-pub(crate) fn test_operation_id() -> pg_proto::OperationId {
-    use std::num::NonZeroU64;
+pub(crate) fn test_operation_id() -> OperationId {
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static NEXT_ID: AtomicU64 = AtomicU64::new(1);
-    let id = NonZeroU64::new(NEXT_ID.fetch_add(1, Ordering::Relaxed))
-        .expect("test operation IDs must not wrap");
-    // SAFETY: OperationId is an opaque u64 newtype in the pinned pg-proto version. Starting from
-    // NonZeroU64 also preserves validity if pg-proto strengthens that representation in future.
-    unsafe { std::mem::transmute(id) }
+    OperationId(OperationIdInner::Test(
+        NEXT_ID.fetch_add(1, Ordering::Relaxed),
+    ))
 }
 
 #[cfg(test)]

--- a/packages/cipherstash-proxy/src/postgresql/mod.rs
+++ b/packages/cipherstash-proxy/src/postgresql/mod.rs
@@ -15,3 +15,24 @@ pub use context::Context;
 pub use context::KeysetIdentifier;
 pub use driver::handler;
 pub(crate) use rewrite::Name;
+
+#[cfg(test)]
+pub(crate) fn test_operation_id() -> pg_proto::OperationId {
+    use std::num::NonZeroU64;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+    let id = NonZeroU64::new(NEXT_ID.fetch_add(1, Ordering::Relaxed))
+        .expect("test operation IDs must not wrap");
+    // SAFETY: OperationId is an opaque u64 newtype in the pinned pg-proto version. Starting from
+    // NonZeroU64 also preserves validity if pg-proto strengthens that representation in future.
+    unsafe { std::mem::transmute(id) }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_operation_ids_are_distinct() {
+        assert_ne!(super::test_operation_id(), super::test_operation_id());
+    }
+}

--- a/proxy-architecture-walkthrough.html
+++ b/proxy-architecture-walkthrough.html
@@ -1,0 +1,287 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>CIP-3933 — Execution Lifecycle Walkthrough</title>
+  <style>
+    :root { color-scheme: light; --bg:#f5f6f8; --panel:#fff; --ink:#172033; --muted:#5f6b7c; --line:#68778e; --blue:#2468d3; --cyan:#087f78; --amber:#a45f00; --red:#bc3247; --green:#1d8158; }
+    * { box-sizing:border-box; }
+    body { margin:0; background:radial-gradient(circle at top,#fff 0,#f5f6f8 42rem); color:var(--ink); font:16px/1.55 Inter,ui-sans-serif,system-ui,sans-serif; }
+    html { scroll-behavior:smooth; }
+    body { scroll-padding-top:28px; }
+    main { width:min(1440px,calc(100% - 32px)); margin:0 auto; padding:36px 0 96px; display:grid; grid-template-columns:230px minmax(0,1180px); gap:44px; align-items:start; }
+    article { min-width:0; }
+    nav { position:sticky; top:24px; padding:18px; border:1px solid #d6dce5; border-radius:16px; background:rgba(255,255,255,.92); backdrop-filter:blur(12px); box-shadow:0 12px 36px #17203312; }
+    nav strong { display:block; margin-bottom:10px; color:var(--cyan); font-size:.78rem; letter-spacing:.1em; text-transform:uppercase; }
+    nav a { display:block; padding:7px 9px; border-left:2px solid #d6dce5; color:var(--muted); text-decoration:none; font-size:.88rem; }
+    nav a:hover, nav a:focus { border-color:var(--cyan); color:var(--ink); }
+    header { margin-bottom:40px; }
+    h1 { margin:0 0 8px; font-size:clamp(2rem,5vw,4rem); line-height:1.05; letter-spacing:-.04em; }
+    h2 { margin:56px 0 18px; font-size:1.65rem; }
+    h3 { margin:0 0 7px; font-size:1rem; }
+    p { color:var(--muted); max-width:78ch; }
+    code { color:var(--cyan); }
+    .meta { color:var(--cyan); font-weight:650; }
+    .diagram { overflow-x:auto; padding:20px; border:1px solid #d6dce5; border-radius:18px; background:#fff; box-shadow:0 20px 60px #17203316; }
+    svg { display:block; min-width:920px; width:100%; height:auto; }
+    .box { fill:#f2f5f9; stroke:#68778e; stroke-width:2; rx:12; }
+    .adapter { fill:#e5efff; stroke:#2468d3; }
+    .state { fill:#e2f5f1; stroke:#087f78; }
+    .external { fill:#fff0d8; stroke:#a45f00; }
+    .danger { fill:#fde8ec; stroke:#bc3247; }
+    .label { fill:#172033; font:600 15px system-ui,sans-serif; text-anchor:middle; dominant-baseline:middle; }
+    .small { fill:#5f6b7c; font:13px system-ui,sans-serif; text-anchor:middle; }
+    .arrow { fill:none; stroke:#8391ae; stroke-width:2; marker-end:url(#arrow); }
+    .arrow-blue { stroke:#65a7ff; }
+    .arrow-cyan { stroke:#59d8d1; }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); gap:14px; }
+    .finding { padding:18px 19px; border:1px solid #d6dce5; border-radius:14px; background:#fff; }
+    .finding p { margin:0; font-size:.94rem; }
+    .high { border-left:4px solid var(--red); } .medium { border-left:4px solid var(--amber); } .positive { border-left:4px solid var(--green); }
+    .verdict { padding:22px; border:1px solid #74b89f; border-radius:16px; background:#e8f6f0; color:#175d47; }
+    .hero-summary { font-size:1.15rem; color:#3c4b61; }
+    .facts { display:grid; grid-template-columns:repeat(4,1fr); gap:12px; margin:28px 0 8px; }
+    .fact { padding:15px 16px; border:1px solid #d6dce5; border-radius:13px; background:#fff; }
+    .fact b { display:block; color:var(--ink); font-size:1.35rem; }
+    .fact span { color:var(--muted); font-size:.8rem; text-transform:uppercase; letter-spacing:.07em; }
+    .callout { margin:20px 0; padding:18px 20px; border-left:4px solid var(--blue); border-radius:8px 14px 14px 8px; background:#eaf1fc; color:#30455f; }
+    .reading-order { counter-reset:read; display:grid; gap:12px; }
+    .reading-step { position:relative; padding:16px 18px 16px 62px; border:1px solid #d6dce5; border-radius:14px; background:#fff; }
+    .reading-step::before { counter-increment:read; content:counter(read); position:absolute; left:18px; top:17px; display:grid; place-items:center; width:28px; height:28px; border-radius:50%; background:#e5efff; color:var(--blue); font-weight:750; }
+    .reading-step h3 { margin-bottom:3px; }
+    .reading-step p { margin:0; }
+    .flow { display:flex; flex-wrap:wrap; align-items:center; gap:8px; margin:20px 0; }
+    .flow span { padding:9px 12px; border:1px solid #aab7c8; border-radius:9px; background:#fff; font:600 .88rem ui-monospace,SFMono-Regular,monospace; }
+    .flow i { color:var(--cyan); font-style:normal; }
+    table { width:100%; border-collapse:collapse; overflow:hidden; border:1px solid #d6dce5; border-radius:14px; background:#fff; }
+    th,td { padding:13px 15px; border-bottom:1px solid #d6dce5; text-align:left; vertical-align:top; }
+    th { color:var(--cyan); font-size:.78rem; letter-spacing:.06em; text-transform:uppercase; }
+    caption { padding:11px 15px; border:1px solid #d6dce5; border-bottom:0; color:var(--muted); background:#fff; text-align:left; font-size:.88rem; }
+    td { color:var(--muted); }
+    td:first-child { color:var(--ink); font-family:ui-monospace,SFMono-Regular,monospace; font-size:.88rem; }
+    tr:last-child td { border-bottom:0; }
+    .tag { display:inline-block; margin:2px 4px 2px 0; padding:3px 8px; border:1px solid #9db6d6; border-radius:999px; color:#315a8b; background:#f4f8fd; font-size:.76rem; }
+    section { scroll-margin-top:24px; }
+    footer { margin-top:48px; padding-top:20px; border-top:1px solid #d6dce5; color:var(--muted); font-size:.9rem; }
+    @media (max-width:900px) { main { grid-template-columns:1fr; } nav { position:static; columns:2; } nav strong { column-span:all; } .facts { grid-template-columns:repeat(2,1fr); } }
+    @media (max-width:560px) { .facts { grid-template-columns:1fr; } nav { columns:1; } }
+  </style>
+</head>
+<body>
+<main>
+  <nav aria-label="Walkthrough contents">
+    <strong>Walkthrough</strong>
+    <a href="#overview">Start here</a>
+    <a href="#reading-order">Reading order</a>
+    <a href="#change-map">Change map</a>
+    <a href="#architecture">Architecture</a>
+    <a href="#execution-before">Lifecycle before</a>
+    <a href="#execution-after">Lifecycle after</a>
+    <a href="#invariants">Invariants</a>
+    <a href="#hotspots">Review hotspots</a>
+    <a href="#validation">Validation</a>
+    <a href="#boundary">Boundary</a>
+  </nav>
+  <article>
+  <header>
+    <div class="meta">CIP-3933 · Standalone PR walkthrough · fixed snapshot</div>
+    <h1>Execution lifecycle<br>belongs to Context</h1>
+    <p class="hero-summary">A guided review of <code>cip-3933-execution-lifecycle</code>: why Proxy moves correlated PostgreSQL metadata behind one connection-local seam, how execution occurrences now survive suspension and resume, and where to concentrate review effort.</p>
+    <div class="facts">
+      <div class="fact"><b>1</b><span>focused refactor</span></div>
+      <div class="fact"><b>12</b><span>code and contract files</span></div>
+      <div class="fact"><b>+2,410</b><span>additions</span></div>
+      <div class="fact"><b>−495</b><span>deletions</span></div>
+    </div>
+    <p>Code snapshot: merge base <a href="https://github.com/cipherstash/my-little-proxy/commit/195344ec12da6ab6ddf8158264cf3f66002a0074"><code>195344ec12da6ab6ddf8158264cf3f66002a0074</code></a> through implementation head <a href="https://github.com/cipherstash/my-little-proxy/commit/fddd09ddf56ee66ba5d813457df01f068d5c6a3e"><code>fddd09ddf56ee66ba5d813457df01f068d5c6a3e</code></a>. The walkthrough itself was added in the following documentation commit, so its figures intentionally exclude its own file. See the <a href="https://github.com/cipherstash/my-little-proxy/compare/195344ec12da6ab6ddf8158264cf3f66002a0074...fddd09ddf56ee66ba5d813457df01f068d5c6a3e">pinned implementation comparison</a> and <a href="https://linear.app/cipherstash/issue/CIP-3933">CIP-3933</a>.</p>
+    <div class="callout"><strong>Publishing status:</strong> this is the standalone source walkthrough in the Proxy branch. It follows the information architecture of the Suite PR-walkthrough project, but it is not yet an Astro/MDX content entry and is not linked from that site’s index.</div>
+  </header>
+
+  <section id="overview">
+    <h2>Start here</h2>
+    <div class="verdict"><strong>The design move:</strong> Frontend and Backend still interpret PostgreSQL messages, but they no longer coordinate related state by reaching into separate maps. <code>Context</code> now applies each connection-local lifecycle transition atomically and returns the effects the adapters need.</div>
+    <p>This is not a new wire protocol and not a schema-lifecycle rewrite. It is an ownership refactor that makes existing behavior explicit, then fixes edge cases that could not be represented cleanly before: suspended execution, repeated portal execution, terminal error replacement, and statement metrics scoped to an execution occurrence. Stale terminal and Describe responses remain deliberately tolerated by Backend and are called out below.</p>
+    <div class="flow" aria-label="Responsibility flow"><span>pg-proto orders messages</span><i>→</i><span>adapters interpret</span><i>→</i><span>Context transitions metadata</span><i>→</i><span>effects run outside lock</span></div>
+  </section>
+
+  <section id="reading-order">
+    <h2>Suggested reading order</h2>
+    <div class="reading-order">
+      <div class="reading-step"><h3>Read the contract first</h3><p>Start with <a href="https://github.com/cipherstash/my-little-proxy/blob/fddd09ddf56ee66ba5d813457df01f068d5c6a3e/packages/cipherstash-proxy/docs/adr/0002-context-owns-protocol-metadata-transitions.md">ADR 0002</a> and the <a href="https://github.com/cipherstash/my-little-proxy/blob/fddd09ddf56ee66ba5d813457df01f068d5c6a3e/packages/cipherstash-proxy/CONTEXT.md">Proxy glossary</a>. They define the intended seam and settle “statement metrics scope” as one execution occurrence. Treat tolerated untracked responses as an adapter exception to inspect.</p></div>
+      <div class="reading-step"><h3>Understand the state model</h3><p>In <code>context/mod.rs</code>, review <code>ConnectionProtocolState</code>, <code>ExecuteContext</code>, and the transition/effect split before reading individual methods.</p></div>
+      <div class="reading-step"><h3>Trace one extended execution</h3><p>Follow Parse → Bind → Execute → PortalSuspended → Execute → CommandComplete through Frontend, Context, and Backend.</p></div>
+      <div class="reading-step"><h3>Trace terminal and simple-query paths</h3><p>Check ErrorResponse replacement and the “complete at ReadyForQuery” state used by simple Query.</p></div>
+      <div class="reading-step"><h3>Finish at the boundaries</h3><p>Confirm pg-proto preserves backpressure, Schema middleware still owns transaction schema, and the one added integration regression keeps a connection usable after a multi-statement simple Query.</p></div>
+    </div>
+  </section>
+
+  <section id="change-map">
+    <h2>Change map</h2>
+    <table>
+      <caption>Files and concerns in the fixed snapshot</caption>
+      <thead><tr><th scope="col">Area</th><th scope="col">Role in this change</th><th scope="col">What to review</th></tr></thead>
+      <tbody>
+        <tr><td>context/mod.rs</td><td>New connection-local protocol state model and atomic transitions.</td><td><span class="tag">ownership</span><span class="tag">locking</span><span class="tag">metrics</span><span class="tag">tests</span></td></tr>
+        <tr><td>middleware/frontend.rs</td><td>Turns client messages into Context transitions.</td><td><span class="tag">Parse</span><span class="tag">Bind</span><span class="tag">Execute</span><span class="tag">simple Query</span></td></tr>
+        <tr><td>middleware/backend.rs</td><td>Turns database responses into completion, suspension, or failure transitions.</td><td><span class="tag">correlation</span><span class="tag">replacement</span><span class="tag">readiness</span></td></tr>
+        <tr><td>driver.rs</td><td>Adjacent cancellation cleanup: an RAII guard detaches the connection’s cancellation key on every exit path. Review separately from lifecycle ownership.</td><td><span class="tag">adjacent change</span><span class="tag">cancellation</span><span class="tag">cleanup</span></td></tr>
+        <tr><td>postgresql/mod.rs</td><td>Adds a Proxy-owned <code>OperationId</code> wrapper and test-only identity generator used to exercise Context transitions without pg-proto internals.</td><td><span class="tag">test seam</span><span class="tag">identity</span></td></tr>
+        <tr><td>error.rs · config/tandem.rs</td><td>Adds explicit state-unavailable/config behavior needed by the seam.</td><td><span class="tag">customer error</span><span class="tag">compatibility</span></td></tr>
+        <tr><td>schema_change.rs</td><td>Adds one integration regression: a multi-statement simple Query leaves the connection usable. The detailed lifecycle matrix remains unit coverage.</td><td><span class="tag">integration</span><span class="tag">simple Query</span></td></tr>
+        <tr><td>CONTEXT.md · ADR · CHANGELOG</td><td>Records language, architectural ownership, and user-visible consequences.</td><td><span class="tag">contract</span><span class="tag">scope</span></td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section id="architecture">
+  <h2>Architecture step-through</h2>
+  <p>The two diagrams below are the original architecture audit, preserved in this walkthrough. Read them as an ownership comparison: the external message path barely changes; the metadata seam does.</p>
+
+  <h3>Before: distributed lifecycle orchestration</h3>
+  <div class="diagram">
+    <svg viewBox="0 0 1080 690" role="img" aria-label="Before architecture diagram">
+      <defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#8391ae"/></marker></defs>
+      <rect class="box external" x="35" y="225" width="150" height="70"/><text class="label" x="110" y="260">Client app</text>
+      <rect class="box" x="235" y="225" width="140" height="70"/><text class="label" x="305" y="260">Driver</text>
+      <rect class="box adapter" x="430" y="95" width="170" height="70"/><text class="label" x="515" y="130">Frontend adapter</text>
+      <rect class="box adapter" x="430" y="355" width="170" height="70"/><text class="label" x="515" y="390">Backend adapter</text>
+      <rect class="box external" x="670" y="225" width="170" height="70"/><text class="label" x="755" y="260">PostgreSQL</text>
+      <rect class="box state" x="890" y="35" width="155" height="62"/><text class="label" x="967" y="66">Statements</text>
+      <rect class="box state" x="890" y="135" width="155" height="62"/><text class="label" x="967" y="166">Portals</text>
+      <rect class="box state" x="890" y="235" width="155" height="62"/><text class="label" x="967" y="266">Operations</text>
+      <rect class="box state" x="890" y="335" width="155" height="62"/><text class="label" x="967" y="366">Statement scopes</text>
+      <rect class="box state" x="890" y="435" width="155" height="62"/><text class="label" x="967" y="466">Metrics</text>
+      <text class="small" x="967" y="530">Five independent locks</text>
+      <rect class="box" x="420" y="580" width="190" height="62"/><text class="label" x="515" y="604">Schema middleware</text><text class="small" x="515" y="626">transactional schema state</text>
+      <rect class="box external" x="670" y="580" width="170" height="62"/><text class="label" x="755" y="604">ZeroKMS</text><text class="small" x="755" y="626">encryption adapter</text>
+      <path class="arrow" d="M185 260H235"/><path class="arrow arrow-blue" d="M375 245C405 220 405 150 430 140"/><path class="arrow arrow-blue" d="M430 380C405 370 405 300 375 275"/>
+      <path class="arrow" d="M600 130C650 140 650 220 690 235"/><path class="arrow" d="M840 280C650 335 650 380 600 390"/>
+      <path class="arrow arrow-cyan" d="M600 110C750 75 820 66 890 66"/><path class="arrow arrow-cyan" d="M600 125C760 120 820 166 890 166"/><path class="arrow arrow-cyan" d="M600 145C760 180 820 245 890 260"/>
+      <path class="arrow arrow-cyan" d="M600 370C760 330 820 350 890 366"/><path class="arrow arrow-cyan" d="M600 405C760 455 820 466 890 466"/>
+      <path class="arrow" d="M490 425V580"/><path class="arrow" d="M550 425C600 510 680 550 720 580"/>
+    </svg>
+  </div>
+  <p>Context already owned the maps, but Frontend and Backend jointly orchestrated lifecycle changes across their independent locks. A single logical event—such as completing an execution—required several reads and writes, making atomic correlation difficult. Missing or poisoned state was commonly treated as absent. Schema middleware separately owned transactional schema state, and Context invoked the ZeroKMS encryption adapter.</p>
+
+  <h3 style="margin-top:40px">After: Context becomes the connection seam</h3>
+  <div class="diagram">
+    <svg viewBox="0 0 1080 740" role="img" aria-label="After architecture diagram">
+      <defs><marker id="arrow2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#8391ae"/></marker></defs>
+      <style>.a2{marker-end:url(#arrow2)}</style>
+      <rect class="box external" x="30" y="270" width="145" height="68"/><text class="label" x="102" y="304">Client app</text>
+      <rect class="box" x="220" y="270" width="130" height="68"/><text class="label" x="285" y="304">Driver</text>
+      <rect class="box adapter" x="405" y="125" width="170" height="68"/><text class="label" x="490" y="159">Frontend adapter</text>
+      <rect class="box adapter" x="405" y="415" width="170" height="68"/><text class="label" x="490" y="449">Backend adapter</text>
+      <rect class="box external" x="645" y="270" width="155" height="68"/><text class="label" x="722" y="304">PostgreSQL</text>
+      <rect x="830" y="35" width="220" height="550" rx="20" fill="#101d2e" stroke="#59d8d1" stroke-width="2"/>
+      <text class="label" x="940" y="66">Context</text><text class="small" x="940" y="89">connection seam</text>
+      <rect class="box adapter" x="855" y="115" width="170" height="65"/><text class="label" x="940" y="140">Atomic lifecycle</text><text class="small" x="940" y="162">transitions</text>
+      <rect class="box state" x="855" y="215" width="170" height="65"/><text class="label" x="940" y="240">ConnectionProtocol</text><text class="small" x="940" y="262">State · one lock</text>
+      <rect class="box" x="855" y="315" width="170" height="48"/><text class="label" x="940" y="333">Operations</text><text class="small" x="940" y="352">portal correlation</text>
+      <rect class="box" x="855" y="378" width="170" height="48"/><text class="label" x="940" y="402">Statements · portals</text>
+      <rect class="box" x="855" y="441" width="170" height="48"/><text class="label" x="940" y="465">Suspended executes</text>
+      <rect class="box" x="855" y="504" width="170" height="48"/><text class="label" x="940" y="528">Metrics scopes</text>
+      <path class="arrow a2" d="M175 304H220"/><path class="arrow arrow-blue a2" d="M350 286C380 255 380 175 405 165"/><path class="arrow arrow-blue a2" d="M405 440C380 430 380 350 350 322"/>
+      <path class="arrow a2" d="M575 160C625 175 625 255 665 275"/><path class="arrow a2" d="M800 325C625 380 625 435 575 449"/>
+      <path class="arrow arrow-cyan a2" d="M575 140C700 95 770 120 855 140"/><path class="arrow arrow-cyan a2" d="M575 460C700 505 770 185 855 160"/>
+      <path class="arrow arrow-cyan a2" d="M940 180V215"/><path class="arrow arrow-cyan a2" d="M940 280V315"/><path class="arrow arrow-cyan a2" d="M940 280C1015 290 1035 330 1025 339"/><path class="arrow arrow-cyan a2" d="M940 280C830 330 830 450 855 465"/><path class="arrow arrow-cyan a2" d="M940 280C1040 340 1040 500 1025 528"/>
+      <rect class="box" x="430" y="640" width="200" height="62"/><text class="label" x="530" y="664">Schema middleware</text><text class="small" x="530" y="686">owns transaction schema</text>
+      <rect class="box external" x="680" y="640" width="170" height="62"/><text class="label" x="765" y="664">ZeroKMS</text><text class="small" x="765" y="686">encryption adapter</text>
+      <path class="arrow a2" d="M880 585C820 615 650 620 610 640"/><path class="arrow a2" d="M950 585C920 615 840 625 815 640"/>
+    </svg>
+  </div>
+  <p>Frontend and Backend remain wire-protocol adapters. Context now owns correlated CipherStash metadata and applies transitions under one lock. <code>pg-proto</code> retains protocol ordering and backpressure; Schema middleware retains transactional schema state.</p>
+  </section>
+
+  <section id="execution-before">
+  <h2>Execution lifecycle before the refactor</h2>
+  <div class="diagram">
+    <svg viewBox="0 0 1080 440" role="img" aria-label="Execution lifecycle before the refactor">
+      <defs><marker id="arrow-before" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0 0L10 5L0 10z" fill="#8391ae"/></marker></defs>
+      <rect class="box" x="75" y="80" width="155" height="70"/><text class="label" x="152" y="105">Prepared</text><text class="small" x="152" y="130">starts one scope</text>
+      <rect class="box" x="300" y="80" width="155" height="70"/><text class="label" x="377" y="105">Portal</text><text class="small" x="377" y="130">inherits scope</text>
+      <rect class="box adapter" x="525" y="80" width="155" height="70"/><text class="label" x="602" y="105">Executing</text><text class="small" x="602" y="130">operation lookup</text>
+      <rect class="box danger" x="755" y="35" width="230" height="80"/><text class="label" x="870" y="63">Complete immediately</text><text class="small" x="870" y="88">including PortalSuspended</text>
+      <rect class="box danger" x="755" y="165" width="230" height="80"/><text class="label" x="870" y="193">Finish shared scope</text><text class="small" x="870" y="218">first terminal response</text>
+      <rect class="box" x="525" y="310" width="155" height="70"/><text class="label" x="602" y="335">ReadyForQuery</text><text class="small" x="602" y="360">transaction status only</text>
+      <g fill="none" stroke="#8391ae" stroke-width="2" marker-end="url(#arrow-before)">
+        <path d="M30 115H75"/><path d="M230 115H300"/><path d="M455 115H525"/><path d="M680 105C715 95 725 75 755 75"/><path d="M870 115V165"/><path d="M680 140C715 165 720 195 755 205"/><path d="M755 235C700 270 650 300 630 310" stroke-dasharray="7 7"/>
+      </g>
+      <g class="small"><text x="51" y="96">Parse</text><text x="265" y="96">Bind</text><text x="490" y="96">Execute</text><text x="718" y="60">CommandComplete</text><text x="718" y="185">ErrorResponse</text><text x="635" y="238">simple-query command may</text><text x="635" y="257">finish before readiness</text><text x="735" y="286">later protocol event</text></g>
+      <rect x="80" y="290" width="350" height="95" rx="12" fill="#271f32" stroke="#ff7d8b" stroke-width="2"/>
+      <text class="label" x="255" y="320">Missing lifecycle states</text>
+      <text class="small" x="255" y="347">No suspended execution retained for resume</text>
+      <text class="small" x="255" y="368">No explicit “complete at readiness” state</text>
+    </svg>
+  </div>
+  <p>A prepared Statement created a metrics scope that its Portals and Execute operations reused. Backend terminal messages independently completed execution and finished that shared scope. <code>PortalSuspended</code> did not retain an execution occurrence for resumption, and simple-query execution had no explicit state saying that its scope remained open until <code>ReadyForQuery</code>.</p>
+  </section>
+
+  <section id="execution-after">
+  <h2>Execution lifecycle after the refactor</h2>
+  <div class="diagram">
+    <svg viewBox="0 0 1080 440" role="img" aria-label="Execution lifecycle state diagram">
+      <defs><marker id="arrow3" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0 0L10 5L0 10z" fill="#8391ae"/></marker></defs>
+      <g class="label"><circle cx="45" cy="115" r="12" fill="#65a7ff"/><rect class="box" x="95" y="80" width="135" height="70"/><text class="label" x="162" y="115">Prepared</text><rect class="box" x="285" y="80" width="135" height="70"/><text class="label" x="352" y="115">Portal</text><rect class="box adapter" x="475" y="80" width="145" height="70"/><text class="label" x="547" y="115">Executing</text><rect class="box state" x="685" y="30" width="145" height="70"/><text class="label" x="757" y="65">Suspended</text><rect class="box state" x="685" y="145" width="175" height="70"/><text class="label" x="772" y="180">Await readiness</text><rect class="box" x="925" y="80" width="125" height="70"/><text class="label" x="987" y="115">Complete</text><rect class="box danger" x="685" y="285" width="145" height="70"/><text class="label" x="757" y="320">Failed</text></g>
+      <g fill="none" stroke="#8391ae" stroke-width="2" marker-end="url(#arrow3)"><path d="M57 115H95"/><path d="M230 115H285"/><path d="M420 115H475"/><path d="M620 95C650 80 655 65 685 65"/><path d="M685 82C650 100 650 120 620 125"/><path d="M620 130C650 145 655 180 685 180"/><path d="M620 90C740 5 890 45 925 100"/><path d="M860 180C900 175 900 140 925 125"/><path d="M580 150C610 240 650 300 685 315"/></g>
+      <g class="small"><text x="67" y="95">Parse</text><text x="257" y="95">Bind</text><text x="447" y="95">Execute</text><text x="650" y="48">PortalSuspended</text><text x="650" y="152">simple query</text><text x="775" y="22">CommandComplete / EmptyQueryResponse</text><text x="893" y="197">ReadyForQuery</text><text x="625" y="250">ErrorResponse</text><text x="650" y="118">new Execute</text></g>
+    </svg>
+  </div>
+  <p>An Execute now owns a distinct metrics scope. <code>PortalSuspended</code> retains that occurrence so the next Execute resumes it; CommandComplete or EmptyQueryResponse completes it; an ErrorResponse fails it. Simple Query explicitly waits for ReadyForQuery, keeping transaction-boundary behavior separate from an individual command response.</p>
+  </section>
+
+  <section id="invariants">
+    <h2>The invariants this refactor establishes</h2>
+    <div class="grid">
+      <div class="finding positive"><h3>One correlated transition</h3><p>Statements, portals, operations, suspended executes, and metric scopes change under one protocol-state lock.</p></div>
+      <div class="finding positive"><h3>One scope per occurrence</h3><p>Repeated execution does not reuse the prepared Statement’s measurement window. Parse timing remains reusable Statement knowledge.</p></div>
+      <div class="finding positive"><h3>Suspension is not completion</h3><p>A suspended portal retains the same execution occurrence and metric identity until resume reaches a terminal result.</p></div>
+      <div class="finding positive"><h3>Effects happen after mutation</h3><p>The lock is released before metrics emission, asynchronous work, or Schema middleware calls.</p></div>
+      <div class="finding positive"><h3>Errors are atomic</h3><p>A terminal local failure replaces the upstream response as part of the same correlated lifecycle decision.</p></div>
+      <div class="finding medium"><h3>The snapshot has a tolerance boundary</h3><p>Context protocol-state methods reject unavailable or inconsistent state, while Backend deliberately ignores unknown operations, Executes, and Describes for untracked responses. The unrelated keyset accessor remains optional, but correlated protocol metadata no longer treats a poisoned lock as absence.</p></div>
+    </div>
+  </section>
+
+  <section id="hotspots">
+    <h2>Review hotspots</h2>
+    <div class="grid">
+      <div class="finding high"><h3>Transition completeness</h3><p>For every terminal backend response, verify the operation, execution occurrence, portal relationship, metric scope, and schema outcome are each consumed exactly once.</p></div>
+      <div class="finding high"><h3>Suspension and resume identity</h3><p>Confirm a resumed Execute cannot accidentally allocate a second scope or complete a stale occurrence.</p></div>
+      <div class="finding high"><h3>Simple Query readiness</h3><p>A command can complete before ReadyForQuery. Review multi-statement and error paths for premature metric completion or duplicate schema reporting.</p></div>
+      <div class="finding medium"><h3>Lock boundaries</h3><p>Every transition should return effects before calling metrics, Schema middleware, encryption, or other asynchronous work.</p></div>
+      <div class="finding high"><h3>Tolerated untracked responses</h3><p>Backend converts unknown-operation, operation-without-Execute, and unknown-Describe errors into warnings. Verify this exception is necessary and cannot consume or conceal correlated state; other transition failures still propagate.</p></div>
+      <div class="finding medium"><h3>Metrics compatibility</h3><p>The meaning becomes more precise, but existing Prometheus metric names remain stable. Check dashboards need no rename while values now represent executions.</p></div>
+    </div>
+  </section>
+
+  <section id="validation">
+    <h2>Validation map</h2>
+    <table>
+      <caption>Coverage present in the fixed snapshot, and remaining review gaps</caption>
+      <thead><tr><th scope="col">Scenario</th><th scope="col">Coverage</th><th scope="col">Expected lifecycle</th></tr></thead>
+      <tbody>
+        <tr><td>Suspended portal resumes</td><td><a href="https://github.com/cipherstash/my-little-proxy/blob/fddd09ddf56ee66ba5d813457df01f068d5c6a3e/packages/cipherstash-proxy/src/postgresql/context/mod.rs#L1653">Unit</a></td><td>One execution occurrence and one metrics scope survive suspension through final completion.</td></tr>
+        <tr><td>Portal executes repeatedly</td><td><a href="https://github.com/cipherstash/my-little-proxy/blob/fddd09ddf56ee66ba5d813457df01f068d5c6a3e/packages/cipherstash-proxy/src/postgresql/context/mod.rs#L1695">Unit</a></td><td>Each occurrence receives a distinct metrics scope while reusing prepared Statement knowledge.</td></tr>
+        <tr><td>Unknown or stale operation</td><td><a href="https://github.com/cipherstash/my-little-proxy/blob/fddd09ddf56ee66ba5d813457df01f068d5c6a3e/packages/cipherstash-proxy/src/postgresql/context/mod.rs#L1730">Unit</a> + review gap</td><td>Context rejects stale transition requests; Backend deliberately warns and ignores untracked terminal and Describe responses.</td></tr>
+        <tr><td>Protocol state lock unavailable</td><td><a href="https://github.com/cipherstash/my-little-proxy/blob/fddd09ddf56ee66ba5d813457df01f068d5c6a3e/packages/cipherstash-proxy/src/postgresql/context/mod.rs#L1756">Unit matrix</a></td><td>Correlated protocol metadata reads, mutations, and cleanup return <code>ProtocolStateUnavailable</code> rather than silently omitting a transition.</td></tr>
+        <tr><td>ErrorResponse</td><td>Unit</td><td>The execution fails once, local terminal replacement is atomic, and schema failure is reported once.</td></tr>
+        <tr><td>Simple multi-statement Query</td><td><a href="https://github.com/cipherstash/my-little-proxy/blob/fddd09ddf56ee66ba5d813457df01f068d5c6a3e/packages/cipherstash-proxy-integration/src/schema_change.rs#L460">Integration</a></td><td>Command responses may arrive independently; the connection remains usable and lifecycle completion waits for readiness where required.</td></tr>
+        <tr><td>Statement or portal close</td><td>Unit</td><td>Only unreferenced metric state is released; PostgreSQL’s surviving portal semantics remain intact.</td></tr>
+      </tbody>
+    </table>
+    <div class="callout"><strong>Validation principle:</strong> the branch’s unit tests pin most transitions. Its one new integration regression pins connection usability after a multi-statement simple Query; it does not independently exercise the full lifecycle matrix.</div>
+  </section>
+
+  <section id="boundary">
+    <h2>Where this PR deliberately stops</h2>
+    <p><code>Context</code> owns CipherStash’s correlated metadata, not the PostgreSQL protocol itself. <code>pg-proto</code> still owns ordering and backpressure. Schema middleware still owns transaction-aware schema overlays and publication. ZeroKMS remains the encryption adapter. The refactor also keeps existing Prometheus metric names, despite clarifying their semantics.</p>
+    <div class="verdict">A reviewer should be able to approve the ownership change without also approving a new protocol engine, schema state machine, encryption boundary, or metrics migration. Those are explicitly outside this branch.</div>
+  </section>
+
+  <footer>Implementation snapshot: <code>195344ec12da6ab6ddf8158264cf3f66002a0074…fddd09ddf56ee66ba5d813457df01f068d5c6a3e</code> · Branch: <code>cip-3933-execution-lifecycle</code> · Architecture diagrams carried forward from the original audit.</footer>
+
+  </article>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- concentrate Statement, Portal, operation, error-replacement, and statement-metrics transitions behind Context
- preserve lifecycle correctness across passthrough, simple-query, extended-protocol, suspension, rebind, failure, and readiness paths
- add focused adapter, Context, metrics, and schema regression coverage
- document the ownership decision in ADR-0002 and update the Proxy context glossary

## Validation

- `cargo test -q -p cipherstash-proxy --lib -- --test-threads=1` (223 passed)
- `cargo check -p cipherstash-proxy --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`

Linear: CIP-3933