### PR TITLE
fix(deps): patch rand to 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,7 +864,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.3",
  "recipher 0.1.3",
  "regex",
  "rust_decimal",
@@ -912,7 +912,7 @@ dependencies = [
  "fake 4.2.0",
  "hex",
  "postgres-types",
- "rand 0.9.2",
+ "rand 0.9.3",
  "reqwest",
  "rustls",
  "serde",
@@ -1721,7 +1721,7 @@ dependencies = [
  "chrono",
  "deunicode",
  "dummy 0.11.0",
- "rand 0.9.2",
+ "rand 0.9.3",
 ]
 
 [[package]]
@@ -3437,7 +3437,7 @@ dependencies = [
  "bitflags",
  "lazy_static",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -3526,7 +3526,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.2",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3601,9 +3601,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -4452,7 +4452,7 @@ version = "3.0.1"
 dependencies = [
  "cipherstash-client",
  "cipherstash-config",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustls",
  "serde",
  "serde_json",
@@ -4797,7 +4797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.3",
  "windows-sys 0.52.0",
@@ -4986,7 +4986,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.9.2",
+ "rand 0.9.3",
  "socket2 0.5.8",
  "tokio",
  "tokio-util",


### PR DESCRIPTION
Dependency patch for rand to 0.9.3.

This is an automated security patch update.